### PR TITLE
Fix/missing return values from rundownCache edit

### DIFF
--- a/apps/server/src/services/rundown-service/rundownCache.ts
+++ b/apps/server/src/services/rundown-service/rundownCache.ts
@@ -304,7 +304,7 @@ export function edit({ persistedRundown, eventId, patch }: EditArgs): Required<M
   const eventInMemory = persistedRundown[indexAt];
   if (!hasChanges(eventInMemory, patch)) {
     isStale = false;
-    return;
+    return { newRundown: persistedRundown, newEvent: undefined };
   }
 
   const newEvent = makeEvent(eventInMemory, patch);


### PR DESCRIPTION
found by using the change api 
if I try to change somthing to a value it already has 
eg. change {cue: 'test'} to {cue: 'test'}

the edit function would short circuit and return undefined but RundownService editEvent relies on a deconstruction to newEvent
https://github.com/cpvalente/ontime/blob/01000f8837538dd84de2ef60711008198c4c504b/apps/server/src/services/rundown-service/rundownCache.ts#L305-L308

https://github.com/cpvalente/ontime/blob/01000f8837538dd84de2ef60711008198c4c504b/apps/server/src/services/rundown-service/RundownService.ts#L118