### PR TITLE
fix: handle displaying negative timers

### DIFF
--- a/apps/client/src/features/viewers/backstage/Backstage.tsx
+++ b/apps/client/src/features/viewers/backstage/Backstage.tsx
@@ -16,6 +16,7 @@ import ViewParamsEditor from '../../../common/components/view-params-editor/View
 import { useRuntimeStylesheet } from '../../../common/hooks/useRuntimeStylesheet';
 import { useWindowTitle } from '../../../common/hooks/useWindowTitle';
 import { ViewExtendedTimer } from '../../../common/models/TimeManager.type';
+import { timerPlaceholderMin } from '../../../common/utils/styleUtils';
 import { formatTime, getDefaultFormat } from '../../../common/utils/time';
 import { useTranslation } from '../../../translation/TranslationProvider';
 import { titleVariants } from '../common/animation';
@@ -90,7 +91,7 @@ export default function Backstage(props: BackstageProps) {
   const secondaryTextNext = getPropertyValue(eventNext, secondarySource);
   const secondaryTextNow = getPropertyValue(eventNow, secondarySource);
 
-  let stageTimer = millisToString(time.current, { fallback: '- - : - -' });
+  let stageTimer = millisToString(time.current, { fallback: timerPlaceholderMin });
   stageTimer = removeLeadingZero(stageTimer);
 
   const totalTime = (time.duration ?? 0) + (time.addedTime ?? 0);

--- a/apps/client/src/features/viewers/minimal-timer/MinimalTimer.tsx
+++ b/apps/client/src/features/viewers/minimal-timer/MinimalTimer.tsx
@@ -1,6 +1,5 @@
 import { useSearchParams } from 'react-router-dom';
 import { Playback, TimerMessage, TimerType, ViewSettings } from 'ontime-types';
-import { MILLIS_PER_SECOND, millisToString, removeLeadingZero, removeSeconds } from 'ontime-utils';
 
 import { overrideStylesURL } from '../../../common/api/constants';
 import { MINIMAL_TIMER_OPTIONS } from '../../../common/components/view-params-editor/constants';
@@ -9,9 +8,8 @@ import { useRuntimeStylesheet } from '../../../common/hooks/useRuntimeStylesheet
 import { useWindowTitle } from '../../../common/hooks/useWindowTitle';
 import { ViewExtendedTimer } from '../../../common/models/TimeManager.type';
 import { OverridableOptions } from '../../../common/models/View.types';
-import { timerPlaceholder, timerPlaceholderMin } from '../../../common/utils/styleUtils';
 import { useTranslation } from '../../../translation/TranslationProvider';
-import { getTimerByType, isStringBoolean } from '../common/viewUtils';
+import { getFormattedTimer, getTimerByType, isStringBoolean } from '../common/viewUtils';
 
 import './MinimalTimer.scss';
 
@@ -148,28 +146,11 @@ export default function MinimalTimer(props: MinimalTimerProps) {
   if (!timerIsTimeOfDay && showProgress && showDanger) timerColor = viewSettings.dangerColor;
 
   const stageTimer = getTimerByType(viewSettings.freezeEnd, time);
-  const fallback = userOptions.hideTimerSeconds ? timerPlaceholderMin : timerPlaceholder;
-  let display = millisToString(stageTimer, { fallback });
-  if (stageTimer !== null) {
-    if (hideTimerSeconds) {
-      display = removeSeconds(display);
-    }
-    display = removeLeadingZero(display);
+  const display = getFormattedTimer(stageTimer, time.timerType, getLocalizedString('common.minutes'), {
+    removeSeconds: userOptions.hideTimerSeconds,
+    removeLeadingZero: true,
+  });
 
-    if (display.length < 3) {
-      display = `${display} ${getLocalizedString('common.minutes')}`;
-    }
-
-    const isNegative =
-      (stageTimer ?? 0) < -MILLIS_PER_SECOND && !timerIsTimeOfDay && time.timerType !== TimerType.CountUp;
-    if (isNegative) {
-      // last unit rounds up in negative timers
-      if (display === '0') {
-        display = '1';
-      }
-      display = `-${display}`;
-    }
-  }
   const stageTimerCharacters = display.replace('/:/g', '').length;
 
   const timerFontSize = (89 / (stageTimerCharacters - 1)) * (userOptions.size || 1);

--- a/apps/client/src/features/viewers/timer/Timer.tsx
+++ b/apps/client/src/features/viewers/timer/Timer.tsx
@@ -10,7 +10,6 @@ import {
   TimerType,
   ViewSettings,
 } from 'ontime-types';
-import { MILLIS_PER_SECOND, millisToString, removeLeadingZero, removeSeconds } from 'ontime-utils';
 
 import { overrideStylesURL } from '../../../common/api/constants';
 import MultiPartProgressBar from '../../../common/components/multi-part-progress-bar/MultiPartProgressBar';
@@ -20,11 +19,10 @@ import ViewParamsEditor from '../../../common/components/view-params-editor/View
 import { useRuntimeStylesheet } from '../../../common/hooks/useRuntimeStylesheet';
 import { useWindowTitle } from '../../../common/hooks/useWindowTitle';
 import { ViewExtendedTimer } from '../../../common/models/TimeManager.type';
-import { timerPlaceholder, timerPlaceholderMin } from '../../../common/utils/styleUtils';
 import { formatTime, getDefaultFormat } from '../../../common/utils/time';
 import { useTranslation } from '../../../translation/TranslationProvider';
 import SuperscriptTime from '../common/superscript-time/SuperscriptTime';
-import { getPropertyValue, getTimerByType, isStringBoolean } from '../common/viewUtils';
+import { getFormattedTimer, getPropertyValue, getTimerByType, isStringBoolean } from '../common/viewUtils';
 
 import './Timer.scss';
 
@@ -126,27 +124,11 @@ export default function Timer(props: TimerProps) {
   if (!timerIsTimeOfDay && showProgress && showDanger) timerColor = viewSettings.dangerColor;
 
   const stageTimer = getTimerByType(viewSettings.freezeEnd, time);
-  const fallback = userOptions.hideTimerSeconds ? timerPlaceholderMin : timerPlaceholder;
-  let display = millisToString(stageTimer, { fallback });
-  if (stageTimer !== null) {
-    if (hideTimerSeconds) {
-      display = removeSeconds(display);
-    }
-    display = removeLeadingZero(display);
+  const display = getFormattedTimer(stageTimer, time.timerType, getLocalizedString('common.minutes'), {
+    removeSeconds: userOptions.hideTimerSeconds,
+    removeLeadingZero: true,
+  });
 
-    if (display.length < 3) {
-      display = `${display} ${getLocalizedString('common.minutes')}`;
-    }
-    const isNegative =
-      (stageTimer ?? 0) < -MILLIS_PER_SECOND && !timerIsTimeOfDay && time.timerType !== TimerType.CountUp;
-    if (isNegative) {
-      // last unit rounds up in negative timers
-      if (display === '0') {
-        display = '1';
-      }
-      display = `-${display}`;
-    }
-  }
   const stageTimerCharacters = display.replace('/:/g', '').length;
 
   const baseClasses = `stage-timer ${isMirrored ? 'mirror' : ''}`;

--- a/packages/utils/src/date-utils/timeFormatting.test.ts
+++ b/packages/utils/src/date-utils/timeFormatting.test.ts
@@ -1,6 +1,6 @@
 import { dayInMs } from '../timeConstants';
 import { MILLIS_PER_HOUR } from './conversionUtils';
-import { millisToString } from './timeFormatting';
+import { millisToString, removeLeadingZero } from './timeFormatting';
 
 describe('millisToString()', () => {
   it('returns fallback if millis is null', () => {
@@ -52,5 +52,12 @@ describe('millisToString()', () => {
     testScenarios.forEach((scenario) => {
       expect(millisToString(scenario.millis)).toBe(scenario.expected);
     });
+  });
+});
+
+describe('removeLeadingZero()', () => {
+  test('removes leading zero from timer', () => {
+    expect(removeLeadingZero('00:00:00')).toBe('0:00');
+    expect(removeLeadingZero('-00:08:47')).toBe('-8:47');
   });
 });

--- a/packages/utils/src/date-utils/timeFormatting.ts
+++ b/packages/utils/src/date-utils/timeFormatting.ts
@@ -26,7 +26,6 @@ export function millisToString(millis?: MaybeNumber, options?: FormatOptions): s
   const seconds = millisToSeconds(absoluteMillis) % 60;
   const minutes = millisToMinutes(absoluteMillis) % 60;
   const hours = millisToHours(absoluteMillis);
-
   const isNegative = millis < 0;
 
   return `${isNegative ? '-' : ''}${[hours, minutes, seconds].map(pad).join(':')}`;
@@ -44,10 +43,10 @@ export function removeLeadingZero(timer: string): string {
     return timer.slice(3);
   }
   if (timer.startsWith('-00:0')) {
-    return timer.slice(5);
+    return `-${timer.slice(5)}`;
   }
   if (timer.startsWith('-00:')) {
-    return timer.slice(4);
+    return `-${timer.slice(4)}`;
   }
   return timer;
 }


### PR DESCRIPTION
This PR fixes issues with how we display negative timers is handled in the `Timer` and `Minimal` views