### PR TITLE
feat: add user notes to editor

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -40,6 +40,7 @@
     "build:local": "cross-env NODE_ENV=local vite build",
     "build:electron": "cross-env NODE_ENV=local vite build",
     "build:docker": "vite build",
+    "build:localdocker": "cross-env NODE_ENV=local vite build",
     "lint": "eslint . --quiet",
     "lint-staged": "eslint",
     "test": "vitest",

--- a/apps/client/src/features/event-editor/EventEditor.module.scss
+++ b/apps/client/src/features/event-editor/EventEditor.module.scss
@@ -11,9 +11,9 @@ $table-header-font-size: calc(1rem - 3px);
 }
 
 .eventEditor {
-  padding: 1rem 2rem 2rem 2rem;
+  padding: 2rem 2rem 2rem 2rem;
   width: 100%;
-  gap: max(1rem, 2vh);
+  gap: 1rem;
 
   display: grid;
   grid-template-areas: 'time left right';
@@ -38,18 +38,21 @@ $table-header-font-size: calc(1rem - 3px);
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  height: 100%;
 }
 
 .left {
   grid-area: left;
   padding: 0 1rem;
   border-left: 1px solid $border-color-ondark;
+  max-height: 100%;
 }
 
 .right {
   padding-left: 1rem;
   grid-area: right;
   border-left: 1px solid $border-color-ondark;
+  max-height: 100%;
 }
 
 @mixin input-label() {
@@ -119,6 +122,12 @@ $table-header-font-size: calc(1rem - 3px);
 .notes {
   font-size: $table-font-size;
   font-weight: 400;
+  height: 10rem;
+  overflow-y: auto;
+  transition: height 250ms;
+  table {
+    width: 100%;
+  }
 
   tr {
     display: flex;
@@ -133,31 +142,42 @@ $table-header-font-size: calc(1rem - 3px);
     box-shadow: none !important;
     @include ellipsis-overflow;
   }
+
   th:first-child, td:first-child {
     min-width: 10em;
     width: 10em;
   }
 
   th:last-child, td:last-child {
-  flex-grow: 2;
+    flex-grow: 2;
+  }
+}
+
+@media only screen and (min-height: 1081px) { 
+  .notes {
+    height: 25rem;
   }
 }
 
 .noteHeader {
   position: sticky;
-  top: 0;
+  top: -3px;
   z-index: 10;
-
   vertical-align: top;
 
-  font-size: $table-header-font-size;
+  // font-size: $table-header-font-size;
   color: $gray-400;
-  font-weight: 500;
+  // font-weight: 500;
   
   td {
     background-color: $gray-1300 !important;
     border-radius: 2px;
-    padding: 0.25rem;
+    padding: 0.3rem;
+    padding-left: 1em;
+  }
+
+  td {
+    text-align: center;
   }
 }
 

--- a/apps/client/src/features/event-editor/EventEditor.module.scss
+++ b/apps/client/src/features/event-editor/EventEditor.module.scss
@@ -1,4 +1,14 @@
+@use '../../theme/ontimeColours' as *;
 @use '../../theme/v2Styles' as *;
+
+$table-font-size: calc(1rem - 2px);
+$table-header-font-size: calc(1rem - 3px);
+
+@mixin ellipsis-overflow() {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 
 .eventEditor {
   padding: 1rem 2rem 2rem 2rem;
@@ -104,4 +114,63 @@
 
 .fullHeight {
   height: 100%
+}
+
+.notes {
+  font-size: $table-font-size;
+  font-weight: 400;
+
+  tr {
+    display: flex;
+  }
+
+  th, td {
+    margin: 1px;
+    font-weight: inherit;
+    font-size: inherit;
+    text-align: left;
+    position: relative;
+    box-shadow: none !important;
+    @include ellipsis-overflow;
+  }
+  th:first-child, td:first-child {
+    min-width: 10em;
+    width: 10em;
+  }
+
+  th:last-child, td:last-child {
+  flex-grow: 2;
+  }
+}
+
+.noteHeader {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+
+  vertical-align: top;
+
+  font-size: $table-header-font-size;
+  color: $gray-400;
+  font-weight: 500;
+  
+  td {
+    background-color: $gray-1300 !important;
+    border-radius: 2px;
+    padding: 0.25rem;
+  }
+}
+
+.noteRow {
+  td {
+    background-color: $gray-1200 !important;
+    color: white !important;
+    border-radius: 2px;
+    padding: 0.3rem;
+    padding-left: 1em;
+  }
+
+  td:first-child {
+    text-align: center;
+  }
 }

--- a/apps/client/src/features/event-editor/EventEditor.tsx
+++ b/apps/client/src/features/event-editor/EventEditor.tsx
@@ -80,11 +80,11 @@ export default function EventEditor() {
         title={event.title}
         presenter={event.presenter}
         subtitle={event.subtitle}
-        colour={event.colour}
         handleSubmit={handleSubmit}
       />
       <EventEditorDataRight
         key={`${event.id}-right`}
+        colour={event.colour}
         note={event.note}
         user0={event.user0}
         user1={event.user1}

--- a/apps/client/src/features/event-editor/EventEditor.tsx
+++ b/apps/client/src/features/event-editor/EventEditor.tsx
@@ -13,7 +13,23 @@ import EventEditorTimes from './composite/EventEditorTimes';
 import style from './EventEditor.module.scss';
 
 export type EventEditorSubmitActions = keyof OntimeEvent;
-export type EditorUpdateFields = 'cue' | 'title' | 'presenter' | 'subtitle' | 'note' | 'colour';
+export type EditorUpdateFields =
+  | 'cue'
+  | 'title'
+  | 'presenter'
+  | 'subtitle'
+  | 'note'
+  | 'colour'
+  | 'user0'
+  | 'user1'
+  | 'user2'
+  | 'user3'
+  | 'user4'
+  | 'user5'
+  | 'user6'
+  | 'user7'
+  | 'user8'
+  | 'user9';
 
 export default function EventEditor() {
   const openId = useAppMode((state) => state.editId);
@@ -64,12 +80,22 @@ export default function EventEditor() {
         title={event.title}
         presenter={event.presenter}
         subtitle={event.subtitle}
+        colour={event.colour}
         handleSubmit={handleSubmit}
       />
       <EventEditorDataRight
         key={`${event.id}-right`}
         note={event.note}
-        colour={event.colour}
+        user0={event.user0}
+        user1={event.user1}
+        user2={event.user2}
+        user3={event.user3}
+        user4={event.user4}
+        user5={event.user5}
+        user6={event.user6}
+        user7={event.user7}
+        user8={event.user8}
+        user9={event.user9}
         handleSubmit={handleSubmit}
       >
         <CopyTag label='Event ID'>{event.id}</CopyTag>

--- a/apps/client/src/features/event-editor/composite/EventEditorDataLeft.tsx
+++ b/apps/client/src/features/event-editor/composite/EventEditorDataLeft.tsx
@@ -2,7 +2,6 @@ import { memo } from 'react';
 import { Input } from '@chakra-ui/react';
 import { sanitiseCue } from 'ontime-utils';
 
-import SwatchSelect from '../../../common/components/input/colour-input/SwatchSelect';
 import { type EditorUpdateFields } from '../EventEditor';
 
 import CountedTextInput from './CountedTextInput';
@@ -14,13 +13,12 @@ interface EventEditorLeftProps {
   cue: string;
   title: string;
   presenter: string;
-  colour: string;
   subtitle: string;
   handleSubmit: (field: EditorUpdateFields, value: string) => void;
 }
 
 const EventEditorDataLeft = (props: EventEditorLeftProps) => {
-  const { eventId, colour, cue, title, presenter, subtitle, handleSubmit } = props;
+  const { eventId, cue, title, presenter, subtitle, handleSubmit } = props;
 
   const cueSubmitHandler = (_field: string, newValue: string) => {
     handleSubmit('cue', sanitiseCue(newValue));
@@ -49,12 +47,6 @@ const EventEditorDataLeft = (props: EventEditorLeftProps) => {
       <CountedTextInput field='title' label='Title' initialValue={title} submitHandler={handleSubmit} />
       <CountedTextInput field='presenter' label='Presenter' initialValue={presenter} submitHandler={handleSubmit} />
       <CountedTextInput field='subtitle' label='Subtitle' initialValue={subtitle} submitHandler={handleSubmit} />
-      <div className={style.column}>
-        <label className={style.inputLabel}>Colour</label>
-        <div className={style.inline}>
-          <SwatchSelect name='colour' value={colour} handleChange={handleSubmit} />
-        </div>
-      </div>
     </div>
   );
 };

--- a/apps/client/src/features/event-editor/composite/EventEditorDataLeft.tsx
+++ b/apps/client/src/features/event-editor/composite/EventEditorDataLeft.tsx
@@ -2,6 +2,7 @@ import { memo } from 'react';
 import { Input } from '@chakra-ui/react';
 import { sanitiseCue } from 'ontime-utils';
 
+import SwatchSelect from '../../../common/components/input/colour-input/SwatchSelect';
 import { type EditorUpdateFields } from '../EventEditor';
 
 import CountedTextInput from './CountedTextInput';
@@ -13,12 +14,13 @@ interface EventEditorLeftProps {
   cue: string;
   title: string;
   presenter: string;
+  colour: string;
   subtitle: string;
   handleSubmit: (field: EditorUpdateFields, value: string) => void;
 }
 
 const EventEditorDataLeft = (props: EventEditorLeftProps) => {
-  const { eventId, cue, title, presenter, subtitle, handleSubmit } = props;
+  const { eventId, colour, cue, title, presenter, subtitle, handleSubmit } = props;
 
   const cueSubmitHandler = (_field: string, newValue: string) => {
     handleSubmit('cue', sanitiseCue(newValue));
@@ -47,6 +49,12 @@ const EventEditorDataLeft = (props: EventEditorLeftProps) => {
       <CountedTextInput field='title' label='Title' initialValue={title} submitHandler={handleSubmit} />
       <CountedTextInput field='presenter' label='Presenter' initialValue={presenter} submitHandler={handleSubmit} />
       <CountedTextInput field='subtitle' label='Subtitle' initialValue={subtitle} submitHandler={handleSubmit} />
+      <div className={style.column}>
+        <label className={style.inputLabel}>Colour</label>
+        <div className={style.inline}>
+          <SwatchSelect name='colour' value={colour} handleChange={handleSubmit} />
+        </div>
+      </div>
     </div>
   );
 };

--- a/apps/client/src/features/event-editor/composite/EventEditorDataRight.tsx
+++ b/apps/client/src/features/event-editor/composite/EventEditorDataRight.tsx
@@ -1,5 +1,6 @@
 import { memo, PropsWithChildren } from 'react';
 
+import SwatchSelect from '../../../common/components/input/colour-input/SwatchSelect';
 import useUserFields from '../../../common/hooks-query/useUserFields';
 import EditableCell from '../../cuesheet/cuesheet-table-elements/EditableCell';
 import { EditorUpdateFields } from '../EventEditor';
@@ -8,6 +9,7 @@ import { EditorUpdateFields } from '../EventEditor';
 import style from '../EventEditor.module.scss';
 
 interface EventEditorRightProps {
+  colour: string;
   note: string;
   user0: string;
   user1: string;
@@ -23,145 +25,154 @@ interface EventEditorRightProps {
 }
 
 const EventEditorDataRight = (props: PropsWithChildren<EventEditorRightProps>) => {
-  const { children, note, user0, user1, user2, user3, user4, user5, user6, user7, user8, user9, handleSubmit } = props;
+  const { children, colour, note, user0, user1, user2, user3, user4, user5, user6, user7, user8, user9, handleSubmit } =
+    props;
 
   const { data, isFetching } = useUserFields();
 
   return (
     <div className={style.right}>
+      <div className={style.column}>
+        <label className={style.inputLabel}>Colour</label>
+        <div className={style.inline}>
+          <SwatchSelect name='colour' value={colour} handleChange={handleSubmit} />
+        </div>
+      </div>
       {isFetching && !data && 'Loading User Notes'}
       {data && (
-        <table className={`${style.notes}`}>
-          <thead className={`${style.noteHeader}`}>
-            <tr>
-              <td>User</td>
-              <td>Note</td>
-            </tr>
-          </thead>
-          <tbody>
-            <tr className={`${style.noteRow}`}>
-              <td>All Users</td>
-              <td>
-                <EditableCell
-                  handleUpdate={(value) => {
-                    handleSubmit('note', value);
-                  }}
-                  value={note}
-                />
-              </td>
-            </tr>
-            <tr className={`${style.noteRow}`}>
-              <td>{data?.user0}</td>
-              <td>
-                <EditableCell
-                  handleUpdate={(value) => {
-                    handleSubmit('user0', value);
-                  }}
-                  value={user0}
-                />
-              </td>
-            </tr>
-            <tr className={`${style.noteRow}`}>
-              <td>{data?.user1}</td>
-              <td>
-                <EditableCell
-                  handleUpdate={(value) => {
-                    handleSubmit('user1', value);
-                  }}
-                  value={user1}
-                />
-              </td>
-            </tr>
-            <tr className={`${style.noteRow}`}>
-              <td>{data?.user2}</td>
-              <td>
-                <EditableCell
-                  handleUpdate={(value) => {
-                    handleSubmit('user2', value);
-                  }}
-                  value={user2}
-                />
-              </td>
-            </tr>
-            <tr className={`${style.noteRow}`}>
-              <td>{data?.user3}</td>
-              <td>
-                <EditableCell
-                  handleUpdate={(value) => {
-                    handleSubmit('user3', value);
-                  }}
-                  value={user3}
-                />
-              </td>
-            </tr>
-            <tr className={`${style.noteRow}`}>
-              <td>{data?.user4}</td>
-              <td>
-                <EditableCell
-                  handleUpdate={(value) => {
-                    handleSubmit('user4', value);
-                  }}
-                  value={user4}
-                />
-              </td>
-            </tr>
-            <tr className={`${style.noteRow}`}>
-              <td>{data?.user5}</td>
-              <td>
-                <EditableCell
-                  handleUpdate={(value) => {
-                    handleSubmit('user5', value);
-                  }}
-                  value={user5}
-                />
-              </td>
-            </tr>
-            <tr className={`${style.noteRow}`}>
-              <td>{data?.user6}</td>
-              <td>
-                <EditableCell
-                  handleUpdate={(value) => {
-                    handleSubmit('user6', value);
-                  }}
-                  value={user6}
-                />
-              </td>
-            </tr>
-            <tr className={`${style.noteRow}`}>
-              <td>{data?.user7}</td>
-              <td>
-                <EditableCell
-                  handleUpdate={(value) => {
-                    handleSubmit('user7', value);
-                  }}
-                  value={user7}
-                />
-              </td>
-            </tr>
-            <tr className={`${style.noteRow}`}>
-              <td>{data?.user8}</td>
-              <td>
-                <EditableCell
-                  handleUpdate={(value) => {
-                    handleSubmit('user8', value);
-                  }}
-                  value={user8}
-                />
-              </td>
-            </tr>
-            <tr className={`${style.noteRow}`}>
-              <td>{data?.user9}</td>
-              <td>
-                <EditableCell
-                  handleUpdate={(value) => {
-                    handleSubmit('user9', value);
-                  }}
-                  value={user9}
-                />
-              </td>
-            </tr>
-          </tbody>
-        </table>
+        <div className={style.notes}>
+          <table>
+            <thead className={style.noteHeader}>
+              <tr>
+                <td>User</td>
+                <td>Note</td>
+              </tr>
+            </thead>
+            <tbody>
+              <tr className={style.noteRow}>
+                <td>All Users</td>
+                <td>
+                  <EditableCell
+                    handleUpdate={(value) => {
+                      handleSubmit('note', value);
+                    }}
+                    value={note}
+                  />
+                </td>
+              </tr>
+              <tr className={`${style.noteRow}`}>
+                <td>{data?.user0}</td>
+                <td>
+                  <EditableCell
+                    handleUpdate={(value) => {
+                      handleSubmit('user0', value);
+                    }}
+                    value={user0}
+                  />
+                </td>
+              </tr>
+              <tr className={`${style.noteRow}`}>
+                <td>{data?.user1}</td>
+                <td>
+                  <EditableCell
+                    handleUpdate={(value) => {
+                      handleSubmit('user1', value);
+                    }}
+                    value={user1}
+                  />
+                </td>
+              </tr>
+              <tr className={`${style.noteRow}`}>
+                <td>{data?.user2}</td>
+                <td>
+                  <EditableCell
+                    handleUpdate={(value) => {
+                      handleSubmit('user2', value);
+                    }}
+                    value={user2}
+                  />
+                </td>
+              </tr>
+              <tr className={`${style.noteRow}`}>
+                <td>{data?.user3}</td>
+                <td>
+                  <EditableCell
+                    handleUpdate={(value) => {
+                      handleSubmit('user3', value);
+                    }}
+                    value={user3}
+                  />
+                </td>
+              </tr>
+              <tr className={`${style.noteRow}`}>
+                <td>{data?.user4}</td>
+                <td>
+                  <EditableCell
+                    handleUpdate={(value) => {
+                      handleSubmit('user4', value);
+                    }}
+                    value={user4}
+                  />
+                </td>
+              </tr>
+              <tr className={`${style.noteRow}`}>
+                <td>{data?.user5}</td>
+                <td>
+                  <EditableCell
+                    handleUpdate={(value) => {
+                      handleSubmit('user5', value);
+                    }}
+                    value={user5}
+                  />
+                </td>
+              </tr>
+              <tr className={`${style.noteRow}`}>
+                <td>{data?.user6}</td>
+                <td>
+                  <EditableCell
+                    handleUpdate={(value) => {
+                      handleSubmit('user6', value);
+                    }}
+                    value={user6}
+                  />
+                </td>
+              </tr>
+              <tr className={`${style.noteRow}`}>
+                <td>{data?.user7}</td>
+                <td>
+                  <EditableCell
+                    handleUpdate={(value) => {
+                      handleSubmit('user7', value);
+                    }}
+                    value={user7}
+                  />
+                </td>
+              </tr>
+              <tr className={`${style.noteRow}`}>
+                <td>{data?.user8}</td>
+                <td>
+                  <EditableCell
+                    handleUpdate={(value) => {
+                      handleSubmit('user8', value);
+                    }}
+                    value={user8}
+                  />
+                </td>
+              </tr>
+              <tr className={`${style.noteRow}`}>
+                <td>{data?.user9}</td>
+                <td>
+                  <EditableCell
+                    handleUpdate={(value) => {
+                      handleSubmit('user9', value);
+                    }}
+                    value={user9}
+                  />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       )}{' '}
       <div className={style.eventActions}>{children}</div>
     </div>

--- a/apps/client/src/features/event-editor/composite/EventEditorDataRight.tsx
+++ b/apps/client/src/features/event-editor/composite/EventEditorDataRight.tsx
@@ -1,30 +1,168 @@
 import { memo, PropsWithChildren } from 'react';
 
-import SwatchSelect from '../../../common/components/input/colour-input/SwatchSelect';
+import useUserFields from '../../../common/hooks-query/useUserFields';
+import EditableCell from '../../cuesheet/cuesheet-table-elements/EditableCell';
 import { EditorUpdateFields } from '../EventEditor';
 
-import CountedTextArea from './CountedTextArea';
-
+// import CountedTextArea from './CountedTextArea';
 import style from '../EventEditor.module.scss';
 
 interface EventEditorRightProps {
   note: string;
-  colour: string;
+  user0: string;
+  user1: string;
+  user2: string;
+  user3: string;
+  user4: string;
+  user5: string;
+  user6: string;
+  user7: string;
+  user8: string;
+  user9: string;
   handleSubmit: (field: EditorUpdateFields, value: string) => void;
 }
 
 const EventEditorDataRight = (props: PropsWithChildren<EventEditorRightProps>) => {
-  const { children, note, colour, handleSubmit } = props;
+  const { children, note, user0, user1, user2, user3, user4, user5, user6, user7, user8, user9, handleSubmit } = props;
+
+  const { data, isFetching } = useUserFields();
 
   return (
     <div className={style.right}>
-      <div className={style.column}>
-        <label className={style.inputLabel}>Colour</label>
-        <div className={style.inline}>
-          <SwatchSelect name='colour' value={colour} handleChange={handleSubmit} />
-        </div>
-      </div>
-      <CountedTextArea field='note' label='Note' initialValue={note} submitHandler={handleSubmit} />
+      {isFetching && !data && 'Loading User Notes'}
+      {data && (
+        <table className={`${style.notes}`}>
+          <thead className={`${style.noteHeader}`}>
+            <tr>
+              <td>User</td>
+              <td>Note</td>
+            </tr>
+          </thead>
+          <tbody>
+            <tr className={`${style.noteRow}`}>
+              <td>All Users</td>
+              <td>
+                <EditableCell
+                  handleUpdate={(value) => {
+                    handleSubmit('note', value);
+                  }}
+                  value={note}
+                />
+              </td>
+            </tr>
+            <tr className={`${style.noteRow}`}>
+              <td>{data?.user0}</td>
+              <td>
+                <EditableCell
+                  handleUpdate={(value) => {
+                    handleSubmit('user0', value);
+                  }}
+                  value={user0}
+                />
+              </td>
+            </tr>
+            <tr className={`${style.noteRow}`}>
+              <td>{data?.user1}</td>
+              <td>
+                <EditableCell
+                  handleUpdate={(value) => {
+                    handleSubmit('user1', value);
+                  }}
+                  value={user1}
+                />
+              </td>
+            </tr>
+            <tr className={`${style.noteRow}`}>
+              <td>{data?.user2}</td>
+              <td>
+                <EditableCell
+                  handleUpdate={(value) => {
+                    handleSubmit('user2', value);
+                  }}
+                  value={user2}
+                />
+              </td>
+            </tr>
+            <tr className={`${style.noteRow}`}>
+              <td>{data?.user3}</td>
+              <td>
+                <EditableCell
+                  handleUpdate={(value) => {
+                    handleSubmit('user3', value);
+                  }}
+                  value={user3}
+                />
+              </td>
+            </tr>
+            <tr className={`${style.noteRow}`}>
+              <td>{data?.user4}</td>
+              <td>
+                <EditableCell
+                  handleUpdate={(value) => {
+                    handleSubmit('user4', value);
+                  }}
+                  value={user4}
+                />
+              </td>
+            </tr>
+            <tr className={`${style.noteRow}`}>
+              <td>{data?.user5}</td>
+              <td>
+                <EditableCell
+                  handleUpdate={(value) => {
+                    handleSubmit('user5', value);
+                  }}
+                  value={user5}
+                />
+              </td>
+            </tr>
+            <tr className={`${style.noteRow}`}>
+              <td>{data?.user6}</td>
+              <td>
+                <EditableCell
+                  handleUpdate={(value) => {
+                    handleSubmit('user6', value);
+                  }}
+                  value={user6}
+                />
+              </td>
+            </tr>
+            <tr className={`${style.noteRow}`}>
+              <td>{data?.user7}</td>
+              <td>
+                <EditableCell
+                  handleUpdate={(value) => {
+                    handleSubmit('user7', value);
+                  }}
+                  value={user7}
+                />
+              </td>
+            </tr>
+            <tr className={`${style.noteRow}`}>
+              <td>{data?.user8}</td>
+              <td>
+                <EditableCell
+                  handleUpdate={(value) => {
+                    handleSubmit('user8', value);
+                  }}
+                  value={user8}
+                />
+              </td>
+            </tr>
+            <tr className={`${style.noteRow}`}>
+              <td>{data?.user9}</td>
+              <td>
+                <EditableCell
+                  handleUpdate={(value) => {
+                    handleSubmit('user9', value);
+                  }}
+                  value={user9}
+                />
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      )}{' '}
       <div className={style.eventActions}>{children}</div>
     </div>
   );

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -52,6 +52,7 @@
     "build:electron": "pnpm prebuild && esbuild src/app.ts --log-level=error --platform=node --format=cjs --bundle --minify --outfile=dist/index.cjs",
     "build:local": "pnpm prebuild && esbuild src/index.ts --log-level=error --platform=node --format=cjs --bundle --minify --outfile=dist/index.cjs",
     "build:docker": "pnpm prebuild && esbuild src/index.ts --log-level=error --platform=node --format=cjs --minify --bundle --outfile=dist/docker.cjs",
+    "build:localdocker": "NODE_ENV=local pnpm prebuild && esbuild src/index.ts --log-level=error --platform=node --format=cjs --minify --bundle --outfile=dist/docker.cjs",
     "build:debug": "pnpm prebuild && esbuild src/app.ts --platform=node --format=cjs --bundle --outfile=dist/index.cjs",
     "lint": "eslint . --quiet",
     "lint-staged": "eslint",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "build": "turbo run build",
     "build:local": "turbo run build:local",
     "build:electron": "turbo run build:electron",
+    "build:docker": "turbo run build:docker",
+    "build:localdocker": "turbo run build:localdocker",
     "dist-win": "turbo run dist-win",
     "dist-mac": "turbo run dist-mac",
     "dist-linux": "turbo run dist-linux",

--- a/turbo.json
+++ b/turbo.json
@@ -26,6 +26,7 @@
     "build:local": {},
     "build:electron": {},
     "build:docker": {},
+    "build:localdocker": {},
     "e2e": {
       "dependsOn": ["^build"]
     },


### PR DESCRIPTION
I needed this for a show I'm working on where we have a lot of cues and a lot of operators with their own notes, adding the cues then going to the cue sheet or op view to add their notes was taking a lot of time. 

I've added the 10 user notes fields as a table with EditableCells in the EventEditorDataRight component and moved the colour picker to EventEditorDataLeft so it wasn't too tall.

![image](https://github.com/cpvalente/ontime/assets/16844830/e6733cca-54a9-4450-990b-6dfed1d2ad57)

While I do do a fair bit of React I've never really done Typescript and don't fully understand this projects structure yet so I'm absolutely okay with any concerns, complaints, or constructive criticisms related to how I've done it or what exactly it is I've done.