### PR TITLE
Timer: fix too many renders error when using ?progress

### DIFF
--- a/client/src/features/viewers/timer/Timer.jsx
+++ b/client/src/features/viewers/timer/Timer.jsx
@@ -24,6 +24,7 @@ export default function Timer(props) {
   const { general, pres, title, time, viewSettings } = props;
   const { shouldRender } = useRuntimeStylesheet(viewSettings?.overrideStyles && overrideStylesURL);
 
+  const [searchParams] = useSearchParams();
   const [elapsed, setElapsed] = useState(() => {
     // eg. http://localhost:3000/timer?progress=up
     // Check for user options
@@ -33,7 +34,6 @@ export default function Timer(props) {
     return progress === 'up';
   });
 
-  const [searchParams] = useSearchParams();
   const [isMirrored] = useAtom(mirrorViewersAtom);
 
   useEffect(() => {

--- a/client/src/features/viewers/timer/Timer.jsx
+++ b/client/src/features/viewers/timer/Timer.jsx
@@ -23,7 +23,12 @@ const formatOptions = {
 export default function Timer(props) {
   const { general, pres, title, time, viewSettings } = props;
   const { shouldRender } = useRuntimeStylesheet(viewSettings?.overrideStyles && overrideStylesURL);
-  const [elapsed, setElapsed] = useState(true);
+
+  const [elapsed, setElapsed] = useState(() => {
+    const progress = searchParams.get('progress');
+    return progress === 'up';
+  });
+
   const [searchParams] = useSearchParams();
   const [isMirrored] = useAtom(mirrorViewersAtom);
 
@@ -34,17 +39,6 @@ export default function Timer(props) {
   // defer rendering until we load stylesheets
   if (!shouldRender) {
     return null;
-  }
-
-  // eg. http://localhost:3000/timer?progress=up
-  // Check for user options
-  // progress: selector
-  // Should be 'up' or 'down'
-  const progress = searchParams.get('progress');
-  if (progress === 'up') {
-    setElapsed(true);
-  } else if (progress === 'down') {
-    setElapsed(false);
   }
 
   const clock = formatTime(time.clock, formatOptions);

--- a/client/src/features/viewers/timer/Timer.jsx
+++ b/client/src/features/viewers/timer/Timer.jsx
@@ -25,6 +25,10 @@ export default function Timer(props) {
   const { shouldRender } = useRuntimeStylesheet(viewSettings?.overrideStyles && overrideStylesURL);
 
   const [elapsed, setElapsed] = useState(() => {
+    // eg. http://localhost:3000/timer?progress=up
+    // Check for user options
+    // progress: selector
+    // Should be 'up' or 'down'
     const progress = searchParams.get('progress');
     return progress === 'up';
   });


### PR DESCRIPTION
`/timer?progress=up` would crash with the below error:

```
react_devtools_backend.js:2655 Error: Minified React error #301; visit https://reactjs.org/docs/error-decoder.html?invariant=301 for the full message or use the non-minified dev environment for full errors and additional helpful warnings.
    at _m (index.3fcfff09.js:30:19143)
    at Fh (index.3fcfff09.js:32:12523)
    at mw (index.3fcfff09.js:32:45383)
    at dw (index.3fcfff09.js:32:40219)
    at L_ (index.3fcfff09.js:32:40147)
    at Hu (index.3fcfff09.js:32:40001)
    at Hh (index.3fcfff09.js:32:36340)
    at uw (index.3fcfff09.js:32:35288)
    at k (index.3fcfff09.js:17:1560)
    at MessagePort.Z (index.3fcfff09.js:17:1924)
```

The error decodes to
> Too many re-renders. React limits the number of renders to prevent an infinite loop.