### PR TITLE
Movable Menu

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@chakra-ui/react": "^2.7.0",
     "@dnd-kit/core": "^6.0.8",
+    "@dnd-kit/modifiers": "^7.0.0",
     "@dnd-kit/sortable": "^7.0.2",
     "@dnd-kit/utilities": "^3.2.1",
     "@emotion/react": "^11.10.6",

--- a/apps/client/src/common/components/navigation-menu/NavigationMenu.module.scss
+++ b/apps/client/src/common/components/navigation-menu/NavigationMenu.module.scss
@@ -34,6 +34,10 @@ $button-size: 48px;
   }
 }
 
+.menuContent {
+  bottom: 66px;
+}
+
 .button {
   font-size: 24px;
   color: $icon-color;
@@ -47,7 +51,7 @@ $button-size: 48px;
 
 .navButton {
   @extend .button;
-  z-index: 3;
+  z-index: 11;
 }
 
 .menuContainer {
@@ -75,6 +79,7 @@ $button-size: 48px;
   display: flex;
   justify-content: center;
   font-size: 24px;
+  cursor: grab;
 }
 
 .link {

--- a/apps/client/src/common/components/navigation-menu/NavigationMenu.module.scss
+++ b/apps/client/src/common/components/navigation-menu/NavigationMenu.module.scss
@@ -71,6 +71,12 @@ $button-size: 48px;
   margin-top: calc(56px + 1rem);
 }
 
+.dragBtn {
+  display: flex;
+  justify-content: center;
+  font-size: 24px;
+}
+
 .link {
   @include action-link;
   justify-content: space-between;

--- a/apps/client/src/common/components/navigation-menu/NavigationMenu.module.scss
+++ b/apps/client/src/common/components/navigation-menu/NavigationMenu.module.scss
@@ -34,10 +34,6 @@ $button-size: 48px;
   }
 }
 
