### PR TITLE
Backstage options alt

### DIFF
--- a/apps/client/src/common/components/schedule/Schedule.tsx
+++ b/apps/client/src/common/components/schedule/Schedule.tsx
@@ -1,5 +1,3 @@
-import Empty from '../state/Empty';
-
 import { useSchedule } from './ScheduleContext';
 import ScheduleItem from './ScheduleItem';
 
@@ -13,8 +11,9 @@ interface ScheduleProps {
 export default function Schedule({ isProduction, className }: ScheduleProps) {
   const { paginatedEvents, selectedEventId, isBackstage, scheduleType } = useSchedule();
 
+  // TODO: design a nice placeholder for empty schedules
   if (paginatedEvents?.length < 1) {
-    return <Empty text='No events to show' />;
+    return null;
   }
 
   let selectedState: 'past' | 'now' | 'future' = 'past';

--- a/apps/client/src/common/components/schedule/ScheduleContext.tsx
+++ b/apps/client/src/common/components/schedule/ScheduleContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, PropsWithChildren, useContext, useState } from 'react';
+import { createContext, PropsWithChildren, useContext, useState, useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { OntimeEvent } from 'ontime-types';
 
@@ -36,9 +36,8 @@ export const ScheduleProvider = ({
 
   // look for overrides from views
   const hidePast = isStringBoolean(searchParams.get('hidePast'));
-  const stopCycle = isStringBoolean(searchParams.get('stopCycle'));
   const eventsPerPage = Number(searchParams.get('eventsPerPage') ?? 7);
-
+  const followSelected = isStringBoolean(searchParams.get('followSelected'));
 
   let selectedEventIndex = events.findIndex((event) => event.id === selectedEventId);
 
@@ -67,13 +66,18 @@ export const ScheduleProvider = ({
 
   // every SCROLL_TIME go to the next array
   useInterval(() => {
-    if (stopCycle) {
-      setVisiblePage(0);
-    } else if (events.length > eventsPerPage) {
+    if (events.length > eventsPerPage && !followSelected) {
       const next = (visiblePage + 1) % numPages;
       setVisiblePage(next);
     }
   }, time * 1000);
+
+  //Show page with selectedEventIndex or the next one if the selected is the last event on the page
+  useEffect(() => {
+    if (followSelected && events.length > eventsPerPage) {
+      setVisiblePage(Math.floor((selectedEventIndex + 1) / eventsPerPage));
+    }
+  }, [selectedEventId]);
 
   return (
     <ScheduleContext.Provider

--- a/apps/client/src/common/components/schedule/ScheduleContext.tsx
+++ b/apps/client/src/common/components/schedule/ScheduleContext.tsx
@@ -67,9 +67,8 @@ export const ScheduleProvider = ({
   // every SCROLL_TIME go to the next array
   useInterval(() => {
     if (stopCycle) {
-      return;
-    }
-    if (events.length > eventsPerPage) {
+      setVisiblePage(0);
+    } else if (events.length > eventsPerPage) {
       const next = (visiblePage + 1) % numPages;
       setVisiblePage(next);
     }

--- a/apps/client/src/common/components/schedule/ScheduleContext.tsx
+++ b/apps/client/src/common/components/schedule/ScheduleContext.tsx
@@ -1,7 +1,9 @@
 import { createContext, PropsWithChildren, useContext, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { OntimeEvent } from 'ontime-types';
 
 import { useInterval } from '../../hooks/useInterval';
+import { isStringBoolean } from '../../utils/viewUtils';
 
 interface ScheduleContextState {
   events: OntimeEvent[];
@@ -32,12 +34,24 @@ export const ScheduleProvider = ({
   time = 10,
 }: PropsWithChildren<ScheduleProviderProps>) => {
   const [visiblePage, setVisiblePage] = useState(0);
+  const [searchParams] = useSearchParams();
 
-  const numPages = Math.ceil(events.length / eventsPerPage);
+  // look for overrides from views
+  const hidePast = isStringBoolean(searchParams.get('hidePast'));
+  const stopCycle = isStringBoolean(searchParams.get('stopCycle'));
+
+  let selectedEventIndex = events.findIndex((event) => event.id === selectedEventId);
+
+  const viewEvents = [...events];
+  if (hidePast) {
+    viewEvents.splice(0, selectedEventIndex + 1);
+    selectedEventIndex = 0;
+  }
+
+  const numPages = Math.ceil(viewEvents.length / eventsPerPage);
   const eventStart = eventsPerPage * visiblePage;
   const eventEnd = eventsPerPage * (visiblePage + 1);
-  const paginatedEvents = events.slice(eventStart, eventEnd);
-  const selectedEventIndex = events.findIndex((event) => event.id === selectedEventId);
+  const paginatedEvents = viewEvents.slice(eventStart, eventEnd);
 
   const resolveScheduleType = () => {
     if (selectedEventIndex >= eventStart && selectedEventIndex < eventEnd) {
@@ -52,6 +66,9 @@ export const ScheduleProvider = ({
 
   // every SCROLL_TIME go to the next array
   useInterval(() => {
+    if (stopCycle) {
+      return;
+    }
     if (events.length > eventsPerPage) {
       const next = (visiblePage + 1) % numPages;
       setVisiblePage(next);

--- a/apps/client/src/common/components/schedule/ScheduleContext.tsx
+++ b/apps/client/src/common/components/schedule/ScheduleContext.tsx
@@ -21,7 +21,6 @@ interface ScheduleProviderProps {
   events: OntimeEvent[];
   selectedEventId: string | null;
   isBackstage?: boolean;
-  eventsPerPage?: number;
   time?: number;
 }
 
@@ -30,7 +29,6 @@ export const ScheduleProvider = ({
   events,
   selectedEventId,
   isBackstage = false,
-  eventsPerPage = 7,
   time = 10,
 }: PropsWithChildren<ScheduleProviderProps>) => {
   const [visiblePage, setVisiblePage] = useState(0);
@@ -39,6 +37,8 @@ export const ScheduleProvider = ({
   // look for overrides from views
   const hidePast = isStringBoolean(searchParams.get('hidePast'));
   const stopCycle = isStringBoolean(searchParams.get('stopCycle'));
+  const eventsPerPage = Number(searchParams.get('eventsPerPage') ?? 7);
+
 
   let selectedEventIndex = events.findIndex((event) => event.id === selectedEventId);
 

--- a/apps/client/src/common/components/schedule/ScheduleContext.tsx
+++ b/apps/client/src/common/components/schedule/ScheduleContext.tsx
@@ -44,7 +44,8 @@ export const ScheduleProvider = ({
 
   const viewEvents = [...events];
   if (hidePast) {
-    viewEvents.splice(0, selectedEventIndex + 1);
+    // we want to show the event after the next
+    viewEvents.splice(0, selectedEventIndex + 2);
     selectedEventIndex = 0;
   }
 

--- a/apps/client/src/common/components/schedule/ScheduleContext.tsx
+++ b/apps/client/src/common/components/schedule/ScheduleContext.tsx
@@ -35,23 +35,16 @@ export const ScheduleProvider = ({
   const [searchParams] = useSearchParams();
 
   // look for overrides from views
-  const hidePast = isStringBoolean(searchParams.get('hidePast'));
   const eventsPerPage = Number(searchParams.get('eventsPerPage') ?? 7);
   const followSelected = isStringBoolean(searchParams.get('followSelected'));
 
-  let selectedEventIndex = events.findIndex((event) => event.id === selectedEventId);
-
   const viewEvents = [...events];
-  if (hidePast) {
-    // we want to show the event after the next
-    viewEvents.splice(0, selectedEventIndex + 2);
-    selectedEventIndex = 0;
-  }
 
   const numPages = Math.ceil(viewEvents.length / eventsPerPage);
   const eventStart = eventsPerPage * visiblePage;
   const eventEnd = eventsPerPage * (visiblePage + 1);
-  const paginatedEvents = viewEvents.slice(eventStart, eventEnd);
+  const paginatedEvents = events.slice(eventStart, eventEnd);
+  const selectedEventIndex = events.findIndex((event) => event.id === selectedEventId);
 
   const resolveScheduleType = () => {
     if (selectedEventIndex >= eventStart && selectedEventIndex < eventEnd) {

--- a/apps/client/src/common/components/view-params-editor/constants.ts
+++ b/apps/client/src/common/components/view-params-editor/constants.ts
@@ -197,44 +197,32 @@ export const LOWER_THIRDS_OPTIONS: ParamField[] = [
 export const BACKSTAGE_OPTIONS: ParamField[] = [
   TIME_FORMAT_OPTION,
   {
-    id: 'hidePast',
-    title: 'Hide past events',
-    description: 'Scheduler will only show upcoming events',
-    type: 'boolean',
-  },
-  {
-    id: 'stopCycle',
-    title: 'Stop cycling through event pages',
-    description: 'Schedule will not auto-cycle through events',
-    type: 'boolean',
-  },
-  {
     id: 'eventsPerPage',
     title: 'Number of events on page',
     description: '',
     type: 'number',
+  },
+  {
+    id: 'followSelected',
+    title: 'Follow selected event',
+    description: '',
+    type: 'boolean',
   },
 ];
 
 export const PUBLIC_OPTIONS: ParamField[] = [
   TIME_FORMAT_OPTION,
   {
-    id: 'hidePast',
-    title: 'Hide past events',
-    description: 'Scheduler will only show upcoming events',
-    type: 'boolean',
-  },
-  {
-    id: 'stopCycle',
-    title: 'Stop cycling through event pages',
-    description: 'Schedule will not auto-cycle through events',
-    type: 'boolean',
-  },
-  {
     id: 'eventsPerPage',
     title: 'Number of events on page',
     description: '',
     type: 'number',
+  },
+  {
+    id: 'followSelected',
+    title: 'Follow selected event',
+    description: '',
+    type: 'boolean',
   },
 ];
 export const STUDIO_CLOCK_OPTIONS: ParamField[] = [

--- a/apps/client/src/common/components/view-params-editor/constants.ts
+++ b/apps/client/src/common/components/view-params-editor/constants.ts
@@ -205,7 +205,7 @@ export const BACKSTAGE_OPTIONS: ParamField[] = [
   {
     id: 'stopCycle',
     title: 'Stop cycling through event pages',
-    description: 'Schedule will auto not cycle through events',
+    description: 'Schedule will not auto-cycle through events',
     type: 'boolean',
   },
 ];
@@ -221,7 +221,7 @@ export const PUBLIC_OPTIONS: ParamField[] = [
   {
     id: 'stopCycle',
     title: 'Stop cycling through event pages',
-    description: 'Schedule will auto not cycle through events',
+    description: 'Schedule will not auto-cycle through events',
     type: 'boolean',
   },
 ];

--- a/apps/client/src/common/components/view-params-editor/constants.ts
+++ b/apps/client/src/common/components/view-params-editor/constants.ts
@@ -194,6 +194,37 @@ export const LOWER_THIRDS_OPTIONS: ParamField[] = [
   },
 ];
 
+export const BACKSTAGE_OPTIONS: ParamField[] = [
+  TIME_FORMAT_OPTION,
+  {
+    id: 'hidePast',
+    title: 'Hide past events',
+    description: 'Scheduler will only show upcoming events',
+    type: 'boolean',
+  },
+  {
+    id: 'stopCycle',
+    title: 'Stop cycling through event pages',
+    description: 'Schedule will auto not cycle through events',
+    type: 'boolean',
+  },
+];
+
+export const PUBLIC_OPTIONS: ParamField[] = [
+  TIME_FORMAT_OPTION,
+  {
+    id: 'hidePast',
+    title: 'Hide past events',
+    description: 'Scheduler will only show upcoming events',
+    type: 'boolean',
+  },
+  {
+    id: 'stopCycle',
+    title: 'Stop cycling through event pages',
+    description: 'Schedule will auto not cycle through events',
+    type: 'boolean',
+  },
+];
 export const STUDIO_CLOCK_OPTIONS: ParamField[] = [
   TIME_FORMAT_OPTION,
   {

--- a/apps/client/src/common/components/view-params-editor/constants.ts
+++ b/apps/client/src/common/components/view-params-editor/constants.ts
@@ -208,6 +208,12 @@ export const BACKSTAGE_OPTIONS: ParamField[] = [
     description: 'Schedule will not auto-cycle through events',
     type: 'boolean',
   },
+  {
+    id: 'eventsPerPage',
+    title: 'Number of events on page',
+    description: '',
+    type: 'number',
+  },
 ];
 
 export const PUBLIC_OPTIONS: ParamField[] = [
@@ -223,6 +229,12 @@ export const PUBLIC_OPTIONS: ParamField[] = [
     title: 'Stop cycling through event pages',
     description: 'Schedule will not auto-cycle through events',
     type: 'boolean',
+  },
+  {
+    id: 'eventsPerPage',
+    title: 'Number of events on page',
+    description: '',
+    type: 'number',
   },
 ];
 export const STUDIO_CLOCK_OPTIONS: ParamField[] = [

--- a/apps/client/src/features/viewers/ViewWrapper.tsx
+++ b/apps/client/src/features/viewers/ViewWrapper.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/display-name */
 import { ComponentType, useMemo } from 'react';
+import { SupportedEvent } from 'ontime-types';
 import { useStore } from 'zustand';
 
 import useProjectData from '../../common/hooks-query/useProjectData';
@@ -20,7 +21,7 @@ const withData = <P extends object>(Component: ComponentType<P>) => {
 
     const publicEvents = useMemo(() => {
       if (Array.isArray(rundownData)) {
-        return rundownData.filter((e) => e.type === 'event' && e.title && e.isPublic);
+        return rundownData.filter((e) => e.type === SupportedEvent.Event && e.title && e.isPublic);
       }
       return [];
     }, [rundownData]);

--- a/apps/client/src/features/viewers/backstage/Backstage.scss
+++ b/apps/client/src/features/viewers/backstage/Backstage.scss
@@ -99,7 +99,11 @@
     margin-top: 2em;
     padding-top: 1em;
     display: flex;
-    gap: 7.5em;
+  }
+
+  .timer-gap {
+    flex: 1;
+    max-width: 7.5em;
   }
 
   .aux-timers {

--- a/apps/client/src/features/viewers/backstage/Backstage.tsx
+++ b/apps/client/src/features/viewers/backstage/Backstage.tsx
@@ -11,7 +11,7 @@ import Schedule from '../../../common/components/schedule/Schedule';
 import { ScheduleProvider } from '../../../common/components/schedule/ScheduleContext';
 import ScheduleNav from '../../../common/components/schedule/ScheduleNav';
 import TitleCard from '../../../common/components/title-card/TitleCard';
-import { TIME_FORMAT_OPTION } from '../../../common/components/view-params-editor/constants';
+import { BACKSTAGE_OPTIONS } from '../../../common/components/view-params-editor/constants';
 import ViewParamsEditor from '../../../common/components/view-params-editor/ViewParamsEditor';
 import { useRuntimeStylesheet } from '../../../common/hooks/useRuntimeStylesheet';
 import { TimeManagerType } from '../../../common/models/TimeManager.type';
@@ -92,7 +92,7 @@ export default function Backstage(props: BackstageProps) {
   return (
     <div className={`backstage ${isMirrored ? 'mirror' : ''}`} data-testid='backstage-view'>
       <NavigationMenu />
-      <ViewParamsEditor paramFields={[TIME_FORMAT_OPTION]} />
+      <ViewParamsEditor paramFields={BACKSTAGE_OPTIONS} />
       <div className='project-header'>
         {general.title}
         <div className='clock-container'>

--- a/apps/client/src/features/viewers/backstage/Backstage.tsx
+++ b/apps/client/src/features/viewers/backstage/Backstage.tsx
@@ -130,10 +130,12 @@ export default function Backstage(props: BackstageProps) {
                   <div className='aux-timers__label'>{getLocalizedString('common.started_at')}</div>
                   <div className='aux-timers__value'>{startedAt}</div>
                 </div>
+                <div className='timer-gap' />
                 <div className='aux-timers'>
                   <div className='aux-timers__label'>{getLocalizedString('common.expected_finish')}</div>
                   <div className='aux-timers__value'>{expectedFinish}</div>
                 </div>
+                <div className='timer-gap' />
                 <div className='aux-timers'>
                   <div className='aux-timers__label'>{getLocalizedString('common.stage_timer')}</div>
                   <div className='aux-timers__value'>{stageTimer}</div>

--- a/apps/client/src/features/viewers/public/Public.tsx
+++ b/apps/client/src/features/viewers/public/Public.tsx
@@ -9,7 +9,7 @@ import Schedule from '../../../common/components/schedule/Schedule';
 import { ScheduleProvider } from '../../../common/components/schedule/ScheduleContext';
 import ScheduleNav from '../../../common/components/schedule/ScheduleNav';
 import TitleCard from '../../../common/components/title-card/TitleCard';
-import { TIME_FORMAT_OPTION } from '../../../common/components/view-params-editor/constants';
+import { PUBLIC_OPTIONS } from '../../../common/components/view-params-editor/constants';
 import ViewParamsEditor from '../../../common/components/view-params-editor/ViewParamsEditor';
 import { useRuntimeStylesheet } from '../../../common/hooks/useRuntimeStylesheet';
 import { TimeManagerType } from '../../../common/models/TimeManager.type';
@@ -58,7 +58,7 @@ export default function Public(props: BackstageProps) {
   return (
     <div className={`public-screen ${isMirrored ? 'mirror' : ''}`} data-testid='public-view'>
       <NavigationMenu />
-      <ViewParamsEditor paramFields={[TIME_FORMAT_OPTION]} />
+      <ViewParamsEditor paramFields={PUBLIC_OPTIONS} />
       <div className='project-header'>
         {general.title}
         <div className='clock-container'>

--- a/apps/server/src/classes/event-loader/EventLoader.ts
+++ b/apps/server/src/classes/event-loader/EventLoader.ts
@@ -183,6 +183,8 @@ export class EventLoader {
     this.loaded.nextEventId = nextEvent?.id || null;
     this.loaded.nextPublicEventId = nextPublicEvent?.id || null;
 
+    this._loadEvent();
+
     return { currentEvent, nextEvent, timeToNext };
   }
 

--- a/apps/server/src/classes/event-loader/EventLoader.ts
+++ b/apps/server/src/classes/event-loader/EventLoader.ts
@@ -281,6 +281,7 @@ export class EventLoader {
     // check if current is also public
     if (event.isPublic) {
       this.publicEventNow = event;
+      this.loaded.selectedPublicEventId = event.id;
     } else {
       // assume there is no public event
       this.publicEventNow = null;


### PR DESCRIPTION
I combined `stopCycle` and `hidePast` into `followSelected` because I don't see `stopCycle` being used without `hidePast` anyway.
And this way we keep the progression overview in the small dots

also added `eventsPerPage` might be very useful for portrait displays

feel free to drop it if it dosen't solve the intended use case