### PR TITLE
Granular ws

### DIFF
--- a/apps/server/src/services/TimerService.ts
+++ b/apps/server/src/services/TimerService.ts
@@ -151,11 +151,12 @@ function broadcastResult(_target: any, _propertyKey: string, descriptor: Propert
     const hasChangedPlayback = TimerService.previousState.timer?.playback !== state.timer.playback;
     const hasImmediateChanges = hasNewLoaded || hasSkippedBack || justStarted || hasChangedPlayback;
 
+    if (hasChangedPlayback) {
+      eventStore.set('onAir', state.timer.playback !== Playback.Stop);
+    }
+
     if (hasImmediateChanges || (isTimeToUpdate && !deepEqual(TimerService.previousState?.timer, state.timer))) {
-      eventStore.batchSet({
-        timer: state.timer,
-        onAir: state.timer.playback !== Playback.Stop,
-      });
+      eventStore.set('timer', state.timer);
       TimerService.previousState.timer = { ...state.timer };
     }
 


### PR DESCRIPTION
I realised that we send the entire websocket payload every second
this PR makes it that we only ever send the things that change

this makes the app transmit around 8x less data. more importantly, it would allow the consumer to do less work on updating
regardless, the amount of data transmitted is very low (around 200b for a full packet) and it is arguable whether it is worth it