### PR TITLE
dist-mac: create separate dists for aarch64, x64

### DIFF
--- a/.github/workflows/build_v2.yml
+++ b/.github/workflows/build_v2.yml
@@ -35,7 +35,9 @@ jobs:
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
-          files: './apps/electron/dist/ontime-macOS.dmg'
+          files: |
+            './apps/electron/dist/ontime-macOS-x64.dmg'
+            './apps/electron/dist/ontime-macOS-arm64.dmg'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -22,7 +22,7 @@
     "postinstall": "",
     "dev:electron": "NODE_ENV=development electron .",
     "dist-win": "electron-builder --publish=never  --x64 --win",
-    "dist-mac": "electron-builder --publish=never  --arm64 --mac && electron-builder --publish=never  --x64 --mac",
+    "dist-mac": "electron-builder --publish=never  --mac",
     "dist-linux": "electron-builder --publish=never  --x64 --linux",
     "cleanup": "rm -rf .turbo && rm -rf node_modules && rm -rf dist"
   },
@@ -35,7 +35,13 @@
       "icon": "icon.icns"
     },
     "mac": {
-      "target": "dmg",
+      "target": {
+        "target": "dmg",
+        "arch": [
+          "x64",
+          "arm64"
+        ]
+      },
       "category": "public.app-category.productivity",
       "icon": "icon.icns"
     },

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -22,7 +22,7 @@
     "postinstall": "",
     "dev:electron": "NODE_ENV=development electron .",
     "dist-win": "electron-builder --publish=never  --x64 --win",
-    "dist-mac": "electron-builder --publish=never  --x64 --mac",
+    "dist-mac": "electron-builder --publish=never  --universal --mac",
     "dist-linux": "electron-builder --publish=never  --x64 --linux",
     "cleanup": "rm -rf .turbo && rm -rf node_modules && rm -rf dist"
   },

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -22,7 +22,7 @@
     "postinstall": "",
     "dev:electron": "NODE_ENV=development electron .",
     "dist-win": "electron-builder --publish=never  --x64 --win",
-    "dist-mac": "electron-builder --publish=never  --universal --mac",
+    "dist-mac": "electron-builder --publish=never  --arm64 --mac && electron-builder --publish=never  --x64 --mac",
     "dist-linux": "electron-builder --publish=never  --x64 --linux",
     "cleanup": "rm -rf .turbo && rm -rf node_modules && rm -rf dist"
   },
@@ -31,7 +31,7 @@
     "appId": "no.lightdev.ontime",
     "asar": true,
     "dmg": {
-      "artifactName": "ontime-macOS.dmg",
+      "artifactName": "ontime-macOS-${arch}.dmg",
       "icon": "icon.icns"
     },
     "mac": {


### PR DESCRIPTION
Fixes #469.

Current macOS builds for Ontime only build an x64 target, which is less than ideal for Apple Silicon users. Modifies electron dist-mac script to build separate targets for aarch64 and x64 targets, and updates DMG artifactName to include target architecture. 