### PR TITLE
V3 feedback2

### DIFF
--- a/apps/client/src/common/components/multi-part-progress-bar/MultiPartProgressBar.tsx
+++ b/apps/client/src/common/components/multi-part-progress-bar/MultiPartProgressBar.tsx
@@ -19,7 +19,7 @@ interface MultiPartProgressBar {
 export default function MultiPartProgressBar(props: MultiPartProgressBar) {
   const { now, complete, normalColor, warning, warningColor, danger, dangerColor, hidden, className = '' } = props;
 
-  const percentComplete = 100 - clamp(100 - (Math.max(now ?? 0, 0) * 100) / complete, 0, 100);
+  const percentRemaining = complete === 0 ? 0 : 100 - clamp(100 - (Math.max(now ?? 0, 0) * 100) / complete, 0, 100);
 
   const dangerWidth = danger ? clamp((danger / complete) * 100, 0, 100) : 0;
   const warningWidth = warning ? clamp((warning / complete) * 100, 0, 100) : 0;
@@ -37,7 +37,7 @@ export default function MultiPartProgressBar(props: MultiPartProgressBar) {
             className='multiprogress-bar__bg-danger'
             style={{ width: `${dangerWidth}%`, backgroundColor: dangerColor }}
           />
-          <div className='multiprogress-bar__indicator' style={{ width: `${percentComplete}%` }} />
+          <div className='multiprogress-bar__indicator' style={{ width: `${percentRemaining}%` }} />
         </>
       )}
     </div>

--- a/apps/client/src/features/app-settings/panel/project-panel/ProjectList.tsx
+++ b/apps/client/src/features/app-settings/panel/project-panel/ProjectList.tsx
@@ -29,14 +29,14 @@ export default function ProjectList() {
   };
 
   const reorderedProjectFiles = useMemo(() => {
-    if (!data?.files?.length) return [];
+    if (!data.files?.length) return [];
 
     const currentlyLoadedIndex = files.findIndex((project) => project.filename === lastLoadedProject);
     const projectFiles = [...files];
     const current = projectFiles.splice(currentlyLoadedIndex, 1)?.[0];
 
     return [current, ...projectFiles];
-  }, [data.files.length, files, lastLoadedProject]);
+  }, [data.files?.length, files, lastLoadedProject]);
 
   return (
     <Panel.Table>

--- a/apps/client/src/features/cuesheet/CuesheetWrapper.tsx
+++ b/apps/client/src/features/cuesheet/CuesheetWrapper.tsx
@@ -11,7 +11,7 @@ import { useCuesheet } from '../../common/hooks/useSocket';
 import { useWindowTitle } from '../../common/hooks/useWindowTitle';
 import useCustomFields from '../../common/hooks-query/useCustomFields';
 import { useFlatRundown } from '../../common/hooks-query/useRundown';
-import Overview from '../overview/Overview';
+import { CuesheetOverview } from '../overview/Overview';
 
 import CuesheetProgress from './cuesheet-progress/CuesheetProgress';
 import { useCuesheetSettings } from './store/CuesheetSettings';
@@ -85,7 +85,7 @@ export default function CuesheetWrapper() {
   return (
     <div className={styles.tableWrapper} data-testid='cuesheet'>
       <ProductionNavigationMenu isMenuOpen={isMenuOpen} onMenuClose={onClose} />
-      <Overview>
+      <CuesheetOverview>
         <IconButton
           aria-label='Toggle settings'
           variant='ontime-subtle-white'
@@ -100,7 +100,7 @@ export default function CuesheetWrapper() {
           icon={<IoSettingsOutline />}
           onClick={() => toggleSettings()}
         />
-      </Overview>
+      </CuesheetOverview>
       <CuesheetProgress />
       <Cuesheet
         data={flatRundown}

--- a/apps/client/src/features/editors/Editor.tsx
+++ b/apps/client/src/features/editors/Editor.tsx
@@ -8,7 +8,7 @@ import useElectronEvent from '../../common/hooks/useElectronEvent';
 import { useWindowTitle } from '../../common/hooks/useWindowTitle';
 import AppSettings from '../app-settings/AppSettings';
 import useAppSettingsNavigation from '../app-settings/useAppSettingsNavigation';
-import Overview from '../overview/Overview';
+import { EditorOverview } from '../overview/Overview';
 
 import styles from './Editor.module.scss';
 
@@ -65,7 +65,7 @@ export default function Editor() {
   return (
     <div className={styles.mainContainer} data-testid='event-editor'>
       <ProductionNavigationMenu isMenuOpen={isMenuOpen} onMenuClose={onClose} />
-      <Overview>
+      <EditorOverview>
         <IconButton
           aria-label='Toggle navigation'
           variant='ontime-subtle-white'
@@ -80,7 +80,7 @@ export default function Editor() {
           icon={<IoSettingsOutline />}
           onClick={toggleSettings}
         />
-      </Overview>
+      </EditorOverview>
       {isSettingsOpen ? (
         <AppSettings />
       ) : (

--- a/apps/client/src/features/overview/Overview.tsx
+++ b/apps/client/src/features/overview/Overview.tsx
@@ -1,4 +1,5 @@
 import { memo, useMemo } from 'react';
+import { millisToString } from 'ontime-utils';
 
 import ErrorBoundary from '../../common/components/error-boundary/ErrorBoundary';
 import { useRuntimeOverview, useRuntimePlaybackOverview, useTimer } from '../../common/hooks/useSocket';
@@ -9,7 +10,6 @@ import { TimeColumn, TimeRow } from './composite/TimeLayout';
 import { calculateEndAndDaySpan, formatedTime, getOffsetText } from './overviewUtils';
 
 import style from './Overview.module.scss';
-import { millisToString } from 'ontime-utils';
 
 export const EditorOverview = memo(_EditorOverview);
 

--- a/apps/client/src/features/rundown/Rundown.module.scss
+++ b/apps/client/src/features/rundown/Rundown.module.scss
@@ -3,8 +3,8 @@
   width: 100%;
 }
 
-.eventContainer {
-  margin-top: 1em;
+.rundownContainer {
+  margin-top: 1rem;
   display: flex;
   flex-direction: column;
   padding-right: 4px; // size of scrollbar

--- a/apps/client/src/features/rundown/Rundown.tsx
+++ b/apps/client/src/features/rundown/Rundown.tsx
@@ -221,7 +221,7 @@ export default function Rundown({ data }: RundownProps) {
   const isEditMode = appMode === AppMode.Edit;
 
   return (
-    <div className={style.eventContainer} ref={scrollRef} data-testid='rundown'>
+    <div className={style.rundownContainer} ref={scrollRef} data-testid='rundown'>
       <DndContext onDragEnd={handleOnDragEnd} sensors={sensors} collisionDetection={closestCenter}>
         <SortableContext items={statefulEntries} strategy={verticalListSortingStrategy}>
           <div className={style.list}>

--- a/apps/client/src/features/rundown/Rundown.tsx
+++ b/apps/client/src/features/rundown/Rundown.tsx
@@ -1,15 +1,7 @@
 import { Fragment, lazy, useCallback, useEffect, useRef, useState } from 'react';
 import { closestCenter, DndContext, DragEndEvent, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
 import { arrayMove, SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
-import {
-  isOntimeBlock,
-  isOntimeDelay,
-  isOntimeEvent,
-  MaybeNumber,
-  Playback,
-  RundownCached,
-  SupportedEvent,
-} from 'ontime-types';
+import { isOntimeEvent, MaybeNumber, Playback, RundownCached, SupportedEvent } from 'ontime-types';
 import { getFirstNormal, getNextNormal, getPreviousNormal } from 'ontime-utils';
 
 import { useEventAction } from '../../common/hooks/useEventAction';
@@ -260,14 +252,7 @@ export default function Rundown({ data }: RundownProps) {
 
               return (
                 <Fragment key={event.id}>
-                  {isEditMode && (hasCursor || isFirst) && (
-                    <QuickAddBlock
-                      showKbd={hasCursor ? 'above' : 'none'}
-                      previousEventId={previousEventId}
-                      disableAddDelay={isOntimeDelay(event)}
-                      disableAddBlock={isOntimeBlock(event)}
-                    />
-                  )}
+                  {isEditMode && (hasCursor || isFirst) && <QuickAddBlock previousEventId={previousEventId} />}
                   <div className={style.entryWrapper} data-testid={`entry-${eventIndex}`}>
                     {isOntimeEvent(event) && <div className={style.entryIndex}>{eventIndex}</div>}
                     <div className={style.entry} key={event.id} ref={hasCursor ? cursorRef : undefined}>
@@ -287,14 +272,7 @@ export default function Rundown({ data }: RundownProps) {
                       />
                     </div>
                   </div>
-                  {isEditMode && (hasCursor || isLast) && (
-                    <QuickAddBlock
-                      showKbd={hasCursor ? 'below' : 'none'}
-                      previousEventId={event.id}
-                      disableAddDelay={isOntimeDelay(event)}
-                      disableAddBlock={isOntimeBlock(event)}
-                    />
-                  )}
+                  {isEditMode && (hasCursor || isLast) && <QuickAddBlock previousEventId={event.id} />}
                 </Fragment>
               );
             })}

--- a/apps/client/src/features/rundown/delay-block/DelayBlock.tsx
+++ b/apps/client/src/features/rundown/delay-block/DelayBlock.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react';
 import { Button } from '@chakra-ui/react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { IoCheckmark } from '@react-icons/all-files/io5/IoCheckmark';
+import { IoCheckmarkDone } from '@react-icons/all-files/io5/IoCheckmarkDone';
 import { IoClose } from '@react-icons/all-files/io5/IoClose';
 import { IoReorderTwo } from '@react-icons/all-files/io5/IoReorderTwo';
 import { OntimeDelay } from 'ontime-types';
@@ -62,10 +62,10 @@ export default function DelayBlock(props: DelayBlockProps) {
       </span>
       <DelayInput eventId={data.id} duration={data.duration} />
       <div className={style.actionButtons}>
-        <Button onClick={applyDelayHandler} size='sm' leftIcon={<IoCheckmark />} variant='ontime-subtle-white'>
-          Apply
+        <Button onClick={applyDelayHandler} size='sm' leftIcon={<IoCheckmarkDone />} variant='ontime-ghosted-white'>
+          Make permanent
         </Button>
-        <Button onClick={cancelDelayHandler} size='sm' leftIcon={<IoClose />} variant='ontime-subtle-white'>
+        <Button onClick={cancelDelayHandler} size='sm' leftIcon={<IoClose />} variant='ontime-ghosted-white'>
           Cancel
         </Button>
       </div>

--- a/apps/client/src/features/rundown/event-block/EventBlock.tsx
+++ b/apps/client/src/features/rundown/event-block/EventBlock.tsx
@@ -5,10 +5,8 @@ import { IoAdd } from '@react-icons/all-files/io5/IoAdd';
 import { IoDuplicateOutline } from '@react-icons/all-files/io5/IoDuplicateOutline';
 import { IoPeople } from '@react-icons/all-files/io5/IoPeople';
 import { IoPeopleOutline } from '@react-icons/all-files/io5/IoPeopleOutline';
-import { IoRemoveCircleOutline } from '@react-icons/all-files/io5/IoRemoveCircleOutline';
 import { IoReorderTwo } from '@react-icons/all-files/io5/IoReorderTwo';
 import { IoSwapVertical } from '@react-icons/all-files/io5/IoSwapVertical';
-import { IoTimerOutline } from '@react-icons/all-files/io5/IoTimerOutline';
 import { IoTrash } from '@react-icons/all-files/io5/IoTrash';
 import { EndAction, MaybeNumber, MaybeString, OntimeEvent, Playback, TimerType, TimeStrategy } from 'ontime-types';
 
@@ -142,12 +140,6 @@ export default function EventBlock(props: EventBlockProps) {
             isDisabled: selectedEventId == null || selectedEventId === eventId,
           },
           { withDivider: true, label: 'Clone', icon: IoDuplicateOutline, onClick: () => actionHandler('clone') },
-          { withDivider: true, label: 'Event before', icon: IoAdd, onClick: () => actionHandler('event-before') },
-          { label: 'Event after', icon: IoAdd, onClick: () => actionHandler('event') },
-          { label: 'Block before', icon: IoRemoveCircleOutline, onClick: () => actionHandler('block-before') },
-          { label: 'Block after', icon: IoRemoveCircleOutline, onClick: () => actionHandler('block') },
-          { label: 'Delay before', icon: IoTimerOutline, onClick: () => actionHandler('delay-before') },
-          { label: 'Delay after', icon: IoTimerOutline, onClick: () => actionHandler('delay') },
           { withDivider: true, label: 'Delete', icon: IoTrash, onClick: () => actionHandler('delete') },
         ],
   );

--- a/apps/client/src/features/rundown/quick-add-block/QuickAddBlock.module.scss
+++ b/apps/client/src/features/rundown/quick-add-block/QuickAddBlock.module.scss
@@ -1,7 +1,7 @@
 .quickAdd {
-  display: grid;
-  grid-template-columns: 1fr auto;
+  display: flex;
   align-items: center;
+  justify-content: space-between;
   margin: 0.25rem 0;
   font-size: calc(1rem - 3px);
   padding-inline: calc(2em + 0.5rem) 0.75rem;
@@ -26,6 +26,7 @@
 }
 
 .options {
+  margin-left: auto;
   display: flex;
   flex-direction: column;
   white-space: nowrap;

--- a/apps/client/src/features/rundown/quick-add-block/QuickAddBlock.module.scss
+++ b/apps/client/src/features/rundown/quick-add-block/QuickAddBlock.module.scss
@@ -3,15 +3,14 @@
   grid-template-columns: 1fr auto;
   align-items: center;
   margin: 0.25rem 0;
-  font-size: $inner-section-text-size;
-  padding: 0 0.75rem;
+  font-size: calc(1rem - 3px);
+  padding-inline: calc(2em + 0.5rem) 0.75rem;
   gap: 1rem;
 }
 
 .btnRow {
-  justify-self: center;
   display: flex;
-  gap: max(0.5rem, 2rem);
+  gap: 1rem;
 
   .quickBtn {
     font-weight: 400;

--- a/apps/client/src/features/rundown/quick-add-block/QuickAddBlock.module.scss
+++ b/apps/client/src/features/rundown/quick-add-block/QuickAddBlock.module.scss
@@ -1,33 +1,13 @@
 .quickAdd {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  gap: 1rem;
+
   margin: 0.25rem 0;
   font-size: calc(1rem - 3px);
   padding-inline: calc(2em + 0.5rem) 0.75rem;
-  gap: 1rem;
 }
 
-.btnRow {
-  display: flex;
-  gap: 1rem;
-
-  .quickBtn {
-    font-weight: 400;
-  }
-}
-
-.keyboard {
-  margin-left: 0.5rem;
-  padding: 0 0.25rem;
-  color: $label-gray;
-  border-radius: 2px;
-  background-color: $black-10;
-}
-
-.options {
-  margin-left: auto;
-  display: flex;
-  flex-direction: column;
-  white-space: nowrap;
+.quickBtn {
+  font-weight: 400;
 }

--- a/apps/client/src/features/rundown/quick-add-block/QuickAddBlock.tsx
+++ b/apps/client/src/features/rundown/quick-add-block/QuickAddBlock.tsx
@@ -1,10 +1,9 @@
 import { memo, useCallback, useRef } from 'react';
-import { Button, Checkbox } from '@chakra-ui/react';
+import { Button } from '@chakra-ui/react';
 import { IoAdd } from '@react-icons/all-files/io5/IoAdd';
 import { SupportedEvent } from 'ontime-types';
 
 import { useEventAction } from '../../../common/hooks/useEventAction';
-import { useEditorSettings } from '../../../common/stores/editorSettings';
 import { useEmitLog } from '../../../common/stores/logger';
 
 import style from './QuickAddBlock.module.scss';
@@ -22,8 +21,6 @@ function QuickAddBlock(props: QuickAddBlockProps) {
 
   const doLinkPrevious = useRef<HTMLInputElement | null>(null);
   const doPublic = useRef<HTMLInputElement | null>(null);
-
-  const { defaultPublic, linkPrevious } = useEditorSettings((state) => state.eventSettings);
 
   const handleCreateEvent = useCallback(
     (eventType: SupportedEvent) => {
@@ -67,54 +64,35 @@ function QuickAddBlock(props: QuickAddBlockProps) {
     [previousEventId, addEvent, emitError],
   );
 
-  const canLinkPrevious = Boolean(previousEventId);
-  const shouldLinkPrevious = Boolean(linkPrevious) && canLinkPrevious;
-
   return (
     <div className={style.quickAdd}>
-      <div className={style.btnRow}>
-        <Button
-          onClick={() => handleCreateEvent(SupportedEvent.Event)}
-          size='xs'
-          variant='ontime-subtle-white'
-          className={style.quickBtn}
-          leftIcon={<IoAdd />}
-        >
-          Event
-        </Button>
-        <Button
-          onClick={() => handleCreateEvent(SupportedEvent.Delay)}
-          size='xs'
-          variant='ontime-subtle-white'
-          className={style.quickBtn}
-          leftIcon={<IoAdd />}
-        >
-          Delay
-        </Button>
-        <Button
-          onClick={() => handleCreateEvent(SupportedEvent.Block)}
-          size='xs'
-          variant='ontime-subtle-white'
-          className={style.quickBtn}
-          leftIcon={<IoAdd />}
-        >
-          Block
-        </Button>
-      </div>
-      <div className={style.options}>
-        <Checkbox
-          ref={doLinkPrevious}
-          size='sm'
-          variant='ontime-ondark'
-          isDisabled={!canLinkPrevious}
-          defaultChecked={shouldLinkPrevious}
-        >
-          Link to previous
-        </Checkbox>
-        <Checkbox ref={doPublic} size='sm' variant='ontime-ondark' defaultChecked={defaultPublic}>
-          Event is public
-        </Checkbox>
-      </div>
+      <Button
+        onClick={() => handleCreateEvent(SupportedEvent.Event)}
+        size='xs'
+        variant='ontime-subtle-white'
+        className={style.quickBtn}
+        leftIcon={<IoAdd />}
+      >
+        Event
+      </Button>
+      <Button
+        onClick={() => handleCreateEvent(SupportedEvent.Delay)}
+        size='xs'
+        variant='ontime-subtle-white'
+        className={style.quickBtn}
+        leftIcon={<IoAdd />}
+      >
+        Delay
+      </Button>
+      <Button
+        onClick={() => handleCreateEvent(SupportedEvent.Block)}
+        size='xs'
+        variant='ontime-subtle-white'
+        className={style.quickBtn}
+        leftIcon={<IoAdd />}
+      >
+        Block
+      </Button>
     </div>
   );
 }

--- a/apps/client/src/features/rundown/quick-add-block/QuickAddBlock.tsx
+++ b/apps/client/src/features/rundown/quick-add-block/QuickAddBlock.tsx
@@ -1,25 +1,22 @@
 import { memo, useCallback, useRef } from 'react';
-import { Button, Checkbox, Tooltip } from '@chakra-ui/react';
+import { Button, Checkbox } from '@chakra-ui/react';
 import { IoAdd } from '@react-icons/all-files/io5/IoAdd';
 import { SupportedEvent } from 'ontime-types';
 
 import { useEventAction } from '../../../common/hooks/useEventAction';
 import { useEditorSettings } from '../../../common/stores/editorSettings';
 import { useEmitLog } from '../../../common/stores/logger';
-import { deviceAlt } from '../../../common/utils/deviceUtils';
-import { tooltipDelayMid } from '../../../ontimeConfig';
 
 import style from './QuickAddBlock.module.scss';
 
 interface QuickAddBlockProps {
-  showKbd: 'above' | 'below' | 'none';
   previousEventId?: string;
-  disableAddDelay?: boolean;
-  disableAddBlock: boolean;
 }
 
-const QuickAddBlock = (props: QuickAddBlockProps) => {
-  const { showKbd = 'none', previousEventId, disableAddDelay = true, disableAddBlock } = props;
+export default memo(QuickAddBlock);
+
+function QuickAddBlock(props: QuickAddBlockProps) {
+  const { previousEventId } = props;
   const { addEvent } = useEventAction();
   const { emitError } = useEmitLog();
 
@@ -27,8 +24,6 @@ const QuickAddBlock = (props: QuickAddBlockProps) => {
   const doPublic = useRef<HTMLInputElement | null>(null);
 
   const { defaultPublic, linkPrevious } = useEditorSettings((state) => state.eventSettings);
-
-  const shortcutBase = showKbd === 'none' ? '' : `${deviceAlt} ${showKbd === 'above' ? '⇧' : ''}`;
 
   const handleCreateEvent = useCallback(
     (eventType: SupportedEvent) => {
@@ -78,41 +73,33 @@ const QuickAddBlock = (props: QuickAddBlockProps) => {
   return (
     <div className={style.quickAdd}>
       <div className={style.btnRow}>
-        <Tooltip label='Add Event' openDelay={tooltipDelayMid}>
-          <Button
-            onClick={() => handleCreateEvent(SupportedEvent.Event)}
-            size='xs'
-            variant='ontime-subtle-white'
-            className={style.quickBtn}
-            leftIcon={<IoAdd />}
-          >
-            Event {shortcutBase && <span className={style.keyboard}>{`${shortcutBase} E`}</span>}
-          </Button>
-        </Tooltip>
-        <Tooltip label='Add Delay' openDelay={tooltipDelayMid}>
-          <Button
-            onClick={() => handleCreateEvent(SupportedEvent.Delay)}
-            size='xs'
-            variant='ontime-subtle-white'
-            disabled={disableAddDelay}
-            className={style.quickBtn}
-            leftIcon={<IoAdd />}
-          >
-            Delay {shortcutBase && <span className={style.keyboard}>{`${shortcutBase} D`}</span>}
-          </Button>
-        </Tooltip>
-        <Tooltip label='Add Block' openDelay={tooltipDelayMid}>
-          <Button
-            onClick={() => handleCreateEvent(SupportedEvent.Block)}
-            size='xs'
-            variant='ontime-subtle-white'
-            disabled={disableAddBlock}
-            className={style.quickBtn}
-            leftIcon={<IoAdd />}
-          >
-            Block {shortcutBase && <span className={style.keyboard}>{`${shortcutBase} B`}</span>}
-          </Button>
-        </Tooltip>
+        <Button
+          onClick={() => handleCreateEvent(SupportedEvent.Event)}
+          size='xs'
+          variant='ontime-subtle-white'
+          className={style.quickBtn}
+          leftIcon={<IoAdd />}
+        >
+          Event
+        </Button>
+        <Button
+          onClick={() => handleCreateEvent(SupportedEvent.Delay)}
+          size='xs'
+          variant='ontime-subtle-white'
+          className={style.quickBtn}
+          leftIcon={<IoAdd />}
+        >
+          Delay
+        </Button>
+        <Button
+          onClick={() => handleCreateEvent(SupportedEvent.Block)}
+          size='xs'
+          variant='ontime-subtle-white'
+          className={style.quickBtn}
+          leftIcon={<IoAdd />}
+        >
+          Block
+        </Button>
       </div>
       <div className={style.options}>
         <Checkbox
@@ -130,6 +117,4 @@ const QuickAddBlock = (props: QuickAddBlockProps) => {
       </div>
     </div>
   );
-};
-
-export default memo(QuickAddBlock);
+}

--- a/apps/client/src/features/rundown/rundown-header/RundownHeader.module.scss
+++ b/apps/client/src/features/rundown/rundown-header/RundownHeader.module.scss
@@ -1,6 +1,5 @@
 .header {
-  padding-left: 2rem;
-  padding-right: 1rem;
+  padding-inline: calc(2rem - 6px + 0.5rem) calc(1rem + 2px);
   
   display: flex;
   align-items: center;

--- a/apps/client/src/features/rundown/rundown-header/RundownHeader.tsx
+++ b/apps/client/src/features/rundown/rundown-header/RundownHeader.tsx
@@ -1,8 +1,5 @@
-import { ButtonGroup } from '@chakra-ui/react';
-import { IoOptions } from '@react-icons/all-files/io5/IoOptions';
-import { IoPlay } from '@react-icons/all-files/io5/IoPlay';
+import { Button, ButtonGroup } from '@chakra-ui/react';
 
-import TooltipActionBtn from '../../../common/components/buttons/TooltipActionBtn';
 import { AppMode, useAppMode } from '../../../common/stores/appModeStore';
 
 import RundownMenu from './RundownMenu';
@@ -18,22 +15,12 @@ export default function RundownHeader() {
   return (
     <div className={style.header}>
       <ButtonGroup isAttached>
-        <TooltipActionBtn
-          variant={appMode === AppMode.Run ? 'ontime-filled' : 'ontime-outlined'}
-          size='sm'
-          icon={<IoPlay />}
-          clickHandler={setRunMode}
-          tooltip='Run mode'
-          aria-label='Run mode'
-        />
-        <TooltipActionBtn
-          variant={appMode === AppMode.Edit ? 'ontime-filled' : 'ontime-outlined'}
-          size='sm'
-          icon={<IoOptions />}
-          clickHandler={setEditMode}
-          tooltip='Edit mode'
-          aria-label='Edit mode'
-        />
+        <Button size='sm' variant={appMode === AppMode.Run ? 'ontime-filled' : 'ontime-subtle'} onClick={setRunMode}>
+          Run
+        </Button>
+        <Button size='sm' variant={appMode === AppMode.Edit ? 'ontime-filled' : 'ontime-subtle'} onClick={setEditMode}>
+          Edit
+        </Button>
       </ButtonGroup>
       <RundownMenu />
     </div>

--- a/apps/client/src/features/viewers/minimal-timer/MinimalTimer.tsx
+++ b/apps/client/src/features/viewers/minimal-timer/MinimalTimer.tsx
@@ -154,14 +154,19 @@ export default function MinimalTimer(props: MinimalTimerProps) {
       display = removeSeconds(display);
     }
     display = removeLeadingZero(display);
+
+    if (display.length < 3) {
+      display = `${display} ${getLocalizedString('common.minutes')}`;
+    }
+
     // last unit rounds up in negative timers
     const isNegative =
       (stageTimer ?? 0 < MILLIS_PER_SECOND) && !timerIsTimeOfDay && time.timerType !== TimerType.CountUp;
-    if (isNegative && display === '0') {
-      display = '-1';
-    }
-    if (display.length < 3) {
-      display = `${display} ${getLocalizedString('common.minutes')}`;
+    if (isNegative) {
+      if (display === '0') {
+        display = '1';
+      }
+      display = `-${display}`;
     }
   }
   const stageTimerCharacters = display.replace('/:/g', '').length;

--- a/apps/client/src/features/viewers/minimal-timer/MinimalTimer.tsx
+++ b/apps/client/src/features/viewers/minimal-timer/MinimalTimer.tsx
@@ -159,10 +159,10 @@ export default function MinimalTimer(props: MinimalTimerProps) {
       display = `${display} ${getLocalizedString('common.minutes')}`;
     }
 
-    // last unit rounds up in negative timers
     const isNegative =
-      (stageTimer ?? 0 < MILLIS_PER_SECOND) && !timerIsTimeOfDay && time.timerType !== TimerType.CountUp;
+      (stageTimer ?? 0) < -MILLIS_PER_SECOND && !timerIsTimeOfDay && time.timerType !== TimerType.CountUp;
     if (isNegative) {
+      // last unit rounds up in negative timers
       if (display === '0') {
         display = '1';
       }

--- a/apps/client/src/features/viewers/timer/Timer.tsx
+++ b/apps/client/src/features/viewers/timer/Timer.tsx
@@ -136,10 +136,10 @@ export default function Timer(props: TimerProps) {
     if (display.length < 3) {
       display = `${display} ${getLocalizedString('common.minutes')}`;
     }
-    // last unit rounds up in negative timers
     const isNegative =
-      (stageTimer ?? 0 < -MILLIS_PER_SECOND) && !timerIsTimeOfDay && time.timerType !== TimerType.CountUp;
+      (stageTimer ?? 0) < -MILLIS_PER_SECOND && !timerIsTimeOfDay && time.timerType !== TimerType.CountUp;
     if (isNegative) {
+      // last unit rounds up in negative timers
       if (display === '0') {
         display = '1';
       }

--- a/apps/client/src/features/viewers/timer/Timer.tsx
+++ b/apps/client/src/features/viewers/timer/Timer.tsx
@@ -132,14 +132,18 @@ export default function Timer(props: TimerProps) {
       display = removeSeconds(display);
     }
     display = removeLeadingZero(display);
+
+    if (display.length < 3) {
+      display = `${display} ${getLocalizedString('common.minutes')}`;
+    }
     // last unit rounds up in negative timers
     const isNegative =
       (stageTimer ?? 0 < -MILLIS_PER_SECOND) && !timerIsTimeOfDay && time.timerType !== TimerType.CountUp;
-    if (isNegative && display === '0') {
-      display = '-1';
-    }
-    if (display.length < 3) {
-      display = `${display} ${getLocalizedString('common.minutes')}`;
+    if (isNegative) {
+      if (display === '0') {
+        display = '1';
+      }
+      display = `-${display}`;
     }
   }
   const stageTimerCharacters = display.replace('/:/g', '').length;

--- a/apps/client/src/theme/ontimeMenu.ts
+++ b/apps/client/src/theme/ontimeMenu.ts
@@ -11,7 +11,7 @@ export const ontimeMenuOnDark = {
     backgroundColor: 'transparent',
     paddingBlock: '0.5rem',
     _hover: {
-      backgroundColor: 'rgba(0, 0, 0, 0.1)',
+      backgroundColor: 'rgba(0, 0, 0, 0.2)',
       _disabled: {
         backgroundColor: 'transparent',
       },

--- a/e2e/tests/000-upload-showfile.spec.ts
+++ b/e2e/tests/000-upload-showfile.spec.ts
@@ -4,7 +4,7 @@ const fileToUpload = 'e2e/tests/fixtures/test-db.json';
 
 test('project file upload', async ({ page }) => {
   await page.goto('http://localhost:4001/editor');
-  await page.getByRole('button', { name: 'Edit mode' }).click();
+  await page.getByRole('button', { name: 'Edit' }).click();
   await page.getByRole('button', { name: 'Clear rundown' }).click();
 
   await page.getByRole('button', { name: 'toggle settings' }).click();

--- a/e2e/tests/features/203-delay-block.spec.ts
+++ b/e2e/tests/features/203-delay-block.spec.ts
@@ -17,7 +17,7 @@ test('delay blocks add time to events', async ({ page }) => {
   await page.getByTestId('rundown').getByPlaceholder('Duration').press('Enter');
 
   // add delay block
-  await page.getByRole('button', { name: 'Delay Alt ⇧ D' }).click();
+  await page.getByRole('button', { name: 'Delay' }).click();
 
   // fill positive delay
   await page.getByTestId('delay-input').click();
@@ -35,7 +35,7 @@ test('delay blocks add time to events', async ({ page }) => {
 
   // add new delay
   await page.getByTestId('rundown').getByPlaceholder('Start').click();
-  await page.getByRole('button', { name: 'Delay Alt ⇧ D' }).click();
+  await page.getByRole('button', { name: 'Delay' }).click();
   await page.getByTestId('delay-input').click();
   await page.getByTestId('delay-input').fill('10m');
   await page.getByTestId('delay-input').press('Enter');
@@ -68,7 +68,7 @@ test('delays are show correctly', async ({ page }) => {
   await expect(page.getByTestId('entry-1').locator('#block-status')).toHaveAttribute('data-ispublic', 'true');
 
   // add a delay
-  await page.getByRole('button', { name: 'Delay Alt ⇧ D' }).click();
+  await page.getByRole('button', { name: 'Delay' }).click();
   await page.getByTestId('delay-input').click();
   await page.getByTestId('delay-input').fill('1');
   await page.getByTestId('delay-input').press('Enter');

--- a/e2e/tests/features/203-delay-block.spec.ts
+++ b/e2e/tests/features/203-delay-block.spec.ts
@@ -4,7 +4,7 @@ test('delay blocks add time to events', async ({ page }) => {
   await page.goto('http://localhost:4001/editor');
 
   // delete all events and add a new one
-  await page.getByRole('button', { name: 'Edit mode' }).click();
+  await page.getByRole('button', { name: 'Edit' }).click();
   await page.getByRole('button', { name: 'Clear rundown' }).click();
   await page.getByRole('button', { name: 'Create event' }).click();
 
@@ -51,7 +51,7 @@ test('delays are show correctly', async ({ page }) => {
   await page.goto('http://localhost:4001/editor');
 
   // add a test event
-  await page.getByRole('button', { name: 'Edit mode' }).click();
+  await page.getByRole('button', { name: 'Edit' }).click();
   await page.getByRole('button', { name: 'Clear rundown' }).click();
   await page.getByRole('button', { name: 'Create Event' }).click();
 

--- a/e2e/tests/features/203-delay-block.spec.ts
+++ b/e2e/tests/features/203-delay-block.spec.ts
@@ -17,7 +17,7 @@ test('delay blocks add time to events', async ({ page }) => {
   await page.getByTestId('rundown').getByPlaceholder('Duration').press('Enter');
 
   // add delay block
-  await page.getByRole('button', { name: 'Delay' }).click();
+  await page.getByRole('button', { name: 'Delay' }).nth(0).click();
 
   // fill positive delay
   await page.getByTestId('delay-input').click();
@@ -30,12 +30,12 @@ test('delay blocks add time to events', async ({ page }) => {
   await page.getByText('New start 00:08').click();
 
   // apply delay
-  await page.getByRole('button', { name: 'Apply' }).click();
+  await page.getByRole('button', { name: 'Make permanent' }).click();
   await expect(page.getByTestId('rundown').getByTestId('time-input-timeStart')).toHaveValue('00:08:00');
 
   // add new delay
   await page.getByTestId('rundown').getByPlaceholder('Start').click();
-  await page.getByRole('button', { name: 'Delay' }).click();
+  await page.getByRole('button', { name: 'Delay' }).nth(0).click();
   await page.getByTestId('delay-input').click();
   await page.getByTestId('delay-input').fill('10m');
   await page.getByTestId('delay-input').press('Enter');
@@ -68,7 +68,7 @@ test('delays are show correctly', async ({ page }) => {
   await expect(page.getByTestId('entry-1').locator('#block-status')).toHaveAttribute('data-ispublic', 'true');
 
   // add a delay
-  await page.getByRole('button', { name: 'Delay' }).click();
+  await page.getByRole('button', { name: 'Delay' }).nth(0).click();
   await page.getByTestId('delay-input').click();
   await page.getByTestId('delay-input').fill('1');
   await page.getByTestId('delay-input').press('Enter');

--- a/e2e/tests/features/204-editor-crud.spec.ts
+++ b/e2e/tests/features/204-editor-crud.spec.ts
@@ -18,11 +18,9 @@ test('CRUD operations on the rundown', async ({ page }) => {
   // test quick add options - star2+5-t is last end
   await page.getByTestId('entry-2').getByTestId('time-input-duration').fill('20m');
   await page.getByRole('button', { name: 'Event', exact: true }).nth(1).click();
-  await expect(page.getByLabel('Link to previous').nth(1)).toBeChecked();
   expect(await page.getByTestId('entry-3').getByTestId('time-input-timeStart').inputValue()).toContain('00:30:00');
 
   // test quick add options - event is public
-  await expect(page.getByLabel('Event is public').nth(1)).toBeChecked();
   await page.getByRole('button', { name: 'Event', exact: true }).nth(1).click();
 
   await expect(page.getByTestId('entry-4').locator('#block-status')).toHaveAttribute('data-ispublic', 'true');

--- a/e2e/tests/features/204-editor-crud.spec.ts
+++ b/e2e/tests/features/204-editor-crud.spec.ts
@@ -4,7 +4,7 @@ test('CRUD operations on the rundown', async ({ page }) => {
   await page.goto('http://localhost:4001/editor');
 
   // clear rundown
-  await page.getByRole('button', { name: 'Edit mode' }).click();
+  await page.getByRole('button', { name: 'Edit' }).click();
   await page.getByRole('button', { name: 'Clear rundown' }).click();
 
   // create event from the rundown empty button

--- a/e2e/tests/features/205-operator.spec.ts
+++ b/e2e/tests/features/205-operator.spec.ts
@@ -25,7 +25,7 @@ test('smoke test operator', async ({ page }) => {
 
   await page.getByRole('button', { name: 'Block', exact: true }).nth(0).click();
 
-  await page.getByRole('button', { name: 'Edit' }).click();
+  await page.getByRole('button', { name: 'Edit' }).nth(1).click();
   await page.getByTestId('entry-1').click({ button: 'right' });
   await page.getByRole('menuitem', { name: 'Event after' }).click();
 

--- a/e2e/tests/features/205-operator.spec.ts
+++ b/e2e/tests/features/205-operator.spec.ts
@@ -18,7 +18,7 @@ test('smoke test operator', async ({ page }) => {
   await page.getByTestId('entry-2').getByTestId('time-input-duration').press('Enter');
   await page.getByTestId('entry-2').getByTestId('time-input-duration').press('Enter');
 
-  await page.getByRole('button', { name: 'Event Alt E', exact: true }).click();
+  await page.getByRole('button', { name: 'Event', exact: true }).click();
   await page.getByTestId('entry-3').getByTestId('lock__duration').click();
   await page.getByTestId('entry-3').getByTestId('time-input-duration').fill('1m');
   await page.getByTestId('entry-3').getByTestId('time-input-duration').press('Enter');

--- a/e2e/tests/features/205-operator.spec.ts
+++ b/e2e/tests/features/205-operator.spec.ts
@@ -25,7 +25,7 @@ test('smoke test operator', async ({ page }) => {
 
   await page.getByRole('button', { name: 'Block' }).nth(1).click();
 
-  await page.getByRole('button', { name: 'Edit' }).nth(1).click();
+  await page.getByRole('button', { name: 'Edit' }).click();
   await page.getByTestId('entry-1').click();
   await page.getByRole('button', { name: 'Event', exact: true }).nth(1).click();
 

--- a/e2e/tests/features/205-operator.spec.ts
+++ b/e2e/tests/features/205-operator.spec.ts
@@ -26,22 +26,22 @@ test('smoke test operator', async ({ page }) => {
   await page.getByRole('button', { name: 'Block', exact: true }).nth(0).click();
 
   await page.getByRole('button', { name: 'Edit' }).nth(1).click();
-  await page.getByTestId('entry-1').click({ button: 'right' });
-  await page.getByRole('menuitem', { name: 'Event after' }).click();
+  await page.getByTestId('entry-1').click();
+  await page.getByRole('button', { name: 'Event' }).nth(1).click();
 
   await page.getByTestId('entry-1').getByTestId('block__title').click();
   await page.getByTestId('entry-1').getByTestId('block__title').fill('title 1');
   await page.getByTestId('entry-1').getByTestId('block__title').press('Enter');
 
-  await page.getByTestId('entry-2').click({ button: 'right' });
-  await page.getByRole('menuitem', { name: 'Event after' }).click();
+  await page.getByTestId('entry-2').click();
+  await page.getByRole('button', { name: 'Event' }).nth(1).click();
 
   await page.getByTestId('entry-2').getByTestId('block__title').click();
   await page.getByTestId('entry-2').getByTestId('block__title').fill('title 2');
   await page.getByTestId('entry-2').getByTestId('block__title').press('Enter');
 
-  await page.getByTestId('entry-3').click({ button: 'right' });
-  await page.getByRole('menuitem', { name: 'Event after' }).click();
+  await page.getByTestId('entry-3').click();
+  await page.getByRole('button', { name: 'Event' }).nth(1).click();
 
   await page.getByTestId('entry-3').getByTestId('block__title').click();
   await page.getByTestId('entry-3').getByTestId('block__title').fill('title 3');

--- a/e2e/tests/features/205-operator.spec.ts
+++ b/e2e/tests/features/205-operator.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from '@playwright/test';
 test('smoke test operator', async ({ page }) => {
   // make some boilerplate
   await page.goto('http://localhost:4001/editor');
-  await page.getByRole('button', { name: 'Edit mode' }).click();
+  await page.getByRole('button', { name: 'Edit' }).click();
   await page.getByRole('button', { name: 'Clear rundown' }).click();
   await page.getByRole('button', { name: 'Create Event' }).click();
 
@@ -25,7 +25,7 @@ test('smoke test operator', async ({ page }) => {
 
   await page.getByRole('button', { name: 'Block', exact: true }).nth(0).click();
 
-  await page.getByRole('button', { name: 'Edit mode' }).click();
+  await page.getByRole('button', { name: 'Edit' }).click();
   await page.getByTestId('entry-1').click({ button: 'right' });
   await page.getByRole('menuitem', { name: 'Event after' }).click();
 

--- a/e2e/tests/features/205-operator.spec.ts
+++ b/e2e/tests/features/205-operator.spec.ts
@@ -25,6 +25,7 @@ test('smoke test operator', async ({ page }) => {
 
   await page.getByRole('button', { name: 'Block' }).nth(1).click();
 
+  await page.getByRole('button', { name: 'Edit' }).nth(1).click();
   await page.getByTestId('entry-1').click();
   await page.getByRole('button', { name: 'Event', exact: true }).nth(1).click();
 

--- a/e2e/tests/features/205-operator.spec.ts
+++ b/e2e/tests/features/205-operator.spec.ts
@@ -12,18 +12,18 @@ test('smoke test operator', async ({ page }) => {
   await page.getByTestId('time-input-duration').fill('1m');
   await page.getByTestId('time-input-duration').press('Enter');
 
-  await page.getByRole('button', { name: 'Event', exact: true }).nth(1).click();
+  await page.getByRole('button', { name: 'Event' }).nth(1).click();
   await page.getByTestId('entry-2').getByTestId('lock__duration').click();
   await page.getByTestId('entry-2').getByTestId('time-input-duration').fill('1m');
   await page.getByTestId('entry-2').getByTestId('time-input-duration').press('Enter');
   await page.getByTestId('entry-2').getByTestId('time-input-duration').press('Enter');
 
-  await page.getByRole('button', { name: 'Event', exact: true }).click();
+  await page.getByRole('button', { name: 'Event' }).nth(1).click();
   await page.getByTestId('entry-3').getByTestId('lock__duration').click();
   await page.getByTestId('entry-3').getByTestId('time-input-duration').fill('1m');
   await page.getByTestId('entry-3').getByTestId('time-input-duration').press('Enter');
 
-  await page.getByRole('button', { name: 'Block', exact: true }).nth(0).click();
+  await page.getByRole('button', { name: 'Block' }).nth(0).click();
 
   await page.getByRole('button', { name: 'Edit' }).nth(1).click();
   await page.getByTestId('entry-1').click();

--- a/e2e/tests/features/205-operator.spec.ts
+++ b/e2e/tests/features/205-operator.spec.ts
@@ -12,36 +12,35 @@ test('smoke test operator', async ({ page }) => {
   await page.getByTestId('time-input-duration').fill('1m');
   await page.getByTestId('time-input-duration').press('Enter');
 
-  await page.getByRole('button', { name: 'Event' }).nth(1).click();
+  await page.getByRole('button', { name: 'Event', exact: true }).nth(1).click();
   await page.getByTestId('entry-2').getByTestId('lock__duration').click();
   await page.getByTestId('entry-2').getByTestId('time-input-duration').fill('1m');
   await page.getByTestId('entry-2').getByTestId('time-input-duration').press('Enter');
   await page.getByTestId('entry-2').getByTestId('time-input-duration').press('Enter');
 
-  await page.getByRole('button', { name: 'Event' }).nth(1).click();
+  await page.getByRole('button', { name: 'Event', exact: true }).nth(1).click();
   await page.getByTestId('entry-3').getByTestId('lock__duration').click();
   await page.getByTestId('entry-3').getByTestId('time-input-duration').fill('1m');
   await page.getByTestId('entry-3').getByTestId('time-input-duration').press('Enter');
 
-  await page.getByRole('button', { name: 'Block' }).nth(0).click();
+  await page.getByRole('button', { name: 'Block' }).nth(1).click();
 
-  await page.getByRole('button', { name: 'Edit' }).nth(1).click();
   await page.getByTestId('entry-1').click();
-  await page.getByRole('button', { name: 'Event' }).nth(1).click();
+  await page.getByRole('button', { name: 'Event', exact: true }).nth(1).click();
 
   await page.getByTestId('entry-1').getByTestId('block__title').click();
   await page.getByTestId('entry-1').getByTestId('block__title').fill('title 1');
   await page.getByTestId('entry-1').getByTestId('block__title').press('Enter');
 
   await page.getByTestId('entry-2').click();
-  await page.getByRole('button', { name: 'Event' }).nth(1).click();
+  await page.getByRole('button', { name: 'Event', exact: true }).nth(1).click();
 
   await page.getByTestId('entry-2').getByTestId('block__title').click();
   await page.getByTestId('entry-2').getByTestId('block__title').fill('title 2');
   await page.getByTestId('entry-2').getByTestId('block__title').press('Enter');
 
   await page.getByTestId('entry-3').click();
-  await page.getByRole('button', { name: 'Event' }).nth(1).click();
+  await page.getByRole('button', { name: 'Event', exact: true }).nth(1).click();
 
   await page.getByTestId('entry-3').getByTestId('block__title').click();
   await page.getByTestId('entry-3').getByTestId('block__title').fill('title 3');

--- a/e2e/tests/features/301-spreadsheet-import.spec.ts
+++ b/e2e/tests/features/301-spreadsheet-import.spec.ts
@@ -4,7 +4,7 @@ const fileToUpload = 'e2e/tests/fixtures/test-sheet.xlsx';
 
 test('sheet file upload', async ({ page }) => {
   await page.goto('http://localhost:4001/editor');
-  await page.getByRole('button', { name: 'Edit mode' }).click();
+  await page.getByRole('button', { name: 'Edit' }).click();
   await page.getByRole('button', { name: 'Clear rundown' }).click();
 
   await page.getByRole('button', { name: 'Toggle settings' }).click();


### PR DESCRIPTION
Small tweaks from user feedback on alpha 3

- [x] remove Add actions from context menu, the feedback was that this made the menu confusing. Since the quick add now shows in edit mode, that should be the way to add events
- [x] restyle quick add buttons to make sure they are always the same size (opinion was that change of sizes was confusing and distracting)
- [x] simplify quick add
- [x] rename action in delay from `Apply` to `Make permanent`, this attempts to clarify that the action is not mandatory
- [x] fix missing negative timer
- [x] small style tweaks
- [x] fix issue with multi progress bar when timer duration is 0
- [x] fix issue with project list being undefined
- [x] cuesheet overview has running timer data  
 
@alex-Arc , what do you think of changing the text in the delay block from Apply to Make permanent?
The idea is that users seem to be confused as to what apply does. Delays do not need to be applied, this only makes them part of the schedule. Another alternative was to call it `Reschedule`, but I thought that could be even more confusing