### PR TITLE
refactor: skip expected end if not playing

### DIFF
--- a/apps/server/src/stores/runtimeState.ts
+++ b/apps/server/src/stores/runtimeState.ts
@@ -115,7 +115,7 @@ export function updateRundownData(playableRundown: OntimeEvent[]) {
 
   runtimeState.runtime.plannedStart = firstEvent?.timeStart ?? null;
   runtimeState.runtime.plannedEnd = lastEvent?.timeEnd ?? null;
-  if (runtimeState.runtime.plannedEnd === null) {
+  if (runtimeState.runtime.plannedEnd === null || !runtimeState.runtime.actualStart) {
     runtimeState.runtime.expectedEnd = null;
   } else {
     runtimeState.runtime.expectedEnd = (runtimeState.runtime.plannedEnd + runtimeState.runtime.offset) % dayInMs;


### PR DESCRIPTION
testing ideas to let the end times overflow, that way we could tell the clients that an event end is the day after

however this means traversing through the rundown to find how many times we go over midnight