### PR TITLE
refactor: prevent accidental edit in operator view

### DIFF
--- a/apps/client/src/common/components/view-params-editor/constants.ts
+++ b/apps/client/src/common/components/view-params-editor/constants.ts
@@ -381,9 +381,9 @@ export const getOperatorOptions = (userFields: UserFields, timeFormat: TimeForma
       },
     },
     {
-      id: 'preventEdit',
-      title: 'Prevent Edit',
-      description: 'Prevents entering edit mode on scroll',
+      id: 'shouldEdit',
+      title: 'Edit user field',
+      description: 'Allows editing an events user field by long pressing on it. Needs a selected highlighted field',
       type: 'boolean',
       defaultValue: false,
     },

--- a/apps/client/src/common/components/view-params-editor/constants.ts
+++ b/apps/client/src/common/components/view-params-editor/constants.ts
@@ -380,5 +380,12 @@ export const getOperatorOptions = (userFields: UserFields, timeFormat: TimeForma
         user9: userFields.user9 || 'user9',
       },
     },
+    {
+      id: 'preventEdit',
+      title: 'Prevent Edit',
+      description: 'Prevents entering edit mode on scroll',
+      type: 'boolean',
+      defaultValue: false,
+    },
   ];
 };

--- a/apps/client/src/features/operator/Operator.tsx
+++ b/apps/client/src/features/operator/Operator.tsx
@@ -123,9 +123,9 @@ export default function Operator() {
   }
 
   // get fields which the user subscribed to
-  const preventEdit = searchParams.get('preventEdit');
+  const shouldEdit = searchParams.get('shouldEdit');
   const subscribe = searchParams.get('subscribe') as keyof UserFields | null;
-  const canEdit = !preventEdit && subscribe;
+  const canEdit = shouldEdit && subscribe;
 
   const main = searchParams.get('main') as keyof TitleFields | null;
   const secondary = searchParams.get('secondary') as keyof TitleFields | null;

--- a/apps/client/src/features/operator/Operator.tsx
+++ b/apps/client/src/features/operator/Operator.tsx
@@ -123,7 +123,10 @@ export default function Operator() {
   }
 
   // get fields which the user subscribed to
+  const preventEdit = searchParams.get('preventEdit');
   const subscribe = searchParams.get('subscribe') as keyof UserFields | null;
+  const canEdit = !preventEdit && subscribe;
+
   const main = searchParams.get('main') as keyof TitleFields | null;
   const secondary = searchParams.get('secondary') as keyof TitleFields | null;
   const subscribedAlias = subscribe ? userFields[subscribe] : '';
@@ -152,7 +155,7 @@ export default function Operator() {
         lastId={lastEvent?.id}
       />
 
-      {subscribe && (
+      {canEdit && (
         <div className={`${style.editPrompt} ${showEditPrompt ? style.show : undefined}`}>
           Press and hold to edit user field
         </div>
@@ -193,7 +196,7 @@ export default function Operator() {
                 showSeconds={showSeconds}
                 isPast={isPast}
                 selectedRef={isSelected ? selectedRef : undefined}
-                onLongPress={subscribe ? handleEdit : () => undefined}
+                onLongPress={canEdit ? handleEdit : () => undefined}
               />
             );
           }


### PR DESCRIPTION
Adds user option to prevent the operator view from being editable on long press as suggested by @viktorfreiman in #609 