### PR TITLE
URL Params Form

### DIFF
--- a/apps/client/src/common/components/edit-form-drawer/EditFormDrawer.module.scss
+++ b/apps/client/src/common/components/edit-form-drawer/EditFormDrawer.module.scss
@@ -9,3 +9,27 @@
 .drawerContent {
   background-color: $gray-1200;
 }
+
+.label {
+  font-size: $inner-section-text-size;
+  color: $label-gray;
+}
+
+.columnSection {
+  display: flex;
+  padding: $element-spacing;
+  flex-direction: column;
+  gap: $element-inner-spacing;
+}
+
+.title {
+  font-size: $inner-section-text-size;
+  display: block;
+  width: 100%;
+}
+
+.description {
+  font-size: $inner-section-text-size;
+  display: block;
+  color: $modal-note-color;
+}

--- a/apps/client/src/common/components/edit-form-drawer/EditFormDrawer.module.scss
+++ b/apps/client/src/common/components/edit-form-drawer/EditFormDrawer.module.scss
@@ -1,0 +1,11 @@
+@use '../../../theme/v2Styles' as *;
+@use '../../../theme/ontimeColours' as *;
+
+.drawerHeader {
+  color: $section-white;
+  background-color: $gray-1200;
+}
+
+.drawerContent {
+  background-color: $gray-1200;
+}

--- a/apps/client/src/common/components/edit-form-drawer/EditFormDrawer.module.scss
+++ b/apps/client/src/common/components/edit-form-drawer/EditFormDrawer.module.scss
@@ -1,13 +1,19 @@
 @use '../../../theme/v2Styles' as *;
 @use '../../../theme/ontimeColours' as *;
 
-.drawerHeader {
-  color: $section-white;
+.drawerContent {
   background-color: $gray-1200;
 }
 
-.drawerContent {
-  background-color: $gray-1200;
+.drawerHeader {
+  @extend .drawerContent;
+  color: $section-white;
+}
+
+.drawerFooter {
+  @extend .drawerContent;
+  display: flex;
+  gap: $element-spacing;
 }
 
 .label {

--- a/apps/client/src/common/components/edit-form-drawer/EditFormDrawer.module.scss
+++ b/apps/client/src/common/components/edit-form-drawer/EditFormDrawer.module.scss
@@ -14,6 +14,10 @@
   @extend .drawerContent;
   display: flex;
   gap: $element-spacing;
+
+  button[type='submit'] {
+    padding: 0 2em;
+  }
 }
 
 .label {

--- a/apps/client/src/common/components/edit-form-drawer/EditFormDrawer.tsx
+++ b/apps/client/src/common/components/edit-form-drawer/EditFormDrawer.tsx
@@ -63,11 +63,13 @@ export default function EditFormDrawer({ options }: EditFormDrawerProps) {
           </form>
         </DrawerBody>
 
-        <DrawerFooter className={style.drawerContent}>
-          <Button variant='outline' mr={3} onClick={onEditDrawerClose}>
+        <DrawerFooter className={style.drawerFooter}>
+          <Button variant='ontime-subtle' onClick={onEditDrawerClose}>
             Cancel
           </Button>
-          <Button colorScheme='blue'>Save</Button>
+          <Button variant='ontime-filled' form='edit-params-form' type='submit'>
+            Save
+          </Button>
         </DrawerFooter>
       </DrawerContent>
     </Drawer>

--- a/apps/client/src/common/components/edit-form-drawer/EditFormDrawer.tsx
+++ b/apps/client/src/common/components/edit-form-drawer/EditFormDrawer.tsx
@@ -9,13 +9,19 @@ import {
   DrawerFooter,
   DrawerHeader,
   DrawerOverlay,
-  Input,
   useDisclosure,
 } from '@chakra-ui/react';
 
+import EditFormInput from './EditFormInput';
+import { Field } from './types';
+
 import style from './EditFormDrawer.module.scss';
 
-export const EditFormDrawer = () => {
+interface EditFormDrawerProps {
+  options: Field[];
+}
+
+export default function EditFormDrawer({ options }: EditFormDrawerProps) {
   const [searchParams, setSearchParams] = useSearchParams();
   const { isOpen, onClose, onOpen } = useDisclosure();
 
@@ -44,7 +50,17 @@ export const EditFormDrawer = () => {
         </DrawerHeader>
 
         <DrawerBody className={style.drawerContent}>
-          <Input placeholder='Type here...' variant='ontime-filled' />
+          <form id='edit-params-form'>
+            {options.map((field) => (
+              <div key={field.title} className={style.columnSection}>
+                <label className={style.label}>
+                  <span className={style.title}>{field.title}</span>
+                  <span className={style.description}>{field.description}</span>
+                </label>
+                <EditFormInput field={field} />
+              </div>
+            ))}
+          </form>
         </DrawerBody>
 
         <DrawerFooter className={style.drawerContent}>
@@ -56,4 +72,4 @@ export const EditFormDrawer = () => {
       </DrawerContent>
     </Drawer>
   );
-};
+}

--- a/apps/client/src/common/components/edit-form-drawer/EditFormDrawer.tsx
+++ b/apps/client/src/common/components/edit-form-drawer/EditFormDrawer.tsx
@@ -13,15 +13,15 @@ import {
 } from '@chakra-ui/react';
 
 import EditFormInput from './EditFormInput';
-import { Field } from './types';
+import { ParamField } from './types';
 
 import style from './EditFormDrawer.module.scss';
 
 interface EditFormDrawerProps {
-  options: Field[];
+  paramFields: ParamField[];
 }
 
-export default function EditFormDrawer({ options }: EditFormDrawerProps) {
+export default function EditFormDrawer({ paramFields }: EditFormDrawerProps) {
   const [searchParams, setSearchParams] = useSearchParams();
   const { isOpen, onClose, onOpen } = useDisclosure();
 
@@ -79,14 +79,14 @@ export default function EditFormDrawer({ options }: EditFormDrawerProps) {
         </DrawerHeader>
 
         <DrawerBody className={style.drawerContent}>
-          <form id='edit-params-form' onSubmit={onSettingsSubmit}>
-            {options.map((field) => (
+          <form id='edit-params-form' onSubmit={onParamsFormSubmit}>
+            {paramFields.map((field) => (
               <div key={field.title} className={style.columnSection}>
                 <label className={style.label} htmlFor={field.id}>
                   <span className={style.title}>{field.title}</span>
                   <span className={style.description}>{field.description}</span>
                 </label>
-                <EditFormInput key={field.title} field={field} />
+                <EditFormInput key={field.title} paramField={field} />
               </div>
             ))}
           </form>

--- a/apps/client/src/common/components/edit-form-drawer/EditFormDrawer.tsx
+++ b/apps/client/src/common/components/edit-form-drawer/EditFormDrawer.tsx
@@ -1,0 +1,55 @@
+import { useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import {
+  Button,
+  Drawer,
+  DrawerBody,
+  DrawerCloseButton,
+  DrawerContent,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerOverlay,
+  Input,
+  useDisclosure,
+} from '@chakra-ui/react';
+
+export const EditFormDrawer = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { isOpen, onClose, onOpen } = useDisclosure();
+
+  useEffect(() => {
+    const isEditing = searchParams.get('edit');
+
+    if (isEditing === 'true') {
+      return onOpen();
+    }
+  }, [searchParams, onOpen]);
+
+  const onEditDrawerClose = () => {
+    onClose();
+
+    searchParams.delete('edit');
+    setSearchParams(searchParams);
+  };
+
+  return (
+    <Drawer isOpen={isOpen} placement='right' onClose={onEditDrawerClose}>
+      <DrawerOverlay />
+      <DrawerContent>
+        <DrawerCloseButton />
+        <DrawerHeader>Create your account</DrawerHeader>
+
+        <DrawerBody>
+          <Input placeholder='Type here...' />
+        </DrawerBody>
+
+        <DrawerFooter>
+          <Button variant='outline' mr={3} onClick={onEditDrawerClose}>
+            Cancel
+          </Button>
+          <Button colorScheme='blue'>Save</Button>
+        </DrawerFooter>
+      </DrawerContent>
+    </Drawer>
+  );
+};

--- a/apps/client/src/common/components/edit-form-drawer/EditFormDrawer.tsx
+++ b/apps/client/src/common/components/edit-form-drawer/EditFormDrawer.tsx
@@ -71,11 +71,11 @@ export default function EditFormDrawer({ paramFields }: EditFormDrawerProps) {
           <form id='edit-params-form' onSubmit={onParamsFormSubmit}>
             {paramFields.map((field) => (
               <div key={field.title} className={style.columnSection}>
-                <label className={style.label} htmlFor={field.id}>
+                <label className={style.label}>
                   <span className={style.title}>{field.title}</span>
                   <span className={style.description}>{field.description}</span>
+                  <EditFormInput key={field.title} paramField={field} />
                 </label>
-                <EditFormInput key={field.title} paramField={field} />
               </div>
             ))}
           </form>

--- a/apps/client/src/common/components/edit-form-drawer/EditFormDrawer.tsx
+++ b/apps/client/src/common/components/edit-form-drawer/EditFormDrawer.tsx
@@ -45,17 +45,6 @@ export default function EditFormDrawer({ paramFields }: EditFormDrawerProps) {
 
     const newParamsObject = Object.fromEntries(new FormData(formEvent.currentTarget));
     const newSearchParams = Object.entries(newParamsObject).reduce((newSearchParams, [id, value]) => {
-      const isIdABoolean = paramFields.some((field) => field.id === id);
-
-      // special handling for <Switch /> (aka checkboxes)
-      // unchecked checkboxes DO NOT have a value
-      // checked checkboxes will be 'true' (see <EditFormInput />)
-      if (isIdABoolean && value === 'true') {
-        newSearchParams.set(id, value);
-
-        return newSearchParams;
-      }
-
       if (typeof value === 'string' && value.length) {
         newSearchParams.set(id, value);
 

--- a/apps/client/src/common/components/edit-form-drawer/EditFormDrawer.tsx
+++ b/apps/client/src/common/components/edit-form-drawer/EditFormDrawer.tsx
@@ -13,6 +13,8 @@ import {
   useDisclosure,
 } from '@chakra-ui/react';
 
+import style from './EditFormDrawer.module.scss';
+
 export const EditFormDrawer = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const { isOpen, onClose, onOpen } = useDisclosure();
@@ -33,17 +35,19 @@ export const EditFormDrawer = () => {
   };
 
   return (
-    <Drawer isOpen={isOpen} placement='right' onClose={onEditDrawerClose}>
+    <Drawer isOpen={isOpen} placement='right' onClose={onEditDrawerClose} size='lg'>
       <DrawerOverlay />
       <DrawerContent>
-        <DrawerCloseButton />
-        <DrawerHeader>Create your account</DrawerHeader>
+        <DrawerHeader className={style.drawerHeader}>
+          <DrawerCloseButton _hover={{ bg: '#ebedf0', color: '#333' }} size='lg' />
+          Customise
+        </DrawerHeader>
 
-        <DrawerBody>
-          <Input placeholder='Type here...' />
+        <DrawerBody className={style.drawerContent}>
+          <Input placeholder='Type here...' variant='ontime-filled' />
         </DrawerBody>
 
-        <DrawerFooter>
+        <DrawerFooter className={style.drawerContent}>
           <Button variant='outline' mr={3} onClick={onEditDrawerClose}>
             Cancel
           </Button>

--- a/apps/client/src/common/components/edit-form-drawer/EditFormDrawer.tsx
+++ b/apps/client/src/common/components/edit-form-drawer/EditFormDrawer.tsx
@@ -53,11 +53,11 @@ export default function EditFormDrawer({ options }: EditFormDrawerProps) {
           <form id='edit-params-form'>
             {options.map((field) => (
               <div key={field.title} className={style.columnSection}>
-                <label className={style.label}>
+                <label className={style.label} htmlFor={field.id}>
                   <span className={style.title}>{field.title}</span>
                   <span className={style.description}>{field.description}</span>
                 </label>
-                <EditFormInput field={field} />
+                <EditFormInput key={field.title} field={field} />
               </div>
             ))}
           </form>

--- a/apps/client/src/common/components/edit-form-drawer/EditFormDrawer.tsx
+++ b/apps/client/src/common/components/edit-form-drawer/EditFormDrawer.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { FormEvent, useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import {
   Button,
@@ -40,6 +40,35 @@ export default function EditFormDrawer({ options }: EditFormDrawerProps) {
     setSearchParams(searchParams);
   };
 
+  const onParamsFormSubmit = (formEvent: FormEvent<HTMLFormElement>) => {
+    formEvent.preventDefault();
+
+    const newParamsObject = Object.fromEntries(new FormData(formEvent.currentTarget));
+    const newSearchParams = Object.entries(newParamsObject).reduce((newSearchParams, [id, value]) => {
+      const isIdABoolean = paramFields.some((field) => field.id === id);
+
+      // special handling for <Switch /> (aka checkboxes)
+      // unchecked checkboxes DO NOT have a value
+      // checked checkboxes will be 'true' (see <EditFormInput />)
+      if (isIdABoolean && value === 'true') {
+        newSearchParams.set(id, value);
+
+        return newSearchParams;
+      }
+
+      if (typeof value === 'string' && value.length) {
+        newSearchParams.set(id, value);
+
+        return newSearchParams;
+      }
+
+      return newSearchParams;
+    }, new URLSearchParams());
+
+    onEditDrawerClose();
+    setSearchParams(newSearchParams);
+  };
+
   return (
     <Drawer isOpen={isOpen} placement='right' onClose={onEditDrawerClose} size='lg'>
       <DrawerOverlay />
@@ -50,7 +79,7 @@ export default function EditFormDrawer({ options }: EditFormDrawerProps) {
         </DrawerHeader>
 
         <DrawerBody className={style.drawerContent}>
-          <form id='edit-params-form'>
+          <form id='edit-params-form' onSubmit={onSettingsSubmit}>
             {options.map((field) => (
               <div key={field.title} className={style.columnSection}>
                 <label className={style.label} htmlFor={field.id}>

--- a/apps/client/src/common/components/edit-form-drawer/EditFormInput.tsx
+++ b/apps/client/src/common/components/edit-form-drawer/EditFormInput.tsx
@@ -1,23 +1,23 @@
 import { useSearchParams } from 'react-router-dom';
 import { Input, Select, Switch } from '@chakra-ui/react';
 
-import { Field } from './types';
+import { ParamField } from './types';
 
 interface EditFormInputProps {
-  field: Field;
+  paramField: ParamField;
 }
 
-export default function EditFormInput({ field }: EditFormInputProps) {
+export default function EditFormInput({ paramField }: EditFormInputProps) {
   const [searchParams] = useSearchParams();
-  const { id, type } = field;
+  const { id, type } = paramField;
 
   if (type === 'option') {
     const optionFromParams = searchParams.get(id);
-    const defaultOptionValue = field.values.find((value) => value === optionFromParams);
+    const defaultOptionValue = paramField.values.find((value) => value === optionFromParams);
 
     return (
       <Select placeholder='Select an option' variant='ontime' name={id} defaultValue={defaultOptionValue}>
-        {field.values.map((value) => (
+        {paramField.values.map((value) => (
           <option key={value} value={value}>
             {value}
           </option>

--- a/apps/client/src/common/components/edit-form-drawer/EditFormInput.tsx
+++ b/apps/client/src/common/components/edit-form-drawer/EditFormInput.tsx
@@ -29,7 +29,8 @@ export default function EditFormInput({ field }: EditFormInputProps) {
   if (type === 'boolean') {
     const defaultCheckedValue = searchParams.get(id) === 'true' ?? false;
 
-    return <Switch variant='ontime' name={id} defaultChecked={defaultCheckedValue} />;
+    // checked value should be 'true' (see onSettingSubmit in <EditFormDrawer />)
+    return <Switch variant='ontime' name={id} defaultChecked={defaultCheckedValue} value='true' />;
   }
 
   if (type === 'number') {

--- a/apps/client/src/common/components/edit-form-drawer/EditFormInput.tsx
+++ b/apps/client/src/common/components/edit-form-drawer/EditFormInput.tsx
@@ -29,7 +29,7 @@ export default function EditFormInput({ paramField }: EditFormInputProps) {
   if (type === 'boolean') {
     const defaultCheckedValue = searchParams.get(id) === 'true' ?? false;
 
-    // checked value should be 'true' (see onSettingSubmit in <EditFormDrawer />)
+    // checked value should be 'true' (see onParamsFormSubmit in <EditFormDrawer />)
     return <Switch variant='ontime' name={id} defaultChecked={defaultCheckedValue} value='true' />;
   }
 

--- a/apps/client/src/common/components/edit-form-drawer/EditFormInput.tsx
+++ b/apps/client/src/common/components/edit-form-drawer/EditFormInput.tsx
@@ -29,7 +29,7 @@ export default function EditFormInput({ paramField }: EditFormInputProps) {
   if (type === 'boolean') {
     const defaultCheckedValue = searchParams.get(id) === 'true' ?? false;
 
-    // checked value should be 'true' (see onParamsFormSubmit in <EditFormDrawer />)
+    // checked value should be 'true', so it can be captured by the form event
     return <Switch variant='ontime' name={id} defaultChecked={defaultCheckedValue} value='true' />;
   }
 

--- a/apps/client/src/common/components/edit-form-drawer/EditFormInput.tsx
+++ b/apps/client/src/common/components/edit-form-drawer/EditFormInput.tsx
@@ -1,3 +1,4 @@
+import { useSearchParams } from 'react-router-dom';
 import { Input, Select, Switch } from '@chakra-ui/react';
 
 import { Field } from './types';
@@ -7,9 +8,15 @@ interface EditFormInputProps {
 }
 
 export default function EditFormInput({ field }: EditFormInputProps) {
-  if (field.type === 'option') {
+  const [searchParams] = useSearchParams();
+  const { id, type } = field;
+
+  if (type === 'option') {
+    const optionFromParams = searchParams.get(id);
+    const defaultOptionValue = field.values.find((value) => value === optionFromParams);
+
     return (
-      <Select placeholder='Select an option' variant='ontime'>
+      <Select placeholder='Select an option' variant='ontime' name={id} defaultValue={defaultOptionValue}>
         {field.values.map((value) => (
           <option key={value} value={value}>
             {value}
@@ -19,13 +26,19 @@ export default function EditFormInput({ field }: EditFormInputProps) {
     );
   }
 
-  if (field.type === 'boolean') {
-    return <Switch variant='ontime' />;
+  if (type === 'boolean') {
+    const defaultCheckedValue = searchParams.get(id) === 'true' ?? false;
+
+    return <Switch variant='ontime' name={id} defaultChecked={defaultCheckedValue} />;
   }
 
-  if (field.type === 'number') {
-    return <Input type='number' variant='ontime-filled' />;
+  if (type === 'number') {
+    const defaultNumberValue = searchParams.get(id) ?? '';
+
+    return <Input type='number' variant='ontime-filled' name={id} defaultValue={defaultNumberValue} />;
   }
 
-  return <Input variant='ontime-filled' />;
+  const defaultStringValue = searchParams.get(id) ?? '';
+
+  return <Input variant='ontime-filled' name={id} defaultValue={defaultStringValue} />;
 }

--- a/apps/client/src/common/components/edit-form-drawer/EditFormInput.tsx
+++ b/apps/client/src/common/components/edit-form-drawer/EditFormInput.tsx
@@ -1,0 +1,31 @@
+import { Input, Select, Switch } from '@chakra-ui/react';
+
+import { Field } from './types';
+
+interface EditFormInputProps {
+  field: Field;
+}
+
+export default function EditFormInput({ field }: EditFormInputProps) {
+  if (field.type === 'option') {
+    return (
+      <Select placeholder='Select an option' variant='ontime'>
+        {field.values.map((value) => (
+          <option key={value} value={value}>
+            {value}
+          </option>
+        ))}
+      </Select>
+    );
+  }
+
+  if (field.type === 'boolean') {
+    return <Switch variant='ontime' />;
+  }
+
+  if (field.type === 'number') {
+    return <Input type='number' variant='ontime-filled' />;
+  }
+
+  return <Input variant='ontime-filled' />;
+}

--- a/apps/client/src/common/components/edit-form-drawer/EditFormInput.tsx
+++ b/apps/client/src/common/components/edit-form-drawer/EditFormInput.tsx
@@ -1,6 +1,8 @@
 import { useSearchParams } from 'react-router-dom';
 import { Input, Select, Switch } from '@chakra-ui/react';
 
+import { isStringBoolean } from '../../../common/utils/viewUtils';
+
 import { ParamField } from './types';
 
 interface EditFormInputProps {
@@ -27,7 +29,7 @@ export default function EditFormInput({ paramField }: EditFormInputProps) {
   }
 
   if (type === 'boolean') {
-    const defaultCheckedValue = searchParams.get(id) === 'true' ?? false;
+    const defaultCheckedValue = isStringBoolean(searchParams.get(id)) ?? false;
 
     // checked value should be 'true', so it can be captured by the form event
     return <Switch variant='ontime' name={id} defaultChecked={defaultCheckedValue} value='true' />;

--- a/apps/client/src/common/components/edit-form-drawer/constants.ts
+++ b/apps/client/src/common/components/edit-form-drawer/constants.ts
@@ -203,3 +203,12 @@ export const LOWER_THIRDS_OPTIONS: ParamField[] = [
     type: 'number',
   },
 ];
+
+export const STUDIO_CLOCK_OPTIONS: ParamField[] = [
+  {
+    id: 'seconds',
+    title: 'Seconds',
+    description: 'Shows seconds in clock',
+    type: 'boolean',
+  },
+];

--- a/apps/client/src/common/components/edit-form-drawer/constants.ts
+++ b/apps/client/src/common/components/edit-form-drawer/constants.ts
@@ -81,3 +81,80 @@ export const TIMER_OPTIONS: ParamField[] = [
     values: ['up', 'down'],
   },
 ];
+
+export const MINIMAL_TIMER_OPTIONS: ParamField[] = [
+  {
+    id: 'key',
+    title: 'Key',
+    description: 'Background colour in hexadecimal',
+    type: 'string',
+  },
+  {
+    id: 'text',
+    title: 'Text Colour',
+    description: 'Text colour in hexadecimal',
+    type: 'string',
+  },
+  {
+    id: 'textbg',
+    title: 'Text Background',
+    description: 'Colour of text background in hexadecimal',
+    type: 'string',
+  },
+  {
+    id: 'font',
+    title: 'Font',
+    description: 'Font family, will use the fonts available in the system',
+    type: 'string',
+  },
+  {
+    id: 'size',
+    title: 'Text Size',
+    description: 'Scales the current style (0.5 = 50% 1 = 100% 2 = 200%)',
+    type: 'number',
+  },
+  {
+    id: 'alignx',
+    title: 'Align Horizontal',
+    description: 'Moves the horizontally in page to start = left | center | end = right',
+    type: 'option',
+    values: ['start', 'center', 'end'],
+  },
+  {
+    id: 'offsetx',
+    title: 'Offset Horizontal',
+    description: 'Offsets the timer horizontal position by a given amount in pixels',
+    type: 'number',
+  },
+  {
+    id: 'aligny',
+    title: 'Align Vertical',
+    description: 'Moves the vertically in page to start = left | center | end = right',
+    type: 'option',
+    values: ['start', 'center', 'end'],
+  },
+  {
+    id: 'offsety',
+    title: 'Offset Vertical',
+    description: 'Offsets the timer vertical position by a given amount in pixels',
+    type: 'number',
+  },
+  {
+    id: 'hidenav',
+    title: 'Hide Nav',
+    description: 'Whether to hide the nav logo in the right corner',
+    type: 'boolean',
+  },
+  {
+    id: 'hideovertime',
+    title: 'Hide Overtime',
+    description: 'Whether to supress overtime styles (red borders and red text)',
+    type: 'boolean',
+  },
+  {
+    id: 'hidemessages',
+    title: 'Hide Message Overlay',
+    description: 'Whether to hide the overlay from showing timer screen messages',
+    type: 'boolean',
+  },
+];

--- a/apps/client/src/common/components/edit-form-drawer/constants.ts
+++ b/apps/client/src/common/components/edit-form-drawer/constants.ts
@@ -1,5 +1,13 @@
 import { ParamField } from './types';
 
+export const TIME_FORMAT_OPTION: ParamField = {
+  id: 'format',
+  title: '12  / 24 hour timer',
+  description: 'Whether to show the time in 12 or 24 hour mode. Overrides the global setting from preferences',
+  type: 'option',
+  values: ['12', '24'],
+};
+
 export const CLOCK_OPTIONS: ParamField[] = [
   {
     id: 'key',
@@ -63,13 +71,7 @@ export const CLOCK_OPTIONS: ParamField[] = [
     description: 'Whether to hide the nav logo in the right corner',
     type: 'boolean',
   },
-  {
-    id: 'format',
-    title: '12  / 24 hour timer',
-    description: 'Whether to show the time in 12 or 24 hour mode. Overrides the global setting from preferences',
-    type: 'option',
-    values: ['12', '24'],
-  },
+  TIME_FORMAT_OPTION,
 ];
 
 export const TIMER_OPTIONS: ParamField[] = [
@@ -80,6 +82,7 @@ export const TIMER_OPTIONS: ParamField[] = [
     type: 'option',
     values: ['up', 'down'],
   },
+  TIME_FORMAT_OPTION,
 ];
 
 export const MINIMAL_TIMER_OPTIONS: ParamField[] = [
@@ -202,6 +205,7 @@ export const LOWER_THIRDS_OPTIONS: ParamField[] = [
     description: 'Time (in seconds) the lower third displays before fading out',
     type: 'number',
   },
+  TIME_FORMAT_OPTION,
 ];
 
 export const STUDIO_CLOCK_OPTIONS: ParamField[] = [
@@ -211,4 +215,5 @@ export const STUDIO_CLOCK_OPTIONS: ParamField[] = [
     description: 'Shows seconds in clock',
     type: 'boolean',
   },
+  TIME_FORMAT_OPTION,
 ];

--- a/apps/client/src/common/components/edit-form-drawer/constants.ts
+++ b/apps/client/src/common/components/edit-form-drawer/constants.ts
@@ -185,7 +185,7 @@ export const LOWER_THIRDS_OPTIONS: ParamField[] = [
     type: 'string',
   },
   {
-    id: 'text',
+    id: 'bg',
     title: 'BG',
     description: 'Text background colour in hexadecimal',
     type: 'string',

--- a/apps/client/src/common/components/edit-form-drawer/constants.ts
+++ b/apps/client/src/common/components/edit-form-drawer/constants.ts
@@ -1,6 +1,6 @@
-import { Field } from './types';
+import { ParamField } from './types';
 
-export const CLOCK_OPTIONS: Field[] = [
+export const CLOCK_OPTIONS: ParamField[] = [
   {
     id: 'key',
     title: 'Key',

--- a/apps/client/src/common/components/edit-form-drawer/constants.ts
+++ b/apps/client/src/common/components/edit-form-drawer/constants.ts
@@ -2,58 +2,69 @@ import { Field } from './types';
 
 export const CLOCK_OPTIONS: Field[] = [
   {
+    id: 'key',
     title: 'Key',
     description: 'Background colour in hexadecimal',
     type: 'string',
   },
   {
+    id: 'text',
     title: 'Text Colour',
     description: 'Text colour in hexadecimal',
     type: 'string',
   },
   {
+    id: 'textbg',
     title: 'Text Background',
     description: 'Colour of text background in hexadecimal',
     type: 'string',
   },
   {
+    id: 'font',
     title: 'Font',
     description: 'Font family, will use the fonts available in the system',
     type: 'string',
   },
   {
+    id: 'size',
     title: 'Text Size',
     description: 'Scales the current style (0.5 = 50% 1 = 100% 2 = 200%)',
     type: 'number',
   },
   {
+    id: 'alignx',
     title: 'Align Horizontal',
     description: 'Moves the horizontally in page to start = left | center | end = right',
     type: 'option',
     values: ['start', 'center', 'end'],
   },
   {
+    id: 'offsetx',
     title: 'Offset Horizontal',
     description: 'Offsets the timer horizontal position by a given amount in pixels',
     type: 'number',
   },
   {
+    id: 'aligny',
     title: 'Align Vertical',
     description: 'Moves the vertically in page to start = left | center | end = right',
     type: 'option',
     values: ['start', 'center', 'end'],
   },
   {
+    id: 'offsety',
     title: 'Offset Vertical',
     description: 'Offsets the timer vertical position by a given amount in pixels',
     type: 'number',
   },
   {
+    id: 'hidenav',
     title: 'Hide Nav',
     description: 'Whether to hide the nav logo in the right corner',
     type: 'boolean',
   },
   {
+    id: 'format',
     title: '12  / 24 hour timer',
     description: 'Whether to show the time in 12 or 24 hour mode. Overrides the global setting from preferences',
     type: 'option',

--- a/apps/client/src/common/components/edit-form-drawer/constants.ts
+++ b/apps/client/src/common/components/edit-form-drawer/constants.ts
@@ -1,0 +1,62 @@
+import { Field } from './types';
+
+export const CLOCK_OPTIONS: Field[] = [
+  {
+    title: 'Key',
+    description: 'Background colour in hexadecimal',
+    type: 'string',
+  },
+  {
+    title: 'Text Colour',
+    description: 'Text colour in hexadecimal',
+    type: 'string',
+  },
+  {
+    title: 'Text Background',
+    description: 'Colour of text background in hexadecimal',
+    type: 'string',
+  },
+  {
+    title: 'Font',
+    description: 'Font family, will use the fonts available in the system',
+    type: 'string',
+  },
+  {
+    title: 'Text Size',
+    description: 'Scales the current style (0.5 = 50% 1 = 100% 2 = 200%)',
+    type: 'number',
+  },
+  {
+    title: 'Align Horizontal',
+    description: 'Moves the horizontally in page to start = left | center | end = right',
+    type: 'option',
+    values: ['start', 'center', 'end'],
+  },
+  {
+    title: 'Offset Horizontal',
+    description: 'Offsets the timer horizontal position by a given amount in pixels',
+    type: 'number',
+  },
+  {
+    title: 'Align Vertical',
+    description: 'Moves the vertically in page to start = left | center | end = right',
+    type: 'option',
+    values: ['start', 'center', 'end'],
+  },
+  {
+    title: 'Offset Vertical',
+    description: 'Offsets the timer vertical position by a given amount in pixels',
+    type: 'number',
+  },
+  {
+    title: 'Hide Nav',
+    description: 'Whether to hide the nav logo in the right corner',
+    type: 'boolean',
+  },
+  {
+    title: '12  / 24 hour timer',
+    description: 'Whether to show the time in 12 or 24 hour mode. Overrides the global setting from preferences',
+    type: 'option',
+    values: ['12', '24'],
+  },
+];

--- a/apps/client/src/common/components/edit-form-drawer/constants.ts
+++ b/apps/client/src/common/components/edit-form-drawer/constants.ts
@@ -158,3 +158,48 @@ export const MINIMAL_TIMER_OPTIONS: ParamField[] = [
     type: 'boolean',
   },
 ];
+
+export const LOWER_THIRDS_OPTIONS: ParamField[] = [
+  {
+    id: 'preset',
+    title: 'Preset',
+    description: 'Selects a style preset',
+    type: 'number',
+  },
+  {
+    id: 'size',
+    title: 'Size',
+    description: 'Scales the current style (0.5 = 50% 1 = 100% 2 = 200%)',
+    type: 'number',
+  },
+  {
+    id: 'transition',
+    title: 'Transition',
+    description: 'Transition in time in seconds (default 5)',
+    type: 'number',
+  },
+  {
+    id: 'text',
+    title: 'Text',
+    description: 'Text colour in hexadecimal',
+    type: 'string',
+  },
+  {
+    id: 'text',
+    title: 'BG',
+    description: 'Text background colour in hexadecimal',
+    type: 'string',
+  },
+  {
+    id: 'key',
+    title: 'Key',
+    description: 'Screen background colour in hexadecimal',
+    type: 'string',
+  },
+  {
+    id: 'fadeout',
+    title: 'Fadeout',
+    description: 'Time (in seconds) the lower third displays before fading out',
+    type: 'number',
+  },
+];

--- a/apps/client/src/common/components/edit-form-drawer/constants.ts
+++ b/apps/client/src/common/components/edit-form-drawer/constants.ts
@@ -71,3 +71,13 @@ export const CLOCK_OPTIONS: ParamField[] = [
     values: ['12', '24'],
   },
 ];
+
+export const TIMER_OPTIONS: ParamField[] = [
+  {
+    id: 'progress',
+    title: 'Progress Bar',
+    description: 'Whether bar counts up or down',
+    type: 'option',
+    values: ['up', 'down'],
+  },
+];

--- a/apps/client/src/common/components/edit-form-drawer/types.ts
+++ b/apps/client/src/common/components/edit-form-drawer/types.ts
@@ -1,0 +1,11 @@
+type BaseField = {
+  title: string;
+  description: string;
+};
+
+type OptionsField = { type: 'option'; values: string[] };
+type StringField = { type: 'string' };
+type BooleanField = { type: 'boolean' };
+type NumberField = { type: 'number' };
+
+export type Field = BaseField & (StringField | BooleanField | NumberField | OptionsField);

--- a/apps/client/src/common/components/edit-form-drawer/types.ts
+++ b/apps/client/src/common/components/edit-form-drawer/types.ts
@@ -9,4 +9,4 @@ type StringField = { type: 'string' };
 type BooleanField = { type: 'boolean' };
 type NumberField = { type: 'number' };
 
-export type Field = BaseField & (StringField | BooleanField | NumberField | OptionsField);
+export type ParamField = BaseField & (StringField | BooleanField | NumberField | OptionsField);

--- a/apps/client/src/common/components/edit-form-drawer/types.ts
+++ b/apps/client/src/common/components/edit-form-drawer/types.ts
@@ -1,4 +1,5 @@
 type BaseField = {
+  id: string;
   title: string;
   description: string;
 };

--- a/apps/client/src/common/components/navigation-menu/NavigationMenu.module.scss
+++ b/apps/client/src/common/components/navigation-menu/NavigationMenu.module.scss
@@ -1,6 +1,6 @@
-@use "../../../theme/v2Styles" as *;
-@use "../../../theme/mixins" as *;
-@use "../../../theme/ontimeColours" as *;
+@use '../../../theme/v2Styles' as *;
+@use '../../../theme/mixins' as *;
+@use '../../../theme/ontimeColours' as *;
 
 $menu-bg: $gray-1200;
 $menu-hover-bg: $gray-1350;
@@ -14,14 +14,26 @@ $button-size: 48px;
   transform: rotate(180deg);
 }
 
-.navButton {
-  z-index: 2;
-  position: absolute;
-  left: 0.5em;
-  top: 0.5em;
+.buttonContainer {
+  display: flex;
+  flex-direction: column;
+  row-gap: 1rem;
+  padding: 0.5em;
+
   transition-property: opacity;
   transition-duration: 0.3s;
+
   opacity: 1;
+  position: fixed;
+  left: 0;
+  top: 0;
+
+  &.hidden {
+    opacity: 0;
+  }
+}
+
+.button {
   font-size: 24px;
   color: $icon-color;
   background-color: $button-bg;
@@ -30,10 +42,11 @@ $button-size: 48px;
   display: grid;
   place-content: center;
   border-radius: 3px;
+}
 
-  &.hidden {
-    opacity: 0;
-  }
+.navButton {
+  @extend .button;
+  z-index: 2;
 }
 
 .menuContainer {

--- a/apps/client/src/common/components/navigation-menu/NavigationMenu.tsx
+++ b/apps/client/src/common/components/navigation-menu/NavigationMenu.tsx
@@ -16,7 +16,11 @@ import { useViewOptionsStore } from '../../stores/viewOptions';
 
 import style from './NavigationMenu.module.scss';
 
-export default function NavigationMenu() {
+interface NavigationMenuProps {
+  isEditBtnHidden?: boolean;
+}
+
+export default function NavigationMenu({ isEditBtnHidden = false }: NavigationMenuProps) {
   const location = useLocation();
 
   const { isFullScreen, toggleFullScreen } = useFullscreen();
@@ -62,9 +66,11 @@ export default function NavigationMenu() {
         <button onClick={toggleMenu} aria-label='toggle menu' className={style.navButton}>
           <IoApps />
         </button>
-        <button className={style.button} onClick={showEditFormDrawer}>
-          <IoPencilSharp />
-        </button>
+        {isEditBtnHidden === false && (
+          <button className={style.button} onClick={showEditFormDrawer}>
+            <IoPencilSharp />
+          </button>
+        )}
         {showMenu && (
           <div className={style.menuContainer} data-testid='navigation-menu'>
             <div className={style.buttonsContainer}>

--- a/apps/client/src/common/components/navigation-menu/NavigationMenu.tsx
+++ b/apps/client/src/common/components/navigation-menu/NavigationMenu.tsx
@@ -1,6 +1,6 @@
 import { KeyboardEvent, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation, useSearchParams } from 'react-router-dom';
 import { IoApps } from '@react-icons/all-files/io5/IoApps';
 import { IoArrowUp } from '@react-icons/all-files/io5/IoArrowUp';
 import { IoContract } from '@react-icons/all-files/io5/IoContract';
@@ -22,6 +22,7 @@ export default function NavigationMenu() {
   const { isFullScreen, toggleFullScreen } = useFullscreen();
   const { mirror, toggleMirror } = useViewOptionsStore();
   const [showButton, setShowButton] = useState(false);
+  const [searchParams, setSearchParams] = useSearchParams();
   const [showMenu, setShowMenu] = useState(false);
   const menuRef = useRef<HTMLDivElement | null>(null);
   useClickOutside(menuRef, () => setShowMenu(false));
@@ -50,6 +51,10 @@ export default function NavigationMenu() {
   const isKeyEnter = (event: KeyboardEvent<HTMLDivElement>) => event.key === 'Enter';
   const handleFullscreen = () => toggleFullScreen();
   const handleMirror = () => toggleMirror();
+  const showEditFormDrawer = () => {
+    searchParams.append('edit', 'true');
+    setSearchParams(searchParams);
+  };
 
   return createPortal(
     <div id='navigation-menu-portal' ref={menuRef} className={mirror ? style.mirror : ''}>
@@ -57,7 +62,7 @@ export default function NavigationMenu() {
         <button onClick={toggleMenu} aria-label='toggle menu' className={style.navButton}>
           <IoApps />
         </button>
-        <button className={style.button}>
+        <button className={style.button} onClick={showEditFormDrawer}>
           <IoPencilSharp />
         </button>
         {showMenu && (

--- a/apps/client/src/common/components/navigation-menu/NavigationMenu.tsx
+++ b/apps/client/src/common/components/navigation-menu/NavigationMenu.tsx
@@ -16,11 +16,7 @@ import { useViewOptionsStore } from '../../stores/viewOptions';
 
 import style from './NavigationMenu.module.scss';
 
-interface NavigationMenuProps {
-  isEditBtnHidden?: boolean;
-}
-
-export default function NavigationMenu({ isEditBtnHidden = false }: NavigationMenuProps) {
+export default function NavigationMenu() {
   const location = useLocation();
 
   const { isFullScreen, toggleFullScreen } = useFullscreen();
@@ -66,11 +62,9 @@ export default function NavigationMenu({ isEditBtnHidden = false }: NavigationMe
         <button onClick={toggleMenu} aria-label='toggle menu' className={style.navButton}>
           <IoApps />
         </button>
-        {isEditBtnHidden === false && (
-          <button className={style.button} onClick={showEditFormDrawer}>
-            <IoPencilSharp />
-          </button>
-        )}
+        <button className={style.button} onClick={showEditFormDrawer}>
+          <IoPencilSharp />
+        </button>
         {showMenu && (
           <div className={style.menuContainer} data-testid='navigation-menu'>
             <div className={style.buttonsContainer}>

--- a/apps/client/src/common/components/navigation-menu/NavigationMenu.tsx
+++ b/apps/client/src/common/components/navigation-menu/NavigationMenu.tsx
@@ -28,7 +28,7 @@ export default function NavigationMenu() {
   useClickOutside(menuRef, () => setShowMenu(false));
 
   const toggleMenu = () => setShowMenu((prev) => !prev);
-  useKeyDown(toggleMenu, ' ');
+  useKeyDown(toggleMenu, ' ', { isDisabled: searchParams.get('edit') !== null });
 
   useEffect(() => {
     let fadeOut: NodeJS.Timeout | null = null;

--- a/apps/client/src/common/components/navigation-menu/NavigationMenu.tsx
+++ b/apps/client/src/common/components/navigation-menu/NavigationMenu.tsx
@@ -28,7 +28,7 @@ export default function NavigationMenu() {
   useClickOutside(menuRef, () => setShowMenu(false));
 
   const toggleMenu = () => setShowMenu((prev) => !prev);
-  useKeyDown(toggleMenu, ' ', { isDisabled: searchParams.get('edit') !== null });
+  useKeyDown(toggleMenu, ' ', { isDisabled: searchParams.get('edit') === 'true' });
 
   useEffect(() => {
     let fadeOut: NodeJS.Timeout | null = null;

--- a/apps/client/src/common/components/navigation-menu/NavigationMenu.tsx
+++ b/apps/client/src/common/components/navigation-menu/NavigationMenu.tsx
@@ -5,6 +5,7 @@ import { IoApps } from '@react-icons/all-files/io5/IoApps';
 import { IoArrowUp } from '@react-icons/all-files/io5/IoArrowUp';
 import { IoContract } from '@react-icons/all-files/io5/IoContract';
 import { IoExpand } from '@react-icons/all-files/io5/IoExpand';
+import { IoPencilSharp } from '@react-icons/all-files/io5/IoPencilSharp';
 import { IoSwapVertical } from '@react-icons/all-files/io5/IoSwapVertical';
 
 import { navigatorConstants } from '../../../viewerConfig';
@@ -52,60 +53,61 @@ export default function NavigationMenu() {
 
   return createPortal(
     <div id='navigation-menu-portal' ref={menuRef} className={mirror ? style.mirror : ''}>
-      <button
-        onClick={toggleMenu}
-        aria-label='toggle menu'
-        className={`${style.navButton} ${!showButton && !showMenu ? style.hidden : ''}`}
-      >
-        <IoApps />
-      </button>
-
-      {showMenu && (
-        <div className={style.menuContainer} data-testid='navigation-menu'>
-          <div className={style.buttonsContainer}>
-            <div
-              className={style.link}
-              tabIndex={0}
-              role='button'
-              onClick={handleFullscreen}
-              onKeyDown={(event) => {
-                isKeyEnter(event) && handleFullscreen();
-              }}
-            >
-              Toggle Fullscreen
-              {isFullScreen ? <IoContract /> : <IoExpand />}
+      <div className={`${style.buttonContainer} ${!showButton && !showMenu ? style.hidden : ''}`}>
+        <button onClick={toggleMenu} aria-label='toggle menu' className={style.navButton}>
+          <IoApps />
+        </button>
+        <button className={style.button}>
+          <IoPencilSharp />
+        </button>
+        {showMenu && (
+          <div className={style.menuContainer} data-testid='navigation-menu'>
+            <div className={style.buttonsContainer}>
+              <div
+                className={style.link}
+                tabIndex={0}
+                role='button'
+                onClick={handleFullscreen}
+                onKeyDown={(event) => {
+                  isKeyEnter(event) && handleFullscreen();
+                }}
+              >
+                Toggle Fullscreen
+                {isFullScreen ? <IoContract /> : <IoExpand />}
+              </div>
+              <div
+                className={style.link}
+                tabIndex={0}
+                role='button'
+                onClick={handleMirror}
+                onKeyDown={(event) => {
+                  isKeyEnter(event) && handleMirror();
+                }}
+              >
+                Flip Screen
+                <IoSwapVertical />
+              </div>
+              {/*<div className={style.link} tabIndex={0}>*/}
+              {/*  Rename Client*/}
+              {/*</div>*/}
             </div>
-            <div
-              className={style.link}
-              tabIndex={0}
-              role='button'
-              onClick={handleMirror}
-              onKeyDown={(event) => {
-                isKeyEnter(event) && handleMirror();
-              }}
-            >
-              Flip Screen
-              <IoSwapVertical />
-            </div>
-            {/*<div className={style.link} tabIndex={0}>*/}
-            {/*  Rename Client*/}
-            {/*</div>*/}
+            <hr className={style.separator} />
+            {navigatorConstants.map((route) => (
+              <Link
+                key={route.url}
+                to={route.url}
+                className={`${style.link} ${route.url === location.pathname ? style.current : undefined}`}
+                tabIndex={0}
+              >
+                {route.label}
+                <IoArrowUp className={style.linkIcon} />
+              </Link>
+            ))}
           </div>
-          <hr className={style.separator} />
-          {navigatorConstants.map((route) => (
-            <Link
-              key={route.url}
-              to={route.url}
-              className={`${style.link} ${route.url === location.pathname ? style.current : undefined}`}
-              tabIndex={0}
-            >
-              {route.label}
-              <IoArrowUp className={style.linkIcon} />
-            </Link>
-          ))}
-        </div>
-      )}
+        )}
+      </div>
     </div>,
+
     document.body,
   );
 }

--- a/apps/client/src/common/hooks/useKeyDown.ts
+++ b/apps/client/src/common/hooks/useKeyDown.ts
@@ -1,18 +1,25 @@
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 
-export const useKeyDown = (callback: () => void, targetKey: string) => {
-  const onKeyDown = (event: KeyboardEvent) => {
-    const targetKeyPressed = event.key === targetKey && !event.repeat;
-    if (targetKeyPressed) {
-      event.preventDefault();
-      callback();
-    }
-  };
+type UseKeyDown = (callback: () => void, targetKey: string, options?: { isDisabled?: boolean }) => void;
+
+export const useKeyDown: UseKeyDown = (callback, targetKey, options = {}) => {
+  const { isDisabled = false } = options;
+
+  const onKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      const targetKeyPressed = event.key === targetKey && !event.repeat;
+      if (targetKeyPressed && isDisabled === false) {
+        event.preventDefault();
+        callback();
+      }
+    },
+    [callback, isDisabled, targetKey],
+  );
 
   useEffect(() => {
     document.addEventListener('keydown', onKeyDown);
     return () => {
       document.removeEventListener('keydown', onKeyDown);
     };
-  }, []);
+  }, [onKeyDown]);
 };

--- a/apps/client/src/features/viewers/backstage/Backstage.tsx
+++ b/apps/client/src/features/viewers/backstage/Backstage.tsx
@@ -76,7 +76,7 @@ export default function Backstage(props: BackstageProps) {
 
   return (
     <div className={`backstage ${isMirrored ? 'mirror' : ''}`} data-testid='backstage-view'>
-      <NavigationMenu />
+      <NavigationMenu isEditBtnHidden />
 
       <div className='event-header'>
         {general.title}

--- a/apps/client/src/features/viewers/backstage/Backstage.tsx
+++ b/apps/client/src/features/viewers/backstage/Backstage.tsx
@@ -4,6 +4,8 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { EventData, Message, OntimeEvent, ViewSettings } from 'ontime-types';
 
 import { overrideStylesURL } from '../../../common/api/apiConstants';
+import { TIME_FORMAT_OPTION } from '../../../common/components/edit-form-drawer/constants';
+import EditFormDrawer from '../../../common/components/edit-form-drawer/EditFormDrawer';
 import NavigationMenu from '../../../common/components/navigation-menu/NavigationMenu';
 import ProgressBar from '../../../common/components/progress-bar/ProgressBar';
 import Schedule from '../../../common/components/schedule/Schedule';
@@ -76,8 +78,8 @@ export default function Backstage(props: BackstageProps) {
 
   return (
     <div className={`backstage ${isMirrored ? 'mirror' : ''}`} data-testid='backstage-view'>
-      <NavigationMenu isEditBtnHidden />
-
+      <NavigationMenu />
+      <EditFormDrawer paramFields={[TIME_FORMAT_OPTION]} />
       <div className='event-header'>
         {general.title}
         <div className='clock-container'>

--- a/apps/client/src/features/viewers/clock/Clock.tsx
+++ b/apps/client/src/features/viewers/clock/Clock.tsx
@@ -134,7 +134,7 @@ export default function Clock(props: ClockProps) {
       data-testid='clock-view'
     >
       <NavigationMenu />
-      <EditFormDrawer options={CLOCK_OPTIONS} />
+      <EditFormDrawer paramFields={CLOCK_OPTIONS} />
       <div
         className='clock'
         style={{

--- a/apps/client/src/features/viewers/clock/Clock.tsx
+++ b/apps/client/src/features/viewers/clock/Clock.tsx
@@ -3,6 +3,7 @@ import { useSearchParams } from 'react-router-dom';
 import { ViewSettings } from 'ontime-types';
 
 import { overrideStylesURL } from '../../../common/api/apiConstants';
+import { CLOCK_OPTIONS } from '../../../common/components/edit-form-drawer/constants';
 import { EditFormDrawer } from '../../../common/components/edit-form-drawer/EditFormDrawer';
 import NavigationMenu from '../../../common/components/navigation-menu/NavigationMenu';
 import { useRuntimeStylesheet } from '../../../common/hooks/useRuntimeStylesheet';
@@ -133,7 +134,7 @@ export default function Clock(props: ClockProps) {
       data-testid='clock-view'
     >
       <NavigationMenu />
-      <EditFormDrawer />
+      <EditFormDrawer options={CLOCK_OPTIONS} />
       <div
         className='clock'
         style={{

--- a/apps/client/src/features/viewers/clock/Clock.tsx
+++ b/apps/client/src/features/viewers/clock/Clock.tsx
@@ -3,6 +3,7 @@ import { useSearchParams } from 'react-router-dom';
 import { ViewSettings } from 'ontime-types';
 
 import { overrideStylesURL } from '../../../common/api/apiConstants';
+import { EditFormDrawer } from '../../../common/components/edit-form-drawer/EditFormDrawer';
 import NavigationMenu from '../../../common/components/navigation-menu/NavigationMenu';
 import { useRuntimeStylesheet } from '../../../common/hooks/useRuntimeStylesheet';
 import { TimeManagerType } from '../../../common/models/TimeManager.type';
@@ -132,6 +133,7 @@ export default function Clock(props: ClockProps) {
       data-testid='clock-view'
     >
       <NavigationMenu />
+      <EditFormDrawer />
       <div
         className='clock'
         style={{

--- a/apps/client/src/features/viewers/clock/Clock.tsx
+++ b/apps/client/src/features/viewers/clock/Clock.tsx
@@ -4,7 +4,7 @@ import { ViewSettings } from 'ontime-types';
 
 import { overrideStylesURL } from '../../../common/api/apiConstants';
 import { CLOCK_OPTIONS } from '../../../common/components/edit-form-drawer/constants';
-import { EditFormDrawer } from '../../../common/components/edit-form-drawer/EditFormDrawer';
+import EditFormDrawer from '../../../common/components/edit-form-drawer/EditFormDrawer';
 import NavigationMenu from '../../../common/components/navigation-menu/NavigationMenu';
 import { useRuntimeStylesheet } from '../../../common/hooks/useRuntimeStylesheet';
 import { TimeManagerType } from '../../../common/models/TimeManager.type';

--- a/apps/client/src/features/viewers/countdown/Countdown.tsx
+++ b/apps/client/src/features/viewers/countdown/Countdown.tsx
@@ -3,6 +3,8 @@ import { useSearchParams } from 'react-router-dom';
 import { OntimeEvent, OntimeRundownEntry, Playback, SupportedEvent, ViewSettings } from 'ontime-types';
 
 import { overrideStylesURL } from '../../../common/api/apiConstants';
+import { TIME_FORMAT_OPTION } from '../../../common/components/edit-form-drawer/constants';
+import EditFormDrawer from '../../../common/components/edit-form-drawer/EditFormDrawer';
 import NavigationMenu from '../../../common/components/navigation-menu/NavigationMenu';
 import { useRuntimeStylesheet } from '../../../common/hooks/useRuntimeStylesheet';
 import { TimeManagerType } from '../../../common/models/TimeManager.type';
@@ -109,7 +111,8 @@ export default function Countdown(props: CountdownProps) {
 
   return (
     <div className={`countdown ${isMirrored ? 'mirror' : ''}`} data-testid='countdown-view'>
-      <NavigationMenu isEditBtnHidden />
+      <NavigationMenu />
+      <EditFormDrawer paramFields={[TIME_FORMAT_OPTION]} />
       {follow === null ? (
         <CountdownSelect events={backstageEvents} />
       ) : (

--- a/apps/client/src/features/viewers/countdown/Countdown.tsx
+++ b/apps/client/src/features/viewers/countdown/Countdown.tsx
@@ -109,7 +109,7 @@ export default function Countdown(props: CountdownProps) {
 
   return (
     <div className={`countdown ${isMirrored ? 'mirror' : ''}`} data-testid='countdown-view'>
-      <NavigationMenu />
+      <NavigationMenu isEditBtnHidden />
       {follow === null ? (
         <CountdownSelect events={backstageEvents} />
       ) : (

--- a/apps/client/src/features/viewers/lower-thirds/LowerClean.jsx
+++ b/apps/client/src/features/viewers/lower-thirds/LowerClean.jsx
@@ -21,10 +21,7 @@ export default function LowerClean(props) {
     if (!options.fadeOut) return;
 
     // Calculate time
-    const fadeOutTime =
-      (parseInt(options.fadeOut, 10) +
-        (options.transitionIn || defaults.transitionIn)) *
-      1000;
+    const fadeOutTime = (parseInt(options.fadeOut, 10) + (options.transitionIn || defaults.transitionIn)) * 1000;
     if (isNaN(fadeOutTime)) return;
 
     const timeout = setTimeout(() => {
@@ -86,8 +83,7 @@ export default function LowerClean(props) {
         fontSize: `${sizeMultiplier}vh`,
       }}
     >
-
-      <NavigationMenu />
+      <NavigationMenu isEditBtnHidden />
 
       <AnimatePresence>
         {showLower && (

--- a/apps/client/src/features/viewers/lower-thirds/LowerLines.jsx
+++ b/apps/client/src/features/viewers/lower-thirds/LowerLines.jsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 
+import { LOWER_THIRDS_OPTIONS } from '../../../common/components/edit-form-drawer/constants';
+import EditFormDrawer from '../../../common/components/edit-form-drawer/EditFormDrawer';
 import NavigationMenu from '../../../common/components/navigation-menu/NavigationMenu';
 
 import './LowerLines.scss';
@@ -20,10 +22,7 @@ export default function LowerLines(props) {
     if (!options.fadeOut) return;
 
     // Calculate time
-    const fadeOutTime =
-      (parseInt(options.fadeOut, 10) +
-        (options.transitionIn || defaults.transitionIn)) *
-      1000;
+    const fadeOutTime = (parseInt(options.fadeOut, 10) + (options.transitionIn || defaults.transitionIn)) * 1000;
     if (isNaN(fadeOutTime)) return;
 
     const timeout = setTimeout(() => {
@@ -129,8 +128,8 @@ export default function LowerLines(props) {
         fontSize: `${sizeMultiplier}vh`,
       }}
     >
-
       <NavigationMenu />
+      <EditFormDrawer paramFields={LOWER_THIRDS_OPTIONS} />
 
       <AnimatePresence>
         {showLower && (
@@ -142,24 +141,15 @@ export default function LowerLines(props) {
             animate='visible'
             exit='exit'
           >
-            <motion.div
-              className='title-container'
-              variants={titleContainerVariants}
-            >
+            <motion.div className='title-container' variants={titleContainerVariants}>
               <motion.div className='title' variants={titleVariants}>
                 {title.titleNow}
               </motion.div>
               <div className='title-decor' />
             </motion.div>
-            <motion.div
-              className='subtitle-container'
-              variants={subtitleContainerVariants}
-            >
+            <motion.div className='subtitle-container' variants={subtitleContainerVariants}>
               <div className='sub-decor' />
-              <motion.div
-                className='subtitle'
-                variants={subtitleVariants}
-              >
+              <motion.div className='subtitle' variants={subtitleVariants}>
                 {title.presenterNow}
               </motion.div>
             </motion.div>

--- a/apps/client/src/features/viewers/minimal-timer/MinimalTimer.tsx
+++ b/apps/client/src/features/viewers/minimal-timer/MinimalTimer.tsx
@@ -3,6 +3,8 @@ import { useSearchParams } from 'react-router-dom';
 import { EventData, Message, Playback, TimerType, ViewSettings } from 'ontime-types';
 
 import { overrideStylesURL } from '../../../common/api/apiConstants';
+import { MINIMAL_TIMER_OPTIONS } from '../../../common/components/edit-form-drawer/constants';
+import EditFormDrawer from '../../../common/components/edit-form-drawer/EditFormDrawer';
 import NavigationMenu from '../../../common/components/navigation-menu/NavigationMenu';
 import { useRuntimeStylesheet } from '../../../common/hooks/useRuntimeStylesheet';
 import { TimeManagerType } from '../../../common/models/TimeManager.type';
@@ -167,6 +169,7 @@ export default function MinimalTimer(props: MinimalTimerProps) {
       data-testid='minimal-timer'
     >
       <NavigationMenu />
+      <EditFormDrawer paramFields={MINIMAL_TIMER_OPTIONS} />
       {!hideMessagesOverlay && (
         <div className={showOverlay ? 'message-overlay message-overlay--active' : 'message-overlay'}>
           <div className='message'>{pres.text}</div>

--- a/apps/client/src/features/viewers/public/Public.tsx
+++ b/apps/client/src/features/viewers/public/Public.tsx
@@ -4,6 +4,8 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { EventData, Message, OntimeEvent, ViewSettings } from 'ontime-types';
 
 import { overrideStylesURL } from '../../../common/api/apiConstants';
+import { TIME_FORMAT_OPTION } from '../../../common/components/edit-form-drawer/constants';
+import EditFormDrawer from '../../../common/components/edit-form-drawer/EditFormDrawer';
 import NavigationMenu from '../../../common/components/navigation-menu/NavigationMenu';
 import Schedule from '../../../common/components/schedule/Schedule';
 import { ScheduleProvider } from '../../../common/components/schedule/ScheduleContext';
@@ -54,8 +56,8 @@ export default function Public(props: BackstageProps) {
 
   return (
     <div className={`public-screen ${isMirrored ? 'mirror' : ''}`} data-testid='public-view'>
-      <NavigationMenu isEditBtnHidden />
-
+      <NavigationMenu />
+      <EditFormDrawer paramFields={[TIME_FORMAT_OPTION]} />
       <div className='event-header'>
         {general.title}
         <div className='clock-container'>

--- a/apps/client/src/features/viewers/public/Public.tsx
+++ b/apps/client/src/features/viewers/public/Public.tsx
@@ -54,7 +54,7 @@ export default function Public(props: BackstageProps) {
 
   return (
     <div className={`public-screen ${isMirrored ? 'mirror' : ''}`} data-testid='public-view'>
-      <NavigationMenu />
+      <NavigationMenu isEditBtnHidden />
 
       <div className='event-header'>
         {general.title}

--- a/apps/client/src/features/viewers/studio/StudioClock.jsx
+++ b/apps/client/src/features/viewers/studio/StudioClock.jsx
@@ -4,6 +4,8 @@ import { millisToString } from 'ontime-utils';
 import PropTypes from 'prop-types';
 
 import { overrideStylesURL } from '../../../common/api/apiConstants';
+import { STUDIO_CLOCK_OPTIONS } from '../../../common/components/edit-form-drawer/constants';
+import EditFormDrawer from '../../../common/components/edit-form-drawer/EditFormDrawer';
 import NavigationMenu from '../../../common/components/navigation-menu/NavigationMenu';
 import useFitText from '../../../common/hooks/useFitText';
 import { useRuntimeStylesheet } from '../../../common/hooks/useRuntimeStylesheet';
@@ -73,6 +75,7 @@ export default function StudioClock(props) {
   return (
     <div className={`studio-clock ${isMirrored ? 'mirror' : ''}`} data-testid='studio-view'>
       <NavigationMenu />
+      <EditFormDrawer paramFields={STUDIO_CLOCK_OPTIONS} />
       <div className='clock-container'>
         <div className={`studio-timer ${showSeconds ? 'studio-timer--with-seconds' : ''}`}>{clock}</div>
         <div

--- a/apps/client/src/features/viewers/timer/Timer.tsx
+++ b/apps/client/src/features/viewers/timer/Timer.tsx
@@ -3,6 +3,8 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { EventData, Message, Playback, TimerType, ViewSettings } from 'ontime-types';
 
 import { overrideStylesURL } from '../../../common/api/apiConstants';
+import { TIMER_OPTIONS } from '../../../common/components/edit-form-drawer/constants';
+import EditFormDrawer from '../../../common/components/edit-form-drawer/EditFormDrawer';
 import MultiPartProgressBar from '../../../common/components/multi-part-progress-bar/MultiPartProgressBar';
 import NavigationMenu from '../../../common/components/navigation-menu/NavigationMenu';
 import TitleCard from '../../../common/components/title-card/TitleCard';
@@ -95,6 +97,7 @@ export default function Timer(props: TimerProps) {
   return (
     <div className={showFinished ? `${baseClasses} stage-timer--finished` : baseClasses} data-testid='timer-view'>
       <NavigationMenu />
+      <EditFormDrawer paramFields={TIMER_OPTIONS} />
       <div className={showOverlay ? 'message-overlay message-overlay--active' : 'message-overlay'}>
         <div className='message'>{pres.text}</div>
       </div>


### PR DESCRIPTION
closes #399 

#### Changelog (so far):

- Create `EditFormDrawer` to house the inputs. Add to `/clock` view for testing (will add to more)
- Create `EditFormInput` to handle granulated logic for interacting with search params.
- Add edit button to `NavigationMenu`. Had to adjust styles to make it possible

#### Some thoughts
- Since I'll be adding `EditFormDrawer` to every clock/timer route (despite not being so DRY, which apparently isn't a concern), I simplified logic by passing the `options` prop to `EditFormDrawer`. 
- Styling is a bit difficult due to the amount of files required. I'm trying my best to emulate other `.scss` files.

I opened this PR so it's obvious this issue isn't in limbo and to serve as a source of motivation to complete this feature within a reasonable time. 

Please let me know if you think this a good step in the right direction. Open to criticism, obviously.

