### PR TITLE
Fix to cuesheet table header not resizing

### DIFF
--- a/apps/client/src/features/cuesheet/cuesheet-table-elements/CuesheetHeader.tsx
+++ b/apps/client/src/features/cuesheet/cuesheet-table-elements/CuesheetHeader.tsx
@@ -1,3 +1,4 @@
+import { memo, useEffect } from 'react';
 import { Tooltip } from '@chakra-ui/react';
 import {
   closestCenter,
@@ -29,6 +30,12 @@ interface CuesheetHeaderProps {
 function CuesheetHeader(props: CuesheetHeaderProps) {
   const { headerGroups } = props;
   const [columnOrder, saveColumnOrder] = useLocalStorage<string[]>('table-order', initialColumnOrder);
+
+  useEffect(() => {
+    if (!localStorage.getItem('table-order')) {
+      saveColumnOrder(initialColumnOrder);
+    }
+  }, [saveColumnOrder]);
 
   const handleOnDragEnd = (event: DragEndEvent) => {
     const { delta, active, over } = event;
@@ -113,4 +120,4 @@ function CuesheetHeader(props: CuesheetHeaderProps) {
   );
 }
 
-export default CuesheetHeader;
+export default memo(CuesheetHeader);

--- a/apps/client/src/features/cuesheet/cuesheet-table-elements/CuesheetHeader.tsx
+++ b/apps/client/src/features/cuesheet/cuesheet-table-elements/CuesheetHeader.tsx
@@ -1,4 +1,3 @@
-import { memo } from 'react';
 import { Tooltip } from '@chakra-ui/react';
 import {
   closestCenter,
@@ -114,4 +113,4 @@ function CuesheetHeader(props: CuesheetHeaderProps) {
   );
 }
 
-export default memo(CuesheetHeader);
+export default CuesheetHeader;


### PR DESCRIPTION
Problem is we're memoizing the component, and `headerGroups` prop doesn't have the actual sizes, it is hidden behind a getter.

This means React won't think of it as an actual prop change. If we still want to memoize the component, we could pass the header sizes as a prop separately