### PR TITLE
Local build

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -76,7 +76,7 @@ You can generate a distribution for your OS by running the following steps.
 From the project root, run the following commands
 
 - __Install the project dependencies__ by running `pnpm i`
-- __Build the UI and server__ by running `turbo build:local`
+- __Build the UI and server__ by running `turbo build:electron`
 - __Create the package__ by running `turbo dist-win`, `turbo dist-mac` or `turbo dist-linux`
 
 The build distribution assets will be at `.apps/electron/dist`

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -38,6 +38,7 @@
     "dev": "cross-env BROWSER=none vite",
     "build": "vite build",
     "build:local": "cross-env NODE_ENV=local vite build",
+    "build:electron": "cross-env NODE_ENV=local vite build",
     "build:docker": "vite build",
     "lint": "eslint . --quiet",
     "test": "vitest",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -49,6 +49,7 @@
     "dev:test": "cross-env IS_TEST=true nodemon --exec \"ts-node-esm\" ./src/index.ts",
     "prebuild": "pnpm setdb",
     "build": "pnpm prebuild && esbuild src/app.ts --log-level=error --platform=node --format=cjs --bundle --minify --outfile=dist/index.cjs",
+    "build:electron": "pnpm prebuild && esbuild src/app.ts --log-level=error --platform=node --format=cjs --bundle --minify --outfile=dist/index.cjs",
     "build:local": "pnpm prebuild && esbuild src/index.ts --log-level=error --platform=node --format=cjs --bundle --minify --outfile=dist/index.cjs",
     "build:docker": "pnpm prebuild && esbuild src/index.ts --log-level=error --platform=node --format=cjs --minify --bundle --outfile=dist/docker.cjs",
     "build:debug": "pnpm prebuild && esbuild src/app.ts --platform=node --format=cjs --bundle --outfile=dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "lint-staged": "turbo run lint-staged --concurrency=1",
     "build": "turbo run build",
     "build:local": "turbo run build:local",
+    "build:electron": "turbo run build:electron",
     "dist-win": "turbo run dist-win",
     "dist-mac": "turbo run dist-mac",
     "dist-linux": "turbo run dist-linux",

--- a/turbo.json
+++ b/turbo.json
@@ -24,6 +24,7 @@
     },
     "build": {},
     "build:local": {},
+    "build:electron": {},
     "build:docker": {},
     "e2e": {
       "dependsOn": ["^build"]


### PR DESCRIPTION
fixes #510
the issue comes from build:local in apps/server builds' index and not app that is needed for electron dist

needs testing on mac and linux
- [x] Mac os
- [ ] Linux
- [x] Win

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the build command instructions for UI and server in the development guide to reflect the new process for generating project distributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->