### PR TITLE
fix: Sheet import

### DIFF
--- a/apps/client/src/features/app-settings/panel/sources-panel/GSheetSetup.tsx
+++ b/apps/client/src/features/app-settings/panel/sources-panel/GSheetSetup.tsx
@@ -4,6 +4,7 @@ import { IoCheckmark } from '@react-icons/all-files/io5/IoCheckmark';
 import { IoShieldCheckmarkOutline } from '@react-icons/all-files/io5/IoShieldCheckmarkOutline';
 
 import { getWorksheetNames } from '../../../../common/api/sheets';
+import { maybeAxiosError } from '../../../../common/api/utils';
 import CopyTag from '../../../../common/components/copy-tag/CopyTag';
 import { openLink } from '../../../../common/utils/linkUtils';
 import * as Panel from '../PanelUtils';
@@ -29,7 +30,7 @@ export default function GSheetSetup(props: GSheetSetupProps) {
   const sheetId = useSheetStore((state) => state.sheetId);
   const setSheetId = useSheetStore((state) => state.setSheetId);
   const setWorksheets = useSheetStore((state) => state.setWorksheets);
-
+  const patchStepData = useSheetStore((state) => state.patchStepData);
   const authenticationStatus = useSheetStore((state) => state.authenticationStatus);
   const setAuthenticationStatus = useSheetStore((state) => state.setAuthenticationStatus);
 
@@ -91,8 +92,13 @@ export default function GSheetSetup(props: GSheetSetupProps) {
       setAuthenticationStatus(result.authenticated);
       if (result.authenticated !== 'pending') {
         if (result.authenticated == 'authenticated') {
-          const names = await getWorksheetNames(result.sheetId);
-          setWorksheets(names);
+          try {
+            const names = await getWorksheetNames(result.sheetId);
+            setWorksheets(names);
+          } catch (error) {
+            const message = maybeAxiosError(error);
+            patchStepData({ worksheet: { available: false, error: message } });
+          }
         }
         setLoading('');
         return;

--- a/apps/client/src/features/app-settings/panel/sources-panel/GSheetSetup.tsx
+++ b/apps/client/src/features/app-settings/panel/sources-panel/GSheetSetup.tsx
@@ -190,10 +190,7 @@ export default function GSheetSetup(props: GSheetSetupProps) {
       ) : (
         <Panel.ListGroup>
           <div className={style.buttonRow}>
-            {
-              //TODO: better spinner
-              isAuthenticating ? <Spinner /> : <></>
-            }
+            {isAuthenticating && <Spinner />}
             <CopyTag label='Google Auth Key' disabled={!canAuthenticate} size='sm'>
               {authKey ? authKey : 'Upload files to generate Auth Key'}
             </CopyTag>

--- a/apps/client/src/features/app-settings/panel/sources-panel/GSheetSetup.tsx
+++ b/apps/client/src/features/app-settings/panel/sources-panel/GSheetSetup.tsx
@@ -1,5 +1,5 @@
 import { ChangeEvent, useEffect, useState } from 'react';
-import { Button, Input } from '@chakra-ui/react';
+import { Button, Input, Spinner } from '@chakra-ui/react';
 import { IoCheckmark } from '@react-icons/all-files/io5/IoCheckmark';
 import { IoShieldCheckmarkOutline } from '@react-icons/all-files/io5/IoShieldCheckmarkOutline';
 
@@ -190,6 +190,10 @@ export default function GSheetSetup(props: GSheetSetupProps) {
       ) : (
         <Panel.ListGroup>
           <div className={style.buttonRow}>
+            {
+              //TODO: better spinner
+              isAuthenticating ? <Spinner /> : <></>
+            }
             <CopyTag label='Google Auth Key' disabled={!canAuthenticate} size='sm'>
               {authKey ? authKey : 'Upload files to generate Auth Key'}
             </CopyTag>
@@ -198,8 +202,7 @@ export default function GSheetSetup(props: GSheetSetupProps) {
               size='sm'
               leftIcon={<IoShieldCheckmarkOutline />}
               onClick={handleAuthenticate}
-              isDisabled={!canAuthenticate || isLoading}
-              isLoading={loading === 'authenticate' || isAuthenticating}
+              isDisabled={!canAuthenticate}
             >
               Authenticate
             </Button>

--- a/apps/client/src/features/app-settings/panel/sources-panel/SourcesPanel.module.scss
+++ b/apps/client/src/features/app-settings/panel/sources-panel/SourcesPanel.module.scss
@@ -26,6 +26,7 @@
 .buttonRow {
   display: flex;
   gap: 1rem;
+  align-items: center;
   justify-content: end;
 }
 

--- a/apps/server/src/services/sheet-service/SheetService.ts
+++ b/apps/server/src/services/sheet-service/SheetService.ts
@@ -201,15 +201,15 @@ async function verifySheet(
   sheetId = currentSheetId,
   authClient = currentAuthClient,
 ): Promise<{ worksheetOptions: string[] }> {
-  const spreadsheets = await sheets({ version: 'v4', auth: authClient }).spreadsheets.get({
-    spreadsheetId: sheetId,
-    includeGridData: false,
-  });
-
-  if (spreadsheets.status !== 200) {
-    throw new Error(spreadsheets.statusText);
+  try {
+    const spreadsheets = await sheets({ version: 'v4', auth: authClient }).spreadsheets.get({
+      spreadsheetId: sheetId,
+      includeGridData: false,
+    });
+    return { worksheetOptions: spreadsheets.data.sheets.map((i) => i.properties.title) };
+  } catch (error) {
+    throw new Error(`Failed to verify sheet: ${error.message}`);
   }
-  return { worksheetOptions: spreadsheets.data.sheets.map((i) => i.properties.title) };
 }
 
 export async function handleInitialConnection(

--- a/apps/server/src/services/sheet-service/SheetService.ts
+++ b/apps/server/src/services/sheet-service/SheetService.ts
@@ -183,7 +183,7 @@ function verifyConnection(
         pollInterval = null;
       }
 
-      postAction();
+      await postAction();
     } catch (_error) {
       /** we do not handle failure */
     }


### PR DESCRIPTION
catch the error that happens if you successfully authenticate but don't have permissions to the sheet and display an error in the client

also don't  block the authenticate button with a spinner 
if the user fails the auth they should be able to try again