### PR TITLE
Project Manager: Export

### DIFF
--- a/apps/client/src/common/api/ontimeApi.ts
+++ b/apps/client/src/common/api/ontimeApi.ts
@@ -143,15 +143,19 @@ export async function postOscSubscriptions(data: OscSubscription) {
 /**
  * @description HTTP request to download db in CSV format
  */
-export const downloadCSV = () => {
-  return fileDownload(ontimeURL, { name: 'rundown', type: 'csv' }, { type: 'text/csv;charset=utf-8;' });
+export const downloadCSV = (fileName?: string) => {
+  return fileDownload(ontimeURL, { name: fileName ?? 'rundown', type: 'csv' }, { type: 'text/csv;charset=utf-8;' });
 };
 
 /**
  * @description HTTP request to download db in JSON format
  */
-export const downloadRundown = () => {
-  return fileDownload(ontimeURL, { name: 'rundown', type: 'json' }, { type: 'application/json;charset=utf-8;' });
+export const downloadRundown = (fileName?: string) => {
+  return fileDownload(
+    ontimeURL,
+    { name: fileName ?? 'rundown', type: 'json' },
+    { type: 'application/json;charset=utf-8;' },
+  );
 };
 
 // TODO: should this be extracted to shared code?

--- a/apps/client/src/features/app-settings/panel/project-panel/ProjectListItem.tsx
+++ b/apps/client/src/features/app-settings/panel/project-panel/ProjectListItem.tsx
@@ -3,7 +3,14 @@ import { IconButton, Menu, MenuButton, MenuItem, MenuList } from '@chakra-ui/rea
 import { IoEllipsisHorizontal } from '@react-icons/all-files/io5/IoEllipsisHorizontal';
 
 import { invalidateAllCaches, maybeAxiosError } from '../../../../common/api/apiUtils';
-import { deleteProject, duplicateProject, loadProject, renameProject } from '../../../../common/api/ontimeApi';
+import {
+  deleteProject,
+  downloadCSV,
+  downloadRundown,
+  duplicateProject,
+  loadProject,
+  renameProject,
+} from '../../../../common/api/ontimeApi';
 
 import ProjectForm, { ProjectFormValues } from './ProjectForm';
 
@@ -139,6 +146,14 @@ function ActionMenu({
     await onRefetch();
   };
 
+  const handleDownload = async () => {
+    await downloadRundown(filename);
+  };
+
+  const handleExportCSV = async () => {
+    await downloadCSV(filename);
+  };
+
   return (
     <Menu variant='ontime-on-dark' size='sm'>
       <MenuButton
@@ -154,6 +169,8 @@ function ActionMenu({
         </MenuItem>
         <MenuItem onClick={handleRename}>Rename</MenuItem>
         <MenuItem onClick={handleDuplicate}>Duplicate</MenuItem>
+        <MenuItem onClick={handleDownload}>Download</MenuItem>
+        {current && <MenuItem onClick={handleExportCSV}>Export CSV Rundown</MenuItem>}
         <MenuItem isDisabled={current} onClick={handleDelete}>
           Delete
         </MenuItem>


### PR DESCRIPTION
This includes three changes:

1. Add "Download" button to the ProjectItem overflow menu.
This allows users to download the json project file for any element. 

2. Add "Export CSV Rundown" button to the currently loaded project item overflow menu.
Allowed for the currently selected item.

3. In both cases the file name is the name the user sees eg. Project 1.json or Project 1.csv