### PR TITLE
wip: floating menu

### DIFF
--- a/apps/client/src/features/editors/Editor.tsx
+++ b/apps/client/src/features/editors/Editor.tsx
@@ -4,6 +4,7 @@ import { useDisclosure } from '@chakra-ui/react';
 import ErrorBoundary from '../../common/components/error-boundary/ErrorBoundary';
 import AppSettings from '../app-settings/AppSettings';
 import { SettingsOptionId, useSettingsStore } from '../app-settings/settingsStore';
+import FloatingMenu from '../floating-menu/FloatingMenu';
 import MenuBar from '../menu/MenuBar';
 import QuickStart from '../modals/quick-start/QuickStart';
 import SheetsModal from '../modals/sheets-modal/SheetsModal';
@@ -45,6 +46,7 @@ export default function Editor() {
 
   return (
     <>
+      <FloatingMenu />
       <ErrorBoundary>
         <QuickStart onClose={onQuickStartClose} isOpen={isQuickStartOpen} />
         <UploadModal onClose={onUploadModalClose} isOpen={isUploadModalOpen} />

--- a/apps/client/src/features/floating-menu/FloatingMenu.module.scss
+++ b/apps/client/src/features/floating-menu/FloatingMenu.module.scss
@@ -1,0 +1,16 @@
+.floating {
+    position: fixed;
+    bottom: 0.5rem;
+    left: 50%;
+    transform: translate(-50%, 0%);
+    z-index: 1000;
+
+    border-radius: 99px;
+    display: flex;
+    gap: 0.5rem;
+
+    background-color: $gray-1350;
+    border: 1px solid $white-10;
+    box-shadow: $box-shadow-l2;
+    padding: 0 1em;
+}

--- a/apps/client/src/features/floating-menu/FloatingMenu.tsx
+++ b/apps/client/src/features/floating-menu/FloatingMenu.tsx
@@ -1,0 +1,48 @@
+import { ButtonGroup } from '@chakra-ui/react';
+import { IoSettingsOutline } from '@react-icons/all-files/io5/IoSettingsOutline';
+
+import TooltipActionBtn from '../../common/components/buttons/TooltipActionBtn';
+
+import style from './FloatingMenu.module.scss';
+
+const buttonStyle = {
+  fontSize: '1.25em',
+  size: 'md',
+  colorScheme: 'white',
+  _hover: {
+    background: 'rgba(255, 255, 255, 0.10)', // $white-10
+  },
+  _active: {
+    background: 'rgba(255, 255, 255, 0.13)', // $white-13
+  },
+};
+
+export default function FloatingMenu() {
+  return (
+    <div className={style.floating}>
+      <ButtonGroup isAttached>
+        <TooltipActionBtn
+          clickHandler={() => undefined}
+          {...buttonStyle}
+          icon={<IoSettingsOutline />}
+          tooltip='About'
+          aria-label='About'
+        />
+        <TooltipActionBtn
+          clickHandler={() => undefined}
+          {...buttonStyle}
+          icon={<IoSettingsOutline />}
+          tooltip='About'
+          aria-label='About'
+        />
+        <TooltipActionBtn
+          clickHandler={() => undefined}
+          {...buttonStyle}
+          icon={<IoSettingsOutline />}
+          tooltip='About'
+          aria-label='About'
+        />
+      </ButtonGroup>
+    </div>
+  );
+}


### PR DESCRIPTION
Experimenting with an idea to remove the menu bar on the left and add a floating menu instead
this floating menu will contain

This is because the menu will have significantly fewer items, and I wonder if we can justify the space.
The items left are

Settings
Shutdown
About?

<img width="1506" alt="Screenshot 2024-02-09 at 11 31 03" src="https://github.com/cpvalente/ontime/assets/34649812/175c913e-3046-4a91-a514-d99bc4e48644">

I thought we could make it so that the menu hides itself partially, so it gets out of the way for the most part. But I wonder if this would make it hard for users to figure out how to use the app
