### PR TITLE
chore: disable save params feature

### DIFF
--- a/apps/client/src/common/components/view-params-editor/ViewParamsEditor.tsx
+++ b/apps/client/src/common/components/view-params-editor/ViewParamsEditor.tsx
@@ -51,6 +51,12 @@ export default function ViewParamsEditor({ paramFields }: EditFormDrawerProps) {
     }
   }, [searchParams, onOpen]);
 
+  /**
+   * disabling this for now, this feature needs more testing
+   * - we seem to have a bug where this is conflicting with the aliases
+   * - I wonder if the logic below needs to be inside an effect, 
+   * both localStorage and searchParams should trigger a component update when they change
+
   useEffect(() => {
     const viewParamsObjFromLocalStorage = storedViewParams[pathname];
 
@@ -63,6 +69,8 @@ export default function ViewParamsEditor({ paramFields }: EditFormDrawerProps) {
     // rule is disabled since adding `setSearchParams` & `storedViewParams` results in unnecessary re-renders
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pathname]);
+
+  */
 
   const onEditDrawerClose = () => {
     onClose();


### PR DESCRIPTION
Temporarily disabled the save params feature

Are you ok with this @asharonbaltazar ?

While I was doing this, it occurred to me that the presets work we spoke about might be a simpler way to solve this problem, with less potential edge cases
https://github.com/cpvalente/ontime/issues/608#issuecomment-1823473114