### PR TITLE
feat: notify ws clients on rundown changes

### DIFF
--- a/apps/server/src/adapters/websocketAux.ts
+++ b/apps/server/src/adapters/websocketAux.ts
@@ -1,0 +1,12 @@
+import { socket } from './WebsocketAdapter.js';
+
+/**
+ * Utility function to notify clients that the REST data is stale
+ * @param payload -- possible patch payload
+ */
+export function sendRefetch(payload: any | null = null) {
+  socket.send({
+    type: 'ontime-refetch',
+    payload,
+  });
+}

--- a/apps/server/src/services/RundownService.ts
+++ b/apps/server/src/services/RundownService.ts
@@ -5,6 +5,7 @@ import { block as blockDef, delay as delayDef, event as eventDef } from '../mode
 import { MAX_EVENTS } from '../settings.js';
 import { EventLoader, eventLoader } from '../classes/event-loader/EventLoader.js';
 import { eventTimer } from './TimerService.js';
+import { sendRefetch } from '../adapters/websocketAux.js';
 
 /**
  * Checks if a list of IDs is in the current selection
@@ -145,6 +146,7 @@ export async function addEvent(eventData: Partial<OntimeEvent> | Partial<OntimeD
   }
   updateTimer([id]);
   updateChangeNumEvents();
+  sendRefetch();
   return newEvent;
 }
 
@@ -156,6 +158,7 @@ export async function editEvent(eventData) {
   }
   const newEvent = await DataProvider.updateEventById(eventId, eventData);
   updateTimer([eventId]);
+  sendRefetch();
   return newEvent;
 }
 
@@ -168,6 +171,7 @@ export async function deleteEvent(eventId) {
   await DataProvider.deleteEvent(eventId);
   updateTimer([eventId]);
   updateChangeNumEvents();
+  sendRefetch();
 }
 
 /**
@@ -178,6 +182,7 @@ export async function deleteAllEvents() {
   await DataProvider.clearRundown();
   updateTimer();
   updateChangeNumEvents();
+  sendRefetch();
 }
 
 /**
@@ -202,6 +207,7 @@ export async function reorderEvent(eventId, from, to) {
   // save rundown
   await DataProvider.setRundown(rundown);
   updateTimer();
+  sendRefetch();
   return reorderedItem;
 }
 
@@ -257,6 +263,7 @@ export async function applyDelay(eventId) {
   // update rundown
   await DataProvider.setRundown(rundown);
   updateTimer();
+  sendRefetch();
 }
 
 /**


### PR DESCRIPTION
Broadcast ws message when the rundown changes.

So far message looks like
```
{
    type: 'ontime-refetch',
    payload: null,
};
```

The payload could include a patch object, but we would need to define behaviour flags for updating single/multiple items. One for the future I guess

What do you think about the name **refetch**? We will be stuck with it once we implement, not too sure it is communicative