### PR TITLE
Fix: #279 End Message in Minimal Timer

### DIFF
--- a/apps/client/src/common/models/ViewTypes.ts
+++ b/apps/client/src/common/models/ViewTypes.ts
@@ -11,4 +11,5 @@ export type OverridableOptions = {
   hideNav?: boolean;
   hideOvertime?: boolean;
   hideMessagesOverlay?: boolean;
-}
+  hideEndMessage?: boolean;
+};

--- a/apps/client/src/features/viewers/minimal-timer/MinimalTimer.scss
+++ b/apps/client/src/features/viewers/minimal-timer/MinimalTimer.scss
@@ -76,4 +76,13 @@
     text-align: center;
     font-weight: 600;
   }
+
+  .end-message {
+      text-align: center;
+      font-size: 12vw;
+      line-height: 0.9em;
+      font-weight: 600;
+      color: $timer-finished-color;
+      padding: 0;
+    }
 }

--- a/apps/client/src/features/viewers/minimal-timer/MinimalTimer.tsx
+++ b/apps/client/src/features/viewers/minimal-timer/MinimalTimer.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import { EventDataType } from 'common/models/EventData.type';
 import { useAtom } from 'jotai';
 
 import { overrideStylesURL } from '../../../common/api/apiConstants';
@@ -18,7 +19,7 @@ interface MinimalTimerProps {
   pres: PresenterMessageType;
   time: TimeManagerType;
   viewSettings: ViewSettingsType;
-  general: object;
+  general: EventDataType;
 }
 
 export default function MinimalTimer(props: MinimalTimerProps) {
@@ -125,6 +126,7 @@ export default function MinimalTimer(props: MinimalTimerProps) {
   userOptions.hideMessagesOverlay = Boolean(hideMessagesOverlay);
 
   const hideEndMessage = searchParams.get('hideendmessage');
+  userOptions.hideEndMessage = Boolean(hideEndMessage);
 
   const showOverlay = pres.text !== '' && pres.visible;
   const isPlaying = time.playback !== 'pause';

--- a/apps/client/src/features/viewers/minimal-timer/MinimalTimer.tsx
+++ b/apps/client/src/features/viewers/minimal-timer/MinimalTimer.tsx
@@ -132,6 +132,7 @@ export default function MinimalTimer(props: MinimalTimerProps) {
   const isPlaying = time.playback !== 'pause';
   const isNegative = (time.current ?? 0) < 0;
   const showFinished = isNegative && !userOptions?.hideOvertime;
+  const ShowEndMessage = time.current < 0 && general.endMessage && !hideEndMessage;
 
   const baseClasses = `minimal-timer ${isMirrored ? 'mirror' : ''}`;
 
@@ -162,7 +163,7 @@ export default function MinimalTimer(props: MinimalTimerProps) {
           <div className='message'>{pres.text}</div>
         </div>
       )}
-      {time.finished && general.endMessage && !hideEndMessage ? (
+      {ShowEndMessage ? (
         <div className='end-message'>{general.endMessage}</div>
       ) : (
         <div

--- a/apps/client/src/features/viewers/minimal-timer/MinimalTimer.tsx
+++ b/apps/client/src/features/viewers/minimal-timer/MinimalTimer.tsx
@@ -132,7 +132,7 @@ export default function MinimalTimer(props: MinimalTimerProps) {
   const isPlaying = time.playback !== 'pause';
   const isNegative = (time.current ?? 0) < 0;
   const showFinished = isNegative && !userOptions?.hideOvertime;
-  const ShowEndMessage = time.current < 0 && general.endMessage && !hideEndMessage;
+  const showEndMessage = time.current < 0 && general.endMessage && !hideEndMessage;
 
   const baseClasses = `minimal-timer ${isMirrored ? 'mirror' : ''}`;
 
@@ -163,7 +163,7 @@ export default function MinimalTimer(props: MinimalTimerProps) {
           <div className='message'>{pres.text}</div>
         </div>
       )}
-      {ShowEndMessage ? (
+      {showEndMessage ? (
         <div className='end-message'>{general.endMessage}</div>
       ) : (
         <div

--- a/apps/client/src/features/viewers/minimal-timer/MinimalTimer.tsx
+++ b/apps/client/src/features/viewers/minimal-timer/MinimalTimer.tsx
@@ -18,10 +18,11 @@ interface MinimalTimerProps {
   pres: PresenterMessageType;
   time: TimeManagerType;
   viewSettings: ViewSettingsType;
+  general: object;
 }
 
 export default function MinimalTimer(props: MinimalTimerProps) {
-  const { pres, time, viewSettings } = props;
+  const { pres, time, viewSettings, general } = props;
   const { shouldRender } = useRuntimeStylesheet(viewSettings?.overrideStyles && overrideStylesURL);
   const [searchParams] = useSearchParams();
   const [isMirrored] = useAtom(mirrorViewersAtom);
@@ -123,6 +124,8 @@ export default function MinimalTimer(props: MinimalTimerProps) {
   const hideMessagesOverlay = searchParams.get('hidemessages');
   userOptions.hideMessagesOverlay = Boolean(hideMessagesOverlay);
 
+  const hideEndMessage = searchParams.get('hideendmessage');
+
   const showOverlay = pres.text !== '' && pres.visible;
   const isPlaying = time.playback !== 'pause';
   const isNegative = (time.current ?? 0) < 0;
@@ -157,19 +160,23 @@ export default function MinimalTimer(props: MinimalTimerProps) {
           <div className='message'>{pres.text}</div>
         </div>
       )}
-      <div
-        className={`timer ${!isPlaying ? 'timer--paused' : ''} ${showFinished ? 'timer--finished' : ''}`}
-        style={{
-          color: userOptions.textColour,
-          fontSize: `${(89 / (stageTimerCharacters - 1)) * (userOptions.size || 1)}vw`,
-          fontFamily: userOptions.font,
-          top: userOptions.top,
-          left: userOptions.left,
-          backgroundColor: userOptions.textBackground,
-        }}
-      >
-        {stageTimer}
-      </div>
+      {time.finished && general.endMessage && !hideEndMessage ? (
+        <div className='end-message'>{general.endMessage}</div>
+      ) : (
+        <div
+          className={`timer ${!isPlaying ? 'timer--paused' : ''} ${showFinished ? 'timer--finished' : ''}`}
+          style={{
+            color: userOptions.textColour,
+            fontSize: `${(89 / (stageTimerCharacters - 1)) * (userOptions.size || 1)}vw`,
+            fontFamily: userOptions.font,
+            top: userOptions.top,
+            left: userOptions.left,
+            backgroundColor: userOptions.textBackground,
+          }}
+        >
+          {stageTimer}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/client/src/features/viewers/minimal-timer/MinimalTimer.tsx
+++ b/apps/client/src/features/viewers/minimal-timer/MinimalTimer.tsx
@@ -153,16 +153,12 @@ export default function MinimalTimer(props: MinimalTimerProps) {
     >
       <NavigationMenu />
       {!hideMessagesOverlay && (
-        <div
-          className={showOverlay ? 'message-overlay message-overlay--active' : 'message-overlay'}
-        >
+        <div className={showOverlay ? 'message-overlay message-overlay--active' : 'message-overlay'}>
           <div className='message'>{pres.text}</div>
         </div>
       )}
       <div
-        className={`timer ${!isPlaying ? 'timer--paused' : ''} ${
-          showFinished ? 'timer--finished' : ''
-        }`}
+        className={`timer ${!isPlaying ? 'timer--paused' : ''} ${showFinished ? 'timer--finished' : ''}`}
         style={{
           color: userOptions.textColour,
           fontSize: `${(89 / (stageTimerCharacters - 1)) * (userOptions.size || 1)}vw`,


### PR DESCRIPTION
I've Implemented the end message in the minimal timer, following the behavior from the normal timer. If it exist's it will be shown upon passing 0. Also it is possible to disable the end message using the `?hideendmessage=true` url parameter