### PR TITLE
refactor: obfuscate pincode in transit

### DIFF
--- a/apps/client/src/common/context/AppContext.tsx
+++ b/apps/client/src/common/context/AppContext.tsx
@@ -26,7 +26,6 @@ export const AppContextProvider = ({ children }: PropsWithChildren) => {
 
   useEffect(() => {
     if (status === 'pending') return;
-    if (!data) return;
     const previousEditor = sessionStorage.getItem(storageKeys.editor);
 
     if (previousEditor && previousEditor === data.editorKey) {
@@ -51,10 +50,6 @@ export const AppContextProvider = ({ children }: PropsWithChildren) => {
     (pin: string, permission: 'editor' | 'operator'): boolean => {
       function isValid(pin: string, savedPin?: string | null): boolean {
         return savedPin == null || savedPin === '' || pin === savedPin;
-      }
-
-      if (!data) {
-        return false;
       }
 
       if (permission === 'editor') {

--- a/apps/client/src/common/hooks-query/useSettings.ts
+++ b/apps/client/src/common/hooks-query/useSettings.ts
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+import { unobfuscate } from 'ontime-utils';
 
 import { queryRefetchIntervalSlow } from '../../ontimeConfig';
 import { APP_SETTINGS } from '../api/constants';
@@ -14,7 +15,17 @@ export default function useSettings() {
     retryDelay: (attempt) => attempt * 2500,
     refetchInterval: queryRefetchIntervalSlow,
     networkMode: 'always',
+    select: (data) => {
+      const unobfuscated = { ...data };
+      if (data.editorKey) {
+        unobfuscated.editorKey = unobfuscate(data.editorKey);
+      }
+      if (data.operatorKey) {
+        unobfuscated.operatorKey = unobfuscate(data.operatorKey);
+      }
+      return unobfuscated;
+    },
   });
 
-  return { data, status, isFetching, isError, refetch };
+  return { data: data ?? ontimePlaceholderSettings, status, isFetching, isError, refetch };
 }

--- a/apps/server/src/api-data/settings/settings.controller.ts
+++ b/apps/server/src/api-data/settings/settings.controller.ts
@@ -6,10 +6,20 @@ import { DataProvider } from '../../classes/data-provider/DataProvider.js';
 import { failEmptyObjects } from '../../utils/routerUtils.js';
 import { extractPin } from '../../services/project-service/ProjectService.js';
 import { isDocker } from '../../setup/index.js';
+import { obfuscate } from 'ontime-utils';
 
 export async function getSettings(_req: Request, res: Response<Settings>) {
   const settings = DataProvider.getSettings();
-  res.status(200).send(settings);
+  const obfuscatedSettings = { ...settings };
+  if (settings.editorKey) {
+    obfuscatedSettings.editorKey = obfuscate(settings.editorKey);
+  }
+
+  if (settings.operatorKey) {
+    obfuscatedSettings.editorKey = obfuscate(settings.editorKey);
+  }
+
+  res.status(200).send(obfuscatedSettings);
 }
 
 export async function postSettings(req: Request, res: Response<Settings | ErrorResponse>) {

--- a/apps/server/src/classes/data-provider/DataProvider.ts
+++ b/apps/server/src/classes/data-provider/DataProvider.ts
@@ -48,7 +48,7 @@ export class DataProvider {
     await this.persist();
   }
 
-  static getSettings(): Settings {
+  static getSettings(): Readonly<Settings> {
     return data.settings;
   }
 

--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -56,6 +56,7 @@ export { deleteAtIndex, insertAtIndex, reorderArray, sortArrayByProperty } from 
 
 // generic utilities
 export { unpackError } from './src/generic/generic.js';
+export { obfuscate, unobfuscate } from './src/generic/generic.js';
 export { isNumeric } from './src/types/types.js';
 
 // model validation

--- a/packages/utils/src/generic/__tests__/generic.test.ts
+++ b/packages/utils/src/generic/__tests__/generic.test.ts
@@ -1,0 +1,18 @@
+import { obfuscate, unobfuscate } from '../generic.js';
+
+describe('obfuscate and unobfuscate', () => {
+  it('should return the obfuscated string', () => {
+    const str = 'abc123';
+    const obfuscated = obfuscate(str);
+    expect(obfuscated).not.toBe(str);
+    expect(obfuscated.startsWith('_')).toBe(true);
+  });
+
+  it('should return the original string after obfuscating and unobfuscating', () => {
+    const str = 'abc123';
+    const obfuscated = obfuscate(str);
+    const unobfuscated = unobfuscate(obfuscated);
+    expect(unobfuscated).toBe(str);
+    expect(unobfuscated.startsWith('_')).toBe(false);
+  });
+});

--- a/packages/utils/src/generic/generic.ts
+++ b/packages/utils/src/generic/generic.ts
@@ -4,3 +4,39 @@ export function unpackError(error: unknown): string {
   }
   return String(error);
 }
+
+/**
+ * Obfuscate a string
+ * Uses a variation of ROT13 that handles numeric values
+ * @param str
+ * @returns
+ */
+export function obfuscate(str: string): string {
+  const obfuscated = str.replace(/[a-zA-Z0-9]/g, (c) => {
+    if (/[a-zA-Z]/.test(c)) {
+      // @ts-expect-error -- we use some javascript magic here
+      return String.fromCharCode((c <= 'Z' ? 90 : 122) >= (c = c.charCodeAt(0) + 13) ? c : c - 26);
+    } else {
+      // @ts-expect-error -- we use some javascript magic here
+
+      return String.fromCharCode((c <= '4' ? 57 : 48) >= (c = c.charCodeAt(0) + 5) ? c : c - 10);
+    }
+  });
+  if (str.startsWith('_')) {
+    return obfuscated.replace('_', '');
+  }
+  return `_${obfuscated}`;
+}
+
+/**
+ * Unobfoscate a string
+ * Uses a variation of ROT13 that handles numeric values
+ * @param str
+ * @returns
+ */
+export function unobfuscate(str: string): string {
+  if (str.startsWith('_')) {
+    return obfuscate(str);
+  }
+  return str;
+}


### PR DESCRIPTION
Adding some simple code to obfuscate the pincodes while in transit

any user who is capable of inspecting the network tab will also easily circumvent this. But it I guess it is a micro 
improvement and harmless (and a little fun to investigate)
Closes #755 

@alex-Arc do you think the pincode workflow needs improvements? I was a bit annoyed with having to type it everytime I refreshed the page