### PR TITLE
fix csv export

### DIFF
--- a/apps/client/src/features/cuesheet/CuesheetWrapper.tsx
+++ b/apps/client/src/features/cuesheet/CuesheetWrapper.tsx
@@ -76,12 +76,18 @@ export default function CuesheetWrapper() {
 
       const sheetData = makeTable(headerData, rundown, userFields);
       const csvContent = makeCSV(sheetData);
-      const encodedUri = encodeURI(csvContent);
+
+      const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+      const url = URL.createObjectURL(blob);
+
       const link = document.createElement('a');
-      link.setAttribute('href', encodedUri);
+      link.setAttribute('href', url);
       link.setAttribute('download', 'ontime export.csv');
       document.body.appendChild(link);
       link.click();
+
+      // Clean up the URL.createObjectURL to release resources
+      URL.revokeObjectURL(url);
     },
     [rundown, userFields],
   );

--- a/apps/client/src/features/cuesheet/__tests__/utils.test.js
+++ b/apps/client/src/features/cuesheet/__tests__/utils.test.js
@@ -84,7 +84,7 @@ describe('make CSV()', () => {
   it('joins an array of arrays with commas and newlines', () => {
     const testdata = [['field'], ['after newline', 'after comma'], ['', 'after empty']];
     expect(makeCSV(testdata)).toMatchInlineSnapshot(`
-"data:text/csv;charset=utf-8,field
+"field
 after newline,after comma
 ,after empty
 "

--- a/apps/client/src/features/cuesheet/cuesheetCols.tsx
+++ b/apps/client/src/features/cuesheet/cuesheetCols.tsx
@@ -49,13 +49,13 @@ function MakeTimer({ getValue, row: { original } }: CellContext<OntimeRundownEnt
   const cellValue = (getValue() as number | null) ?? 0;
   const delayValue = (original as OntimeEvent)?.delay ?? 0;
 
-  console.log(delayValue)
-
   return (
     <span className={style.time}>
       <DelayIndicator delayValue={delayValue} />
       {millisToString(cellValue)}
-      {(delayValue !== 0 && showDelayedTimes) && <span className={style.delayedTime}>{` ${millisToString(cellValue + delayValue)}`}</span>}
+      {delayValue !== 0 && showDelayedTimes && (
+        <span className={style.delayedTime}>{` ${millisToString(cellValue + delayValue)}`}</span>
+      )}
     </span>
   );
 }

--- a/apps/client/src/features/cuesheet/cuesheetUtils.ts
+++ b/apps/client/src/features/cuesheet/cuesheetUtils.ts
@@ -108,7 +108,6 @@ export const makeTable = (headerData: EventData, rundown: OntimeRundown, userFie
  * @return {string}
  */
 export const makeCSV = (arrayOfArrays: string[][]) => {
-  const csvData = 'data:text/csv;charset=utf-8,';
   const stringifiedData = stringify(arrayOfArrays);
-  return csvData + stringifiedData;
+  return stringifiedData;
 };


### PR DESCRIPTION
Fixes issue with CSV export reported by user where the export would only contain part of the rundown.
The issue was somewhere between creating the file and the download process, so I decided to change the download process to use blobs instead.

This seems to work correctly