### PR TITLE
Fields' Stale Data Fix

### DIFF
--- a/apps/client/src/features/event-editor/EventEditor.tsx
+++ b/apps/client/src/features/event-editor/EventEditor.tsx
@@ -58,6 +58,7 @@ export default function EventEditor() {
         timerType={event.timerType}
       />
       <EventEditorTitles
+        key={event.id}
         eventId={event.id}
         title={event.title}
         presenter={event.presenter}


### PR DESCRIPTION
closes #388 

#### Changelog
- add `event.id` as `key` to `<EventEditorTitles />`

React will now know to re-render this component whenever the selected event changes

(I cannot reproduce this issue with `<EventEditorTimes />`, but I suspect if this bug pops up again, this fix will probably address it).