-.menuContent {
-  bottom: 66px;
-}
-
 .button {
   font-size: 24px;
   color: $icon-color;
@@ -51,18 +47,13 @@ $button-size: 48px;
 
 .navButton {
   @extend .button;
-  z-index: 11;
 }
 
 .menuContainer {
-  top: 0;
-  left: 0;
   height: fit-content;
-  position: absolute;
   background-color: $menu-bg;
   min-width: 200px;
-  border-radius: 0 0 24px 0;
-  border-right: 1px solid $border-color-ondark;
+  border: 1px solid $border-color-ondark;
 
   box-shadow: $box-shadow-l2;
   padding-bottom: 1rem;
@@ -71,15 +62,18 @@ $button-size: 48px;
   overflow-y: auto;
 }
 
-.buttonsContainer {
-  margin-top: calc(56px + 1rem);
-}
-
-.dragBtn {
+.grabBtn {
   display: flex;
   justify-content: center;
   font-size: 24px;
+}
+
+.grab {
   cursor: grab;
+}
+
+.grabbing {
+  cursor: grabbing;
 }
 
 .link {

--- a/apps/client/src/common/components/navigation-menu/NavigationMenu.tsx
+++ b/apps/client/src/common/components/navigation-menu/NavigationMenu.tsx
@@ -1,7 +1,7 @@
 import { KeyboardEvent, memo, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { Link, useLocation, useSearchParams } from 'react-router-dom';
-import { useDisclosure } from '@chakra-ui/react';
+import { Popover, PopoverBody, PopoverContent, PopoverTrigger, Portal, useDisclosure } from '@chakra-ui/react';
 import { DndContext, DragEndEvent, MouseSensor, TouchSensor, useDraggable, useSensor, useSensors } from '@dnd-kit/core';
 import { Coordinates, CSS } from '@dnd-kit/utilities';
 import { IoApps } from '@react-icons/all-files/io5/IoApps';
@@ -71,7 +71,7 @@ function NavigationMenu({ top, left }: NavigationMenuProps) {
       if (fadeOut) {
         clearTimeout(fadeOut);
       }
-      fadeOut = setTimeout(() => setShowButton(false), 3000);
+      fadeOut = setTimeout(() => setShowButton(true), 3000);
     };
     document.addEventListener('mousemove', setShowMenuTrue);
     return () => {
@@ -94,83 +94,87 @@ function NavigationMenu({ top, left }: NavigationMenuProps) {
   return (
     <div id='navigation-menu-portal' ref={menuRef} className={mirror ? style.mirror : ''}>
       <RenameClientModal isOpen={isOpen} onClose={onClose} />
-      <div
-        className={`${style.buttonContainer} ${!showButton && !showMenu ? style.hidden : ''}`}
-        ref={setNodeRef}
-        style={{ top, left, transform: CSS.Translate.toString(transform) }}
-      >
-        <button onClick={toggleMenu} aria-label='toggle menu' className={style.navButton}>
-          <IoApps />
-        </button>
-        <button className={style.button} onClick={showEditFormDrawer}>
-          <IoPencilSharp />
-        </button>
-        {showMenu && (
-          <div className={style.menuContainer} data-testid='navigation-menu'>
-            <div className={style.buttonsContainer}>
-              <div
-                className={style.link}
-                tabIndex={0}
-                role='button'
-                onClick={handleFullscreen}
-                onKeyDown={(event) => {
-                  isKeyEnter(event) && handleFullscreen();
-                }}
-              >
-                Toggle Fullscreen
-                {isFullScreen ? <IoContract /> : <IoExpand />}
+      <Popover placement='bottom-start'>
+        <div
+          className={`${style.buttonContainer} ${!showButton && !showMenu ? style.hidden : ''}`}
+          ref={setNodeRef}
+          style={{ top, left, transform: CSS.Translate.toString(transform) }}
+        >
+          <PopoverTrigger>
+            <button aria-label='toggle menu' className={style.navButton}>
+              <IoApps />
+            </button>
+          </PopoverTrigger>
+          <button className={style.button} onClick={showEditFormDrawer}>
+            <IoPencilSharp />
+          </button>
+          <button className={style.dragBtn} {...attributes} {...listeners}>
+            <MdDragHandle />
+          </button>
+          <PopoverContent className={style.menuContent} border='none' w='200px'>
+            <PopoverBody className={style.menuContainer} data-testid='navigation-menu' p={0}>
+              <div className={style.buttonsContainer}>
+                <div
+                  className={style.link}
+                  tabIndex={0}
+                  role='button'
+                  onClick={handleFullscreen}
+                  onKeyDown={(event) => {
+                    isKeyEnter(event) && handleFullscreen();
+                  }}
+                >
+                  Toggle Fullscreen
+                  {isFullScreen ? <IoContract /> : <IoExpand />}
+                </div>
+                <div
+                  className={style.link}
+                  tabIndex={0}
+                  role='button'
+                  onClick={handleMirror}
+                  onKeyDown={(event) => {
+                    isKeyEnter(event) && handleMirror();
+                  }}
+                >
+                  Flip Screen
+                  <IoSwapVertical />
+                </div>
+                <div
+                  className={style.link}
+                  tabIndex={0}
+                  role='button'
+                  onClick={onOpen}
+                  onKeyDown={(event) => {
+                    isKeyEnter(event) && onOpen();
+                  }}
+                >
+                  Rename Client
+                </div>
               </div>
-              <div
-                className={style.link}
-                tabIndex={0}
-                role='button'
-                onClick={handleMirror}
-                onKeyDown={(event) => {
-                  isKeyEnter(event) && handleMirror();
-                }}
-              >
-                Flip Screen
-                <IoSwapVertical />
-              </div>
-              <div
-                className={style.link}
-                tabIndex={0}
-                role='button'
-                onClick={onOpen}
-                onKeyDown={(event) => {
-                  isKeyEnter(event) && onOpen();
-                }}
-              >
-                Rename Client
-              </div>
-            </div>
-            <hr className={style.separator} />
-            <Link to='/cuesheet' className={style.link} tabIndex={0}>
-              Cuesheet
-              <IoArrowUp className={style.linkIcon} />
-            </Link>
-            <Link to='/op' className={style.link} tabIndex={0}>
-              Operator
-              <IoArrowUp className={style.linkIcon} />
-            </Link>
-            <hr className={style.separator} />
-            {navigatorConstants.map((route) => (
-              <Link
-                key={route.url}
-                to={route.url}
-                className={`${style.link} ${route.url === location.pathname ? style.current : undefined}`}
-                tabIndex={0}
-              >
-                {route.label}
+              <hr className={style.separator} />
+              <Link to='/cuesheet' className={style.link} tabIndex={0}>
+                Cuesheet
                 <IoArrowUp className={style.linkIcon} />
               </Link>
-            ))}
-          </div>
-        )}
-        <button className={style.dragBtn} {...attributes} {...listeners}>
-          <MdDragHandle />
-        </button>
-      </div>
+              <Link to='/op' className={style.link} tabIndex={0}>
+                Operator
+                <IoArrowUp className={style.linkIcon} />
+              </Link>
+              <hr className={style.separator} />
+              {navigatorConstants.map((route) => (
+                <Link
+                  key={route.url}
+                  to={route.url}
+                  className={`${style.link} ${route.url === location.pathname ? style.current : undefined}`}
+                  tabIndex={0}
+                >
+                  {route.label}
+                  <IoArrowUp className={style.linkIcon} />
+                </Link>
+              ))}
+            </PopoverBody>
+          </PopoverContent>
+        </div>
+      </Popover>
     </div>
   );
 }

--- a/apps/client/src/common/components/navigation-menu/NavigationMenu.tsx
+++ b/apps/client/src/common/components/navigation-menu/NavigationMenu.tsx
@@ -10,6 +10,7 @@ import {
   useDisclosure,
 } from '@chakra-ui/react';
 import { DndContext, DragEndEvent, MouseSensor, TouchSensor, useDraggable, useSensor, useSensors } from '@dnd-kit/core';
+import { restrictToWindowEdges } from '@dnd-kit/modifiers';
 import { Coordinates, CSS, Transform } from '@dnd-kit/utilities';
 import { IoApps } from '@react-icons/all-files/io5/IoApps';
 import { IoArrowUp } from '@react-icons/all-files/io5/IoArrowUp';
@@ -74,7 +75,7 @@ function NavigationMenuDragContext() {
   };
 
   return (
-    <DndContext id='navigation-menu' onDragEnd={onDragEnd} sensors={sensors}>
+    <DndContext id='navigation-menu' onDragEnd={onDragEnd} sensors={sensors} modifiers={[restrictToWindowEdges]}>
       <NavigationMenu
         top={y}
         left={x}

--- a/apps/client/src/common/components/navigation-menu/NavigationMenu.tsx
+++ b/apps/client/src/common/components/navigation-menu/NavigationMenu.tsx
@@ -16,6 +16,7 @@ import { IoArrowUp } from '@react-icons/all-files/io5/IoArrowUp';
 import { IoContract } from '@react-icons/all-files/io5/IoContract';
 import { IoExpand } from '@react-icons/all-files/io5/IoExpand';
 import { IoPencilSharp } from '@react-icons/all-files/io5/IoPencilSharp';
+import { IoRefreshSharp } from '@react-icons/all-files/io5/IoRefreshSharp';
 import { IoSwapVertical } from '@react-icons/all-files/io5/IoSwapVertical';
 import { MdDragHandle } from '@react-icons/all-files/md/MdDragHandle';
 
@@ -26,6 +27,8 @@ import { useViewOptionsStore } from '../../stores/viewOptions';
 import RenameClientModal from './rename-client-modal/RenameClientModal';
 
 import style from './NavigationMenu.module.scss';
+
+const defaultCoordinates: Coordinates = { x: 0, y: 0 };
 
 const getTransformDimensions = (transform: Transform | null, isMirrored: boolean) => {
   if (isMirrored && transform) {
@@ -44,7 +47,7 @@ const getTransformDimensions = (transform: Transform | null, isMirrored: boolean
 };
 
 function NavigationMenuDragContext() {
-  const [{ x, y }, setCoordinates] = useState<Coordinates>({ x: 0, y: 0 });
+  const [{ x, y }, setCoordinates] = useState<Coordinates>(defaultCoordinates);
   const sensors = useSensors(useSensor(MouseSensor), useSensor(TouchSensor));
   const { mirror: isMirrored, toggleMirror } = useViewOptionsStore();
 
@@ -62,11 +65,23 @@ function NavigationMenuDragContext() {
     }));
   };
 
-  const toggleIsMirrored = () => toggleMirror();
+  const toggleIsMirrored = () => {
+    toggleMirror();
+  };
+
+  const onResetMenuCoordinates = () => {
+    setCoordinates(defaultCoordinates);
+  };
 
   return (
     <DndContext id='navigation-menu' onDragEnd={onDragEnd} sensors={sensors}>
-      <NavigationMenu top={y} left={x} isMirrored={isMirrored} toggleIsMirrored={toggleIsMirrored} />
+      <NavigationMenu
+        top={y}
+        left={x}
+        isMirrored={isMirrored}
+        toggleIsMirrored={toggleIsMirrored}
+        onResetMenuCoordinates={onResetMenuCoordinates}
+      />
     </DndContext>
   );
 }
@@ -75,9 +90,10 @@ interface NavigationMenuProps {
   left: number;
   isMirrored: boolean;
   toggleIsMirrored: () => void;
+  onResetMenuCoordinates: () => void;
 }
 
-function NavigationMenu({ top, left, isMirrored, toggleIsMirrored }: NavigationMenuProps) {
+function NavigationMenu({ top, left, isMirrored, toggleIsMirrored, onResetMenuCoordinates }: NavigationMenuProps) {
   const location = useLocation();
 
   const { isFullScreen, toggleFullScreen } = useFullscreen();
@@ -174,6 +190,18 @@ function NavigationMenu({ top, left, isMirrored, toggleIsMirrored }: NavigationM
               >
                 Flip Screen
                 <IoSwapVertical />
+              </div>
+              <div
+                className={style.link}
+                tabIndex={0}
+                role='button'
+                onClick={onResetMenuCoordinates}
+                onKeyDown={(event) => {
+                  isKeyEnter(event) && onResetMenuCoordinates();
+                }}
+              >
+                Reset Menu
+                <IoRefreshSharp />
               </div>
               <div
                 className={style.link}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 importers:
 
   .:
@@ -56,6 +52,9 @@ importers:
       '@dnd-kit/core':
         specifier: ^6.0.8
         version: 6.0.8(react-dom@18.2.0)(react@18.2.0)
+      '@dnd-kit/modifiers':
+        specifier: ^7.0.0
+        version: 7.0.0(@dnd-kit/core@6.0.8)(react@18.2.0)
       '@dnd-kit/sortable':
         specifier: ^7.0.2
         version: 7.0.2(@dnd-kit/core@6.0.8)(react@18.2.0)
@@ -345,7 +344,7 @@ importers:
         version: 5.2.2
       vitest:
         specifier: ^0.30.1
-        version: 0.30.1
+        version: 0.30.1(jsdom@21.1.0)(sass@1.57.1)
 
   packages/types:
     devDependencies:
@@ -406,7 +405,7 @@ importers:
         version: 5.2.2
       vitest:
         specifier: ^0.30.1
-        version: 0.30.1
+        version: 0.30.1(jsdom@21.1.0)(sass@1.57.1)
 
 packages:
 
@@ -1791,7 +1790,7 @@ packages:
       react: '>=16.8.0'
     dependencies:
       react: 18.2.0
-      tslib: 2.5.0
+      tslib: 2.6.2
     dev: false
 
   /@dnd-kit/core@6.0.8(react-dom@18.2.0)(react@18.2.0):
@@ -1805,6 +1804,18 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       tslib: 2.5.0
+    dev: false
+
+  /@dnd-kit/modifiers@7.0.0(@dnd-kit/core@6.0.8)(react@18.2.0):
+    resolution: {integrity: sha512-BG/ETy3eBjFap7+zIti53f0PCLGDzNXyTmn6fSdrudORf+OH04MxrW4p5+mPu4mgMk9kM41iYONjc3DOUWTcfg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.1.0
+      react: '>=16.8.0'
+    dependencies:
+      '@dnd-kit/core': 6.0.8(react-dom@18.2.0)(react@18.2.0)
+      '@dnd-kit/utilities': 3.2.2(react@18.2.0)
+      react: 18.2.0
+      tslib: 2.6.2
     dev: false
 
   /@dnd-kit/sortable@7.0.2(@dnd-kit/core@6.0.8)(react@18.2.0):
@@ -1826,6 +1837,15 @@ packages:
     dependencies:
       react: 18.2.0
       tslib: 2.4.1
+    dev: false
+
+  /@dnd-kit/utilities@3.2.2(react@18.2.0):
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
+    dependencies:
+      react: 18.2.0
+      tslib: 2.6.2
     dev: false
 
   /@electron/get@2.0.2:
@@ -8504,27 +8524,6 @@ packages:
     dev: true
     optional: true
 
-  /vite-node@0.30.1(@types/node@16.18.23):
-    resolution: {integrity: sha512-vTikpU/J7e6LU/8iM3dzBo8ZhEiKZEKRznEMm+mJh95XhWaPrJQraT/QsT2NWmuEf+zgAoMe64PKT7hfZ1Njmg==}
-    engines: {node: '>=v14.18.0'}
-    hasBin: true
-    dependencies:
-      cac: 6.7.14
-      debug: 4.3.4
-      mlly: 1.2.0
-      pathe: 1.1.0
-      picocolors: 1.0.0
-      vite: 4.3.1(@types/node@16.18.23)
-    transitivePeerDependencies:
-      - '@types/node'
-      - less
-      - sass
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-    dev: true
-
   /vite-node@0.30.1(@types/node@18.15.11)(sass@1.57.1):
     resolution: {integrity: sha512-vTikpU/J7e6LU/8iM3dzBo8ZhEiKZEKRznEMm+mJh95XhWaPrJQraT/QsT2NWmuEf+zgAoMe64PKT7hfZ1Njmg==}
     engines: {node: '>=v14.18.0'}
@@ -8618,39 +8617,6 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vite@4.3.1(@types/node@16.18.23):
-    resolution: {integrity: sha512-EPmfPLAI79Z/RofuMvkIS0Yr091T2ReUoXQqc5ppBX/sjFRhHKiPPF/R46cTdoci/XgeQpB23diiJxq5w30vdg==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': '>= 14'
-      less: '*'
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      '@types/node': 16.18.23
-      esbuild: 0.17.5
-      postcss: 8.4.21
-      rollup: 3.20.7
-    optionalDependencies:
-      fsevents: 2.3.3
-    dev: true
-
   /vite@4.3.1(@types/node@18.15.11)(sass@1.57.1):
     resolution: {integrity: sha512-EPmfPLAI79Z/RofuMvkIS0Yr091T2ReUoXQqc5ppBX/sjFRhHKiPPF/R46cTdoci/XgeQpB23diiJxq5w30vdg==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -8683,72 +8649,6 @@ packages:
       sass: 1.57.1
     optionalDependencies:
       fsevents: 2.3.3
-    dev: true
-
-  /vitest@0.30.1:
-    resolution: {integrity: sha512-y35WTrSTlTxfMLttgQk4rHcaDkbHQwDP++SNwPb+7H8yb13Q3cu2EixrtHzF27iZ8v0XCciSsLg00RkPAzB/aA==}
-    engines: {node: '>=v14.18.0'}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@vitest/browser': '*'
-      '@vitest/ui': '*'
-      happy-dom: '*'
-      jsdom: '*'
-      playwright: '*'
-      safaridriver: '*'
-      webdriverio: '*'
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@vitest/browser':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
-        optional: true
-      playwright:
-        optional: true
-      safaridriver:
-        optional: true
-      webdriverio:
-        optional: true
-    dependencies:
-      '@types/chai': 4.3.4
-      '@types/chai-subset': 1.3.3
-      '@types/node': 16.18.23
-      '@vitest/expect': 0.30.1
-      '@vitest/runner': 0.30.1
-      '@vitest/snapshot': 0.30.1
-      '@vitest/spy': 0.30.1
-      '@vitest/utils': 0.30.1
-      acorn: 8.8.2
-      acorn-walk: 8.2.0
-      cac: 6.7.14
-      chai: 4.3.7
-      concordance: 5.0.4
-      debug: 4.3.4
-      local-pkg: 0.4.3
-      magic-string: 0.30.0
-      pathe: 1.1.0
-      picocolors: 1.0.0
-      source-map: 0.6.1
-      std-env: 3.3.2
-      strip-literal: 1.0.1
-      tinybench: 2.4.0
-      tinypool: 0.4.0
-      vite: 4.3.1(@types/node@16.18.23)
-      vite-node: 0.30.1(@types/node@16.18.23)
-      why-is-node-running: 2.2.2
-    transitivePeerDependencies:
-      - less
-      - sass
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
     dev: true
 
   /vitest@0.30.1(jsdom@21.1.0)(sass@1.57.1):
@@ -9085,3 +8985,7 @@ packages:
     engines: {node: '>=0.8'}
     hasBin: true
     dev: false
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false


### PR DESCRIPTION
closes #103 

- add drag-n-drop ability to `NavigationMenu`
- add `dndkit/modifiers` package for preventing menu from leaving the screen
- switch to `Popover` for displaying menu correctly on screen
- add `Reset Menu` button to reset menu to its initial position (`{ x: 0, y: 0 }`)
- update menu styling to support new repositioning logic
- simplify component logic


https://github.com/cpvalente/ontime/assets/58940073/5be9651b-4516-4782-b096-1c7ad3131c5d



