### PR TITLE
time to end

### DIFF
--- a/apps/server/src/state.ts
+++ b/apps/server/src/state.ts
@@ -393,6 +393,10 @@ export const stateMutations = {
             const result = play();
             _shouldNotify = true;
             _isFinished = result.isFinished;
+          } else if (state.eventNow?.timerType === TimerType.TimeToEnd) {
+            // or if we are in a time-to-end timer
+            state.timer.current = getCurrent(state);
+            state.timer.duration = state.timer.current;
           }
 
           // we only update the store at the updateInterval


### PR DESCRIPTION
this PR makes it so that an event marked as `Time-To-End` will always update as long as it is loaded