### PR TITLE
fix: cuesheet header

### DIFF
--- a/apps/client/src/common/hooks/useLocalStorage.ts
+++ b/apps/client/src/common/hooks/useLocalStorage.ts
@@ -4,12 +4,17 @@ const STORAGE_EVENT = 'onetime-storage';
 
 export const useLocalStorage = <T>(key: string, initialValue: T) => {
   const localStorageValue = useSyncExternalStore(subscribe, () => getSnapshot(key));
-  const parsedLocalStorageValue = localStorageValue ? JSON.parse(localStorageValue) : initialValue;
+  const parsedLocalStorageValue: T = localStorageValue ? JSON.parse(localStorageValue) : initialValue;
 
+  /**
+   * @description Set value to local storage
+   * @param value
+   */
   const setLocalStorageValue = (value: T | ((val: T) => T)) => {
+    // Allow value to be a function so we have same API as useState
     const valueToStore = value instanceof Function ? value(parsedLocalStorageValue) : value;
-    localStorage.setItem(`ontime-${key}`, JSON.stringify(valueToStore));
 
+    localStorage.setItem(`ontime-${key}`, JSON.stringify(valueToStore));
     window.dispatchEvent(new StorageEvent(STORAGE_EVENT));
   };
 
@@ -28,6 +33,7 @@ function getSnapshot(key: string): string | null {
   try {
     return window.localStorage.getItem(`ontime-${key}`);
   } catch (error) {
+    console.error(error);
     return null;
   }
 }

--- a/apps/client/src/common/hooks/useLocalStorage.ts
+++ b/apps/client/src/common/hooks/useLocalStorage.ts
@@ -2,9 +2,25 @@ import { useSyncExternalStore } from 'react';
 
 const STORAGE_EVENT = 'ontime-storage';
 
+function getSnapshot(key: string): string | null {
+  try {
+    return window.localStorage.getItem(`ontime-${key}`);
+  } catch {
+    return null;
+  }
+}
+
+function getParsedJson<T>(localStorageValue: string | null, initialValue: T): T {
+  try {
+    return localStorageValue ? JSON.parse(localStorageValue) : initialValue;
+  } catch {
+    return initialValue;
+  }
+}
+
 export const useLocalStorage = <T>(key: string, initialValue: T) => {
   const localStorageValue = useSyncExternalStore(subscribe, () => getSnapshot(key));
-  const parsedLocalStorageValue: T = localStorageValue ? JSON.parse(localStorageValue) : initialValue;
+  const parsedLocalStorageValue = getParsedJson(localStorageValue, initialValue);
 
   /**
    * @description Set value to local storage
@@ -27,13 +43,4 @@ function subscribe(callback: () => void) {
   return () => {
     window.removeEventListener(STORAGE_EVENT, callback);
   };
-}
-
-function getSnapshot(key: string): string | null {
-  try {
-    return window.localStorage.getItem(`ontime-${key}`);
-  } catch (error) {
-    console.error(error);
-    return null;
-  }
 }

--- a/apps/client/src/common/hooks/useLocalStorage.ts
+++ b/apps/client/src/common/hooks/useLocalStorage.ts
@@ -1,6 +1,6 @@
 import { useSyncExternalStore } from 'react';
 
-const STORAGE_EVENT = 'onetime-storage';
+const STORAGE_EVENT = 'ontime-storage';
 
 export const useLocalStorage = <T>(key: string, initialValue: T) => {
   const localStorageValue = useSyncExternalStore(subscribe, () => getSnapshot(key));

--- a/apps/client/src/common/hooks/useLocalStorage.ts
+++ b/apps/client/src/common/hooks/useLocalStorage.ts
@@ -1,53 +1,33 @@
-import { useEffect, useState } from 'react';
+import { useSyncExternalStore } from 'react';
 
-/**
- * @description utility hook to handle state in local storage
- * @param key
- * @param initialValue
- */
-export const useLocalStorage = <T>(key: string, initialValue: T): [T, (value: T | ((val: T) => T)) => void] => {
-  const [storedValue, setStoredValue] = useState<T>(() => {
-    try {
-      const item = window.localStorage.getItem(`ontime-${key}`);
-      return item ? JSON.parse(item) : initialValue;
-    } catch (error) {
-      return initialValue;
-    }
-  });
+const STORAGE_EVENT = 'onetime-storage';
 
-  useEffect(() => {
-    const handleStorageChange = (event: StorageEvent) => {
-      if (event.storageArea === window.localStorage && event.key === key) {
-        try {
-          const newValue = event.newValue ? JSON.parse(event.newValue) : initialValue;
-          setStoredValue(newValue);
-        } catch (_) {
-          /* empty */
-        }
-      }
-    };
+export const useLocalStorage = <T>(key: string, initialValue: T) => {
+  const localStorageValue = useSyncExternalStore(subscribe, () => getSnapshot(key));
+  const parsedLocalStorageValue = localStorageValue ? JSON.parse(localStorageValue) : initialValue;
 
-    window.addEventListener('storage', handleStorageChange);
+  const setLocalStorageValue = (value: T | ((val: T) => T)) => {
+    const valueToStore = value instanceof Function ? value(parsedLocalStorageValue) : value;
+    localStorage.setItem(`ontime-${key}`, JSON.stringify(valueToStore));
 
-    return () => {
-      window.removeEventListener('storage', handleStorageChange);
-    };
-  }, [initialValue, key]);
-
-  /**
-   * @description Set value to local storage
-   * @param value
-   */
-  const setValue = (value: T | ((val: T) => T)) => {
-    try {
-      // Allow value to be a function so we have same API as useState
-      const valueToStore = value instanceof Function ? value(storedValue) : value;
-
-      setStoredValue(valueToStore);
-      window.localStorage.setItem(`ontime-${key}`, JSON.stringify(valueToStore));
-    } catch (error) {
-      console.error(error);
-    }
+    window.dispatchEvent(new StorageEvent(STORAGE_EVENT));
   };
-  return [storedValue, setValue];
+
+  return [parsedLocalStorageValue, setLocalStorageValue] as const;
 };
+
+function subscribe(callback: () => void) {
+  window.addEventListener(STORAGE_EVENT, callback);
+
+  return () => {
+    window.removeEventListener(STORAGE_EVENT, callback);
+  };
+}
+
+function getSnapshot(key: string): string | null {
+  try {
+    return window.localStorage.getItem(`ontime-${key}`);
+  } catch (error) {
+    return null;
+  }
+}

--- a/apps/client/src/features/cuesheet/Cuesheet.tsx
+++ b/apps/client/src/features/cuesheet/Cuesheet.tsx
@@ -64,8 +64,8 @@ export default function Cuesheet({ data, columns, handleUpdate, selectedId }: Cu
   };
 
   const headerGroups = table.getHeaderGroups();
-  const rowModels = table.getRowModel();
-  const allLeafColumns = table.getAllColumns();
+  const rowModel = table.getRowModel();
+  const allLeafColumns = table.getAllLeafColumns();
 
   let eventIndex = 0;
   let isPast = Boolean(selectedId);
@@ -84,7 +84,7 @@ export default function Cuesheet({ data, columns, handleUpdate, selectedId }: Cu
         <table className={style.cuesheet}>
           <CuesheetHeader headerGroups={headerGroups} />
           <tbody>
-            {rowModels.rows.map((row) => {
+            {rowModel.rows.map((row) => {
               const key = row.original.id;
               const isSelected = selectedId === key;
               if (isSelected) {

--- a/apps/client/src/features/cuesheet/Cuesheet.tsx
+++ b/apps/client/src/features/cuesheet/Cuesheet.tsx
@@ -24,10 +24,7 @@ interface CuesheetProps {
 }
 
 export default function Cuesheet({ data, columns, handleUpdate, selectedId }: CuesheetProps) {
-  const followSelected = useCuesheetSettings((state) => state.followSelected);
-  const showSettings = useCuesheetSettings((state) => state.showSettings);
-  const showDelayBlock = useCuesheetSettings((state) => state.showDelayBlock);
-  const showPrevious = useCuesheetSettings((state) => state.showPrevious);
+  const { followSelected, showSettings, showDelayBlock, showPrevious } = useCuesheetSettings();
 
   const [columnVisibility, setColumnVisibility] = useLocalStorage('table-hidden', {});
   const [columnOrder, saveColumnOrder] = useLocalStorage<string[]>('table-order', initialColumnOrder);
@@ -66,7 +63,9 @@ export default function Cuesheet({ data, columns, handleUpdate, selectedId }: Cu
     setColumnSizing({});
   };
 
-  const headerGroups = table.getHeaderGroups;
+  const headerGroups = table.getHeaderGroups();
+  const rowModels = table.getRowModel();
+  const allLeafColumns = table.getAllColumns();
 
   let eventIndex = 0;
   let isPast = Boolean(selectedId);
@@ -75,7 +74,7 @@ export default function Cuesheet({ data, columns, handleUpdate, selectedId }: Cu
     <>
       {showSettings && (
         <CuesheetTableSettings
-          columns={table.getAllLeafColumns()}
+          columns={allLeafColumns}
           handleResetResizing={resetColumnResizing}
           handleResetReordering={resetColumnOrder}
           handleClearToggles={setAllVisible}
@@ -85,7 +84,7 @@ export default function Cuesheet({ data, columns, handleUpdate, selectedId }: Cu
         <table className={style.cuesheet}>
           <CuesheetHeader headerGroups={headerGroups} />
           <tbody>
-            {table.getRowModel().rows.map((row) => {
+            {rowModels.rows.map((row) => {
               const key = row.original.id;
               const isSelected = selectedId === key;
               if (isSelected) {

--- a/apps/client/src/features/cuesheet/cuesheet-table-elements/CuesheetHeader.tsx
+++ b/apps/client/src/features/cuesheet/cuesheet-table-elements/CuesheetHeader.tsx
@@ -23,7 +23,7 @@ import { SortableCell } from './SortableCell';
 import style from '../Cuesheet.module.scss';
 
 interface CuesheetHeaderProps {
-  headerGroups: () => HeaderGroup<OntimeRundownEntry>[];
+  headerGroups: HeaderGroup<OntimeRundownEntry>[];
 }
 
 function CuesheetHeader(props: CuesheetHeaderProps) {
@@ -75,7 +75,7 @@ function CuesheetHeader(props: CuesheetHeaderProps) {
 
   return (
     <thead className={style.tableHeader}>
-      {headerGroups().map((headerGroup) => {
+      {headerGroups.map((headerGroup) => {
         const key = headerGroup.id;
 
         return (

--- a/apps/client/src/features/cuesheet/cuesheet-table-settings/CuesheetTableSettings.tsx
+++ b/apps/client/src/features/cuesheet/cuesheet-table-settings/CuesheetTableSettings.tsx
@@ -22,12 +22,14 @@ interface CuesheetTableSettingsProps {
 
 function CuesheetTableSettings(props: CuesheetTableSettingsProps) {
   const { columns, handleResetResizing, handleResetReordering, handleClearToggles } = props;
-  const showPrevious = useCuesheetSettings((state) => state.showPrevious);
-  const togglePreviousVisibility = useCuesheetSettings((state) => state.togglePreviousVisibility);
-  const showDelayBlock = useCuesheetSettings((state) => state.showDelayBlock);
-  const toggleDelayVisibility = useCuesheetSettings((state) => state.toggleDelayVisibility);
-  const showDelayedTimes = useCuesheetSettings((state) => state.showDelayedTimes);
-  const toggleDelayedTimes = useCuesheetSettings((state) => state.toggleDelayedTimes);
+  const {
+    showPrevious,
+    toggleDelayVisibility,
+    showDelayBlock,
+    showDelayedTimes,
+    toggleDelayedTimes,
+    togglePreviousVisibility,
+  } = useCuesheetSettings();
 
   return (
     <div className={style.tableSettings}>


### PR DESCRIPTION
This PR fixes issues with changes to the table header not causing re-renders:

- drag and drop to reorder columns did not work until a manual refresh of the page
- resize did not seem to work

This was likely caused by attempts to improve table performance, I hope this changes do not worsen performance significantly
