### PR TITLE
Osc enabled out

### DIFF
--- a/apps/server/src/controllers/ontimeController.ts
+++ b/apps/server/src/controllers/ontimeController.ts
@@ -16,6 +16,7 @@ import { deleteAllEvents, notifyChanges } from '../services/rundown-service/Rund
 import { deepmerge } from 'ontime-utils';
 import { runtimeCacheStore } from '../stores/cachingStore.js';
 import { delayedRundownCacheKey } from '../services/rundown-service/delayedRundown.utils.js';
+import { integrationService } from '../services/integration-service/IntegrationService.js';
 
 // Create controller for GET request to '/ontime/poll'
 // Returns data for current state
@@ -315,9 +316,15 @@ export const postOSC = async (req, res) => {
     const oscSettings = req.body;
     await DataProvider.setOsc(oscSettings);
 
+    integrationService.unregister(oscIntegration);
+
     // TODO: this update could be more granular, checking that relevant data was changed
-    const { message } = oscIntegration.init(oscSettings);
+    const { success, message } = oscIntegration.init(oscSettings);
     logger.info(LogOrigin.Tx, message);
+
+    if (success) {
+      integrationService.register(oscIntegration);
+    }
 
     res.send(oscSettings).status(200);
   } catch (error) {

--- a/apps/server/src/services/integration-service/OscIntegration.ts
+++ b/apps/server/src/services/integration-service/OscIntegration.ts
@@ -26,7 +26,15 @@ export class OscIntegration implements IIntegration {
    * Initializes oscClient
    */
   init(config: OSCSettings) {
-    const { targetIP, portOut, subscriptions } = config;
+    const { targetIP, portOut, subscriptions, enabledOut } = config;
+
+    if (!enabledOut) {
+      this.oscClient?.close();
+      return {
+        success: false,
+        message: 'OSC output disabled',
+      };
+    }
 
     this.initSubscriptions(subscriptions);
 


### PR DESCRIPTION
Actually disable/enable osc output depending on `osc.enabledOut`
and also registers or unregisters with the IntegrationService when changing settings in the UI
so the output can now be changed without restarting.