### PR TITLE
refactor: allow import of blocks and skip import

### DIFF
--- a/apps/client/src/features/modals/upload-modal/preview/PreviewRundown.tsx
+++ b/apps/client/src/features/modals/upload-modal/preview/PreviewRundown.tsx
@@ -1,5 +1,5 @@
 import { Fragment } from 'react';
-import { isOntimeEvent, OntimeRundown, UserFields } from 'ontime-types';
+import { isOntimeBlock, isOntimeEvent, OntimeRundown, UserFields } from 'ontime-types';
 import { millisToString } from 'ontime-utils';
 
 import { getAccessibleColour } from '../../../../common/utils/styleUtils';
@@ -18,6 +18,8 @@ function booleanToText(value?: boolean) {
 }
 
 export default function PreviewRundown({ rundown, userFields }: PreviewRundownProps) {
+  // we only count Ontime Events which are 1 based in client
+  let eventIndex = 0;
   return (
     <div className={style.container}>
       <table className={style.rundownPreview}>
@@ -72,22 +74,36 @@ export default function PreviewRundown({ rundown, userFields }: PreviewRundownPr
           </tr>
         </thead>
         <tbody className={style.body}>
-          {rundown.map((event, index) => {
+          {rundown.map((event) => {
+            if (isOntimeBlock(event)) {
+              return (
+                <tr key={event.id}>
+                  <td className={style.center}>
+                    <Tag>-</Tag>
+                  </td>
+                  <td className={style.center}>
+                    <Tag>{event.type}</Tag>
+                  </td>
+                  <td />
+                  <td colSpan={99}>{event.title}</td>
+                </tr>
+              );
+            }
             if (!isOntimeEvent(event)) {
               return null;
             }
-            const key = event.id;
+            eventIndex += 1;
             const colour = event.colour ? getAccessibleColour(event.colour) : {};
             const isPublic = booleanToText(event.isPublic);
             const skip = booleanToText(event.skip);
             return (
-              <Fragment key={key}>
+              <Fragment key={event.id}>
                 <tr>
                   <td className={style.center}>
-                    <Tag>{index + 1}</Tag>
+                    <Tag>{eventIndex}</Tag>
                   </td>
                   <td className={style.center}>
-                    <Tag>Event</Tag>
+                    <Tag>{event.type}</Tag>
                   </td>
                   <td className={style.nowrap}>{event.cue}</td>
                   <td>{event.title}</td>

--- a/apps/client/src/features/modals/upload-modal/preview/Tag.module.scss
+++ b/apps/client/src/features/modals/upload-modal/preview/Tag.module.scss
@@ -6,4 +6,6 @@
   border-radius: 2px;
   padding: 0 0.25rem;
   white-space: nowrap;
+
+  text-transform: capitalize;
 }

--- a/apps/server/src/utils/parser.ts
+++ b/apps/server/src/utils/parser.ts
@@ -38,6 +38,7 @@ import {
 import { parseExcelDate } from './time.js';
 import { configService } from '../services/ConfigService.js';
 import { coerceBoolean } from './coerceType.js';
+import { isKnownTimerType } from '../../../../packages/utils/src/validate-events/validateEvent.js';
 
 export const EXCEL_MIME = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
 export const JSON_MIME = 'application/json';
@@ -112,7 +113,6 @@ export const parseExcel = (excelData: unknown[][], options?: Partial<ExcelImport
       return;
     }
 
-    const event: Partial<OntimeEvent> = {};
     const handlers = {
       [importMap.timeStart]: (row: number, col: number) => {
         timeStartIndex = col;
@@ -219,16 +219,31 @@ export const parseExcel = (excelData: unknown[][], options?: Partial<ExcelImport
       },
     } as const;
 
+    const event: any = {};
     row.forEach((column, j) => {
       // 1. we check if we have set a flag for a known field
-      if (j === timeStartIndex) {
+      if (j === timerTypeIndex) {
+        if (column === 'block') {
+          event.type = SupportedEvent.Block;
+        }
+        if (isKnownTimerType(column)) {
+          event.type = SupportedEvent.Event;
+          event.timerType = validateTimerType(column);
+        }
+        // if it is not a block or a known type, we dont import it
+        return;
+      } else if (j === titleIndex) {
+        event.title = makeString(column, '');
+        // if this is a block, we have nothing else to import
+        if (event.type === SupportedEvent.Block) {
+          return;
+        }
+      } else if (j === timeStartIndex) {
         event.timeStart = parseExcelDate(column);
       } else if (j === timeEndIndex) {
         event.timeEnd = parseExcelDate(column);
       } else if (j === durationIndex) {
         event.duration = parseExcelDate(column);
-      } else if (j === titleIndex) {
-        event.title = makeString(column, '');
       } else if (j === cueIndex) {
         event.cue = makeString(column, '');
       } else if (j === presenterIndex) {
@@ -243,8 +258,6 @@ export const parseExcel = (excelData: unknown[][], options?: Partial<ExcelImport
         event.note = makeString(column, '');
       } else if (j === endActionIndex) {
         event.endAction = validateEndAction(column);
-      } else if (j === timerTypeIndex) {
-        event.timerType = validateTimerType(column);
       } else if (j === timeWarningIndex) {
         event.timeWarning = parseExcelDate(column);
       } else if (j === timeDangerIndex) {
@@ -287,7 +300,7 @@ export const parseExcel = (excelData: unknown[][], options?: Partial<ExcelImport
 
     if (Object.keys(event).length > 0) {
       // if any data was found, push to array
-      rundown.push({ ...event, type: SupportedEvent.Event } as OntimeEvent);
+      rundown.push({ ...event });
     }
   });
 
@@ -430,8 +443,6 @@ export const fileHandler = async (file: string, options: ExcelImportOptions): Pr
   }
 
   if (file.endsWith('.json')) {
-    console.log('JSON!');
-
     const rawdata = fs.readFileSync(file).toString();
     let uploadedJson = null;
 
@@ -441,5 +452,4 @@ export const fileHandler = async (file: string, options: ExcelImportOptions): Pr
     await configService.updateDatabaseConfig(fileName);
     return res;
   }
-  console.log('NOTHIGN');
 };

--- a/apps/server/src/utils/parser.ts
+++ b/apps/server/src/utils/parser.ts
@@ -226,7 +226,7 @@ export const parseExcel = (excelData: unknown[][], options?: Partial<ExcelImport
         if (column === 'block') {
           event.type = SupportedEvent.Block;
         }
-        if (isKnownTimerType(column)) {
+        if (column === '' || isKnownTimerType(column)) {
           event.type = SupportedEvent.Event;
           event.timerType = validateTimerType(column);
         }

--- a/apps/server/src/utils/sheetUtils.ts
+++ b/apps/server/src/utils/sheetUtils.ts
@@ -1,6 +1,6 @@
 import { sheets_v4 } from '@googleapis/sheets';
 import { millisToString } from 'ontime-utils';
-import { OntimeRundownEntry, isOntimeEvent } from 'ontime-types';
+import { OntimeRundownEntry, isOntimeBlock, isOntimeEvent } from 'ontime-types';
 
 /**
  *
@@ -80,6 +80,18 @@ export function cellRequestFromEvent(
       } else if (typeof event[key] === 'boolean') {
         returnRows.push({
           userEnteredValue: { stringValue: event[key] ? 'x' : '' },
+        });
+      } else {
+        returnRows.push({});
+      }
+    } else if (isOntimeBlock(event)) {
+      if (key === 'title') {
+        returnRows.push({
+          userEnteredValue: { stringValue: event[key] },
+        });
+      } else if (key === 'timerType') {
+        returnRows.push({
+          userEnteredValue: { stringValue: 'block' },
         });
       } else {
         returnRows.push({});

--- a/packages/utils/src/validate-events/validateEvent.ts
+++ b/packages/utils/src/validate-events/validateEvent.ts
@@ -20,6 +20,10 @@ export function validateTimerType(maybeTimerType: unknown, fallback = TimerType.
   return Object.values(TimerType).includes(maybeTimerType as TimerType) ? (maybeTimerType as TimerType) : fallback;
 }
 
+export function isKnownTimerType(maybeTimerType: unknown) {
+  return Object.values(TimerType).includes(maybeTimerType as TimerType);
+}
+
 /**
  * @description calculates event duration considering midnight
  * @param {number} timeStart


### PR DESCRIPTION
Allows importing blocks from spreadsheets, it will also skip the import of rows which contain a timer type we dont know