### PR TITLE
feat: add `set-time` endpoint

### DIFF
--- a/apps/client/src/features/event-editor/composite/EventEditorTimes.tsx
+++ b/apps/client/src/features/event-editor/composite/EventEditorTimes.tsx
@@ -118,6 +118,7 @@ const EventEditorTimes = (props: EventEditorTimesProps) => {
           <option value={TimerType.CountUp}>Count up</option>
           <option value={TimerType.TimeToEnd}>Time to end</option>
           <option value={TimerType.Clock}>Clock</option>
+          <option value={TimerType.External}>External</option>
         </Select>
         <label className={style.inputLabel}>End Action</label>
         <Select

--- a/apps/client/src/features/event-editor/composite/EventEditorTimes.tsx
+++ b/apps/client/src/features/event-editor/composite/EventEditorTimes.tsx
@@ -28,7 +28,6 @@ const EventEditorTimes = (props: EventEditorTimesProps) => {
   const { eventId, timeStart, timeEnd, duration, delay, isPublic, endAction, timerType } = props;
   const { updateEvent } = useEventAction();
 
-
   const handleSubmit = (field: TimeActions, value: number | string | boolean) => {
     const newEventData: Partial<OntimeEvent> = { id: eventId };
     switch (field) {
@@ -113,12 +112,12 @@ const EventEditorTimes = (props: EventEditorTimesProps) => {
           value={timerType}
           onChange={(event) => handleSubmit('timerType', event.target.value)}
           variant='ontime'
+          isDisabled={timerType === TimerType.External}
         >
           <option value={TimerType.CountDown}>Count down</option>
           <option value={TimerType.CountUp}>Count up</option>
           <option value={TimerType.TimeToEnd}>Time to end</option>
           <option value={TimerType.Clock}>Clock</option>
-          <option value={TimerType.External}>External</option>
         </Select>
         <label className={style.inputLabel}>End Action</label>
         <Select
@@ -137,6 +136,16 @@ const EventEditorTimes = (props: EventEditorTimesProps) => {
         <label className={`${style.inputLabel} ${style.publicToggle}`}>
           <Switch isChecked={isPublic} onChange={() => handleSubmit('isPublic', isPublic)} variant='ontime' />
           Event is public
+        </label>
+        <label className={`${style.inputLabel} ${style.publicToggle}`}>
+          <Switch
+            isChecked={timerType === TimerType.External}
+            onChange={(event) =>
+              handleSubmit('timerType', event.target.checked ? TimerType.External : TimerType.CountDown)
+            }
+            variant='ontime'
+          />
+          Source: External
         </label>
       </div>
     </div>

--- a/apps/client/src/features/rundown/event-block/EventBlockInner.tsx
+++ b/apps/client/src/features/rundown/event-block/EventBlockInner.tsx
@@ -10,6 +10,7 @@ import { IoPlayForward } from '@react-icons/all-files/io5/IoPlayForward';
 import { IoPlaySkipForward } from '@react-icons/all-files/io5/IoPlaySkipForward';
 import { IoStop } from '@react-icons/all-files/io5/IoStop';
 import { IoTime } from '@react-icons/all-files/io5/IoTime';
+import { MdInput } from '@react-icons/all-files/md/MdInput';
 import { EndAction, Playback, TimerType } from 'ontime-types';
 import { millisToString } from 'ontime-utils';
 
@@ -242,6 +243,9 @@ function TimerIcon(props: { type: TimerType; className: string }) {
   }
   if (type === TimerType.TimeToEnd) {
     return <BiArrowToBottom className={className} />;
+  }
+  if (type === TimerType.External) {
+    return <MdInput className={className} />;
   }
   return <IoArrowDown className={className} />;
 }

--- a/apps/server/src/adapters/OscAdapter.ts
+++ b/apps/server/src/adapters/OscAdapter.ts
@@ -39,7 +39,7 @@ export class OscServer implements IAdapter {
       let transformedPayload: unknown = args;
       // we need to transform the params for the change endpoint
       // OSC: ontime/change/{eventID}/{propertyName} value
-      if (path === 'change') {
+      if (path === 'change' || path === 'set-time') {
         if (params.length < 2) {
           logger.error(LogOrigin.Rx, 'OSC IN: No params provided for change');
           return;

--- a/apps/server/src/controllers/integrationController.ts
+++ b/apps/server/src/controllers/integrationController.ts
@@ -285,19 +285,18 @@ export function dispatchFromAdapter(
       const currentEvent = eventStore.get('eventNow');
       const playback = eventStore.get('playback');
       //TODO: what if in roll mode?
-      console.log(eventId, property, value);
       if (!currentEvent || currentEvent.id !== eventId || playback !== Playback.Play) {
         const success = PlaybackService.startById(eventId);
-        if (success) {
-          eventTimer.setTime(amout * mts);
+        if (!success) {
+          throw new Error(`Unable to start event: ${eventId}`);
         }
-      } else {
-        if (property === 'elapsed') {
-          const duration = currentEvent.duration;
-          eventTimer.setTime(duration - amout * mts);
-        } else if (property === 'remaining') {
-          eventTimer.setTime(amout * mts);
-        }
+      }
+
+      if (property === 'elapsed') {
+        const duration = currentEvent.duration;
+        eventTimer.setTime(duration - amout * mts);
+      } else if (property === 'remaining') {
+        eventTimer.setTime(amout * mts);
       }
       break;
     }

--- a/apps/server/src/services/TimerService.ts
+++ b/apps/server/src/services/TimerService.ts
@@ -309,6 +309,17 @@ export class TimerService {
   }
 
   /**
+   * @description
+   * @param {number} amount
+   */
+  setTime(amount: number) {
+    if (!this.loadedTimerId) {
+      return;
+    }
+    this.timer.current = amount;
+    this.update();
+  }
+  /**
    * Adds time to running timer by given amount
    * @param {number} amount
    */
@@ -385,6 +396,9 @@ export class TimerService {
         this.loadedTimerEnd,
         this.timer.timerType,
       );
+    }
+    if (this.timer.timerType === TimerType.External) {
+      return;
     }
     this.timer.current = getCurrent(
       this.timer.startedAt,

--- a/packages/types/src/definitions/TimerType.type.ts
+++ b/packages/types/src/definitions/TimerType.type.ts
@@ -3,4 +3,5 @@ export enum TimerType {
   CountUp = 'count-up',
   TimeToEnd = 'time-to-end',
   Clock = 'clock',
+  External = 'external',
 }


### PR DESCRIPTION
osc: `/ontime/set-time/<eventId>/[remaining,elapsed] <time in seconds>`
ws: `{"type": "set-time", "payload": {"eventId" : <eventId>, "property": "[remaining,elapsed]", "value": <time in seconds>}}`
![image](https://github.com/cpvalente/ontime/assets/19875125/059df88c-bcf6-4035-9a92-e5fb12b298a0)
![image](https://github.com/cpvalente/ontime/assets/19875125/6af91c22-5e1b-47a2-826e-fe2f8e704efa)

notes:
https://github.com/cpvalente/ontime/issues/334#issuecomment-1877468901
https://github.com/cpvalente/ontime/issues/334#issuecomment-1877686988
#318 #115 