### PR TITLE
fix: prevent clipboard error in secure context

### DIFF
--- a/apps/client/src/common/utils/copyToClipboard.ts
+++ b/apps/client/src/common/utils/copyToClipboard.ts
@@ -1,4 +1,4 @@
 // we need to this as a promise because safari
 export default async function copyToClipboard(text: string) {
-  setTimeout(async () => await navigator.clipboard.writeText(text));
+  setTimeout(async () => await navigator.clipboard?.writeText(text));
 }


### PR DESCRIPTION
handle cases where navigator.clipboard can be undefined https://web.dev/async-clipboard/