### PR TITLE
Fix to `lastLoadedProject` being null

### DIFF
--- a/apps/server/src/setup/index.ts
+++ b/apps/server/src/setup/index.ts
@@ -86,6 +86,9 @@ export const uploadsFolderPath = join(getAppDataPath(), config.uploads);
 const getLastLoadedProject = () => {
   try {
     const appState = JSON.parse(fs.readFileSync(appStatePath, 'utf8'));
+    if (!appState.lastLoadedProject) {
+      throw new Error('No last loaded project');
+    }
     return appState.lastLoadedProject;
   } catch {
     if (!isTest) {

--- a/apps/server/src/setup/index.ts
+++ b/apps/server/src/setup/index.ts
@@ -83,17 +83,21 @@ export const resolveExternalsDirectory = join(isProduction ? getAppDataPath() : 
 export const appStatePath = join(getAppDataPath(), config.appState);
 export const uploadsFolderPath = join(getAppDataPath(), config.uploads);
 
+const ensureAppState = () => {
+  ensureDirectory(getAppDataPath());
+  fs.writeFileSync(appStatePath, JSON.stringify({ lastLoadedProject: 'db.json' }));
+};
+
 const getLastLoadedProject = () => {
   try {
     const appState = JSON.parse(fs.readFileSync(appStatePath, 'utf8'));
     if (!appState.lastLoadedProject) {
-      throw new Error('No last loaded project');
+      ensureAppState();
     }
     return appState.lastLoadedProject;
   } catch {
     if (!isTest) {
-      ensureDirectory(getAppDataPath());
-      fs.writeFileSync(appStatePath, JSON.stringify({ lastLoadedProject: 'db.json' }));
+      ensureAppState();
     }
   }
 };


### PR DESCRIPTION
by throwing an exception there we ensure the code inside the `catch` block runs, which will then create and assign a `lastLoadedProject`