### PR TITLE
Fix websocket connection behind HTTPS reverse proxy

### DIFF
--- a/apps/client/src/common/api/apiConstants.ts
+++ b/apps/client/src/common/api/apiConstants.ts
@@ -14,7 +14,7 @@ export const RUNTIME = ['runtimeStore'];
 
 export const serverPort = import.meta.env.DEV ? STATIC_PORT : window.location.port;
 export const serverURL = import.meta.env.DEV ? `http://localhost:${serverPort}` : window.location.origin;
-export const websocketUrl = `ws://${window.location.hostname}:${serverPort}/ws`;
+export const websocketUrl = `${window.location.protocol === "https:" ? "wss" : "ws"}://${window.location.hostname}:${serverPort}/ws`;
 
 export const eventURL = `${serverURL}/eventdata`;
 export const rundownURL = `${serverURL}/events`;


### PR DESCRIPTION
apiConstants.ts currently hardcodes the websocket protocol as `ws://` which fails if the ontime page is loaded on HTTPS (as the browser rejects it as mixed content). This PR ensures `wss://` is used if the page is loaded over HTTPS.