### PR TITLE
fix: allow spaces in title input

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ontime-ui",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "private": true,
   "dependencies": {
     "@chakra-ui/react": "^2.7.0",

--- a/apps/client/src/features/event-editor/composite/CountedTextInput.tsx
+++ b/apps/client/src/features/event-editor/composite/CountedTextInput.tsx
@@ -1,6 +1,5 @@
 import { useCallback } from 'react';
 import { Input, InputProps } from '@chakra-ui/react';
-import { sanitiseCue } from 'ontime-utils';
 
 import useReactiveTextInput from '../../../common/components/input/text-input/useReactiveTextInput';
 import { EditorUpdateFields } from '../EventEditor';
@@ -17,10 +16,7 @@ interface CountedTextInputProps extends InputProps {
 export default function CountedTextInput(props: CountedTextInputProps) {
   const { field, label, initialValue, submitHandler, maxLength } = props;
 
-  const submitCallback = useCallback(
-    (newValue: string) => submitHandler(field, sanitiseCue(newValue)),
-    [field, submitHandler],
-  );
+  const submitCallback = useCallback((newValue: string) => submitHandler(field, newValue), [field, submitHandler]);
 
   const { value, onChange, onBlur, onKeyDown } = useReactiveTextInput(initialValue, submitCallback, {
     submitOnEnter: true,

--- a/apps/client/src/features/event-editor/composite/EventEditorDataLeft.tsx
+++ b/apps/client/src/features/event-editor/composite/EventEditorDataLeft.tsx
@@ -1,5 +1,6 @@
 import { memo } from 'react';
 import { Input } from '@chakra-ui/react';
+import { sanitiseCue } from 'ontime-utils';
 
 import { type EditorUpdateFields } from '../EventEditor';
 
@@ -19,6 +20,10 @@ interface EventEditorLeftProps {
 const EventEditorDataLeft = (props: EventEditorLeftProps) => {
   const { eventId, cue, title, presenter, subtitle, handleSubmit } = props;
 
+  const cueSubmitHandler = (_field: string, newValue: string) => {
+    handleSubmit('cue', sanitiseCue(newValue));
+  };
+
   return (
     <div className={style.left}>
       <div className={style.splitTwo}>
@@ -37,7 +42,7 @@ const EventEditorDataLeft = (props: EventEditorLeftProps) => {
             readOnly
           />
         </div>
-        <CountedTextInput field='cue' label='Cue' initialValue={cue} submitHandler={handleSubmit} maxLength={10} />
+        <CountedTextInput field='cue' label='Cue' initialValue={cue} submitHandler={cueSubmitHandler} maxLength={10} />
       </div>
       <CountedTextInput field='title' label='Title' initialValue={title} submitHandler={handleSubmit} />
       <CountedTextInput field='presenter' label='Presenter' initialValue={presenter} submitHandler={handleSubmit} />

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ontime",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "author": "Carlos Valente",
   "description": "Time keeping for live events",
   "repository": "https://github.com/cpvalente/ontime",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -2,7 +2,7 @@
   "name": "ontime-server",
   "type": "module",
   "main": "src/index.ts",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "exports": "./src/index.js",
   "dependencies": {
     "body-parser": "^1.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ontime",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "description": "Time keeping for live events",
   "keywords": [
     "lighdev",


### PR DESCRIPTION
fixes a mistake made when adding the new cue operator, which means no text inputs allow text 