### PR TITLE
Enforece type imports

### DIFF
--- a/packages/types/.eslintrc
+++ b/packages/types/.eslintrc
@@ -3,8 +3,14 @@
     "browser": true,
     "node": true
   },
+  "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "ecmaVersion": 2020,
     "sourceType": "module"
+  },
+  "plugins": ["simple-import-sort", "@typescript-eslint"],
+  "rules": {
+    "simple-import-sort/imports": "error",
+    "@typescript-eslint/consistent-type-imports": "error"
   }
 }

--- a/packages/types/src/api/ontime-controller/BackendResponse.type.ts
+++ b/packages/types/src/api/ontime-controller/BackendResponse.type.ts
@@ -1,4 +1,4 @@
-import { OSCSettings } from '../../definitions/core/OscSettings.type.js';
+import type { OSCSettings } from '../../definitions/core/OscSettings.type.js';
 
 export type NetworkInterface = {
   name: string;

--- a/packages/types/src/api/rundown-controller/BackendResponse.type.ts
+++ b/packages/types/src/api/rundown-controller/BackendResponse.type.ts
@@ -1,4 +1,4 @@
-import { OntimeRundownEntry } from '../../definitions/core/Rundown.type.js';
+import type { OntimeRundownEntry } from '../../definitions/core/Rundown.type.js';
 
 type EventId = string;
 export type NormalisedRundown = Record<EventId, OntimeRundownEntry>;

--- a/packages/types/src/definitions/DataModel.type.ts
+++ b/packages/types/src/definitions/DataModel.type.ts
@@ -1,8 +1,8 @@
-import {
+import type {
   CustomFields,
   HttpSettings,
-  OSCSettings,
   OntimeRundown,
+  OSCSettings,
   ProjectData,
   Settings,
   URLPreset,

--- a/packages/types/src/definitions/core/HttpSettings.type.ts
+++ b/packages/types/src/definitions/core/HttpSettings.type.ts
@@ -1,4 +1,4 @@
-import { TimerLifeCycleKey } from './TimerLifecycle.type.js';
+import type { TimerLifeCycleKey } from './TimerLifecycle.type.js';
 
 export type HttpSubscription = { id: string; cycle: TimerLifeCycleKey; message: string; enabled: boolean };
 

--- a/packages/types/src/definitions/core/OntimeEvent.type.ts
+++ b/packages/types/src/definitions/core/OntimeEvent.type.ts
@@ -1,4 +1,4 @@
-import { EventCustomFields, EndAction, MaybeString, TimerType, TimeStrategy } from '../../index.js';
+import type { EndAction, EventCustomFields, MaybeString, TimerType, TimeStrategy } from '../../index.js';
 
 export enum SupportedEvent {
   Event = 'event',

--- a/packages/types/src/definitions/core/OscSettings.type.ts
+++ b/packages/types/src/definitions/core/OscSettings.type.ts
@@ -1,4 +1,4 @@
-import { TimerLifeCycleKey } from './TimerLifecycle.type.js';
+import type { TimerLifeCycleKey } from './TimerLifecycle.type.js';
 
 export type OscSubscription = {
   id: string;

--- a/packages/types/src/definitions/core/Rundown.type.ts
+++ b/packages/types/src/definitions/core/Rundown.type.ts
@@ -1,4 +1,4 @@
-import { OntimeBlock, OntimeDelay, OntimeEvent } from './OntimeEvent.type.js';
+import type { OntimeBlock, OntimeDelay, OntimeEvent } from './OntimeEvent.type.js';
 
 export type OntimeRundownEntry = OntimeDelay | OntimeBlock | OntimeEvent;
 export type OntimeRundown = OntimeRundownEntry[];

--- a/packages/types/src/definitions/core/Settings.type.ts
+++ b/packages/types/src/definitions/core/Settings.type.ts
@@ -1,4 +1,4 @@
-import { TimeFormat } from './TimeFormat.type.js';
+import type { TimeFormat } from './TimeFormat.type.js';
 
 export type Settings = {
   app: 'ontime';

--- a/packages/types/src/definitions/runtime/Runtime.type.ts
+++ b/packages/types/src/definitions/runtime/Runtime.type.ts
@@ -1,4 +1,4 @@
-import { MaybeNumber } from '../../utils/utils.type.js';
+import type { MaybeNumber } from '../../utils/utils.type.js';
 
 export type Runtime = {
   numEvents: number;

--- a/packages/types/src/definitions/runtime/RuntimeStore.type.ts
+++ b/packages/types/src/definitions/runtime/RuntimeStore.type.ts
@@ -1,8 +1,8 @@
-import { MessageState } from './MessageControl.type.js';
-import { TimerState } from './TimerState.type.js';
-import { Runtime } from './Runtime.type.js';
-import { OntimeEvent } from '../core/OntimeEvent.type.js';
-import { SimpleTimerState } from './ExtraTimer.type.js';
+import type { OntimeEvent } from '../core/OntimeEvent.type.js';
+import type { SimpleTimerState } from './ExtraTimer.type.js';
+import type { MessageState } from './MessageControl.type.js';
+import type { Runtime } from './Runtime.type.js';
+import type { TimerState } from './TimerState.type.js';
 
 export type RuntimeStore = {
   // timer data

--- a/packages/types/src/definitions/runtime/TimerState.type.ts
+++ b/packages/types/src/definitions/runtime/TimerState.type.ts
@@ -1,5 +1,5 @@
-import { MaybeNumber } from '../../index.js';
-import { Playback } from './Playback.type.js';
+import type { MaybeNumber } from '../../index.js';
+import type { Playback } from './Playback.type.js';
 
 export type TimerState = {
   addedTime: number; // time added by user, can be negative

--- a/packages/types/src/utils/guards.ts
+++ b/packages/types/src/utils/guards.ts
@@ -1,6 +1,8 @@
-import { OntimeRundownEntry } from '../definitions/core/Rundown.type.js';
-import { OntimeBlock, OntimeDelay, OntimeEvent, SupportedEvent } from '../definitions/core/OntimeEvent.type.js';
-import { TimerLifeCycle, TimerLifeCycleKey } from '../definitions/core/TimerLifecycle.type.js';
+import type { OntimeBlock, OntimeDelay, OntimeEvent } from '../definitions/core/OntimeEvent.type.js';
+import { SupportedEvent } from '../definitions/core/OntimeEvent.type.js';
+import type { OntimeRundownEntry } from '../definitions/core/Rundown.type.js';
+import type { TimerLifeCycleKey } from '../definitions/core/TimerLifecycle.type.js';
+import { TimerLifeCycle } from '../definitions/core/TimerLifecycle.type.js';
 
 type MaybeEvent = OntimeRundownEntry | Partial<OntimeRundownEntry> | null | undefined;
 

--- a/packages/utils/.eslintrc
+++ b/packages/utils/.eslintrc
@@ -3,15 +3,14 @@
     "browser": true,
     "node": true
   },
-  "plugins": [
-    "simple-import-sort"
-  ],
+  "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "ecmaVersion": 2020,
     "sourceType": "module"
   },
+  "plugins": ["simple-import-sort", "@typescript-eslint"],
   "rules": {
-    "simple-import-sort/exports": "error",
-    "simple-import-sort/imports": "error"
+    "simple-import-sort/imports": "error",
+    "@typescript-eslint/consistent-type-imports": "error"
   }
 }

--- a/packages/utils/src/cue-utils/cueUtils.test.ts
+++ b/packages/utils/src/cue-utils/cueUtils.test.ts
@@ -1,4 +1,5 @@
-import { OntimeDelay, OntimeEvent, OntimeRundown, SupportedEvent } from 'ontime-types';
+import type { OntimeDelay, OntimeEvent, OntimeRundown } from 'ontime-types';
+import { SupportedEvent } from 'ontime-types';
 
 import { getCueCandidate, getIncrement, sanitiseCue } from './cueUtils.js';
 

--- a/packages/utils/src/cue-utils/cueUtils.ts
+++ b/packages/utils/src/cue-utils/cueUtils.ts
@@ -1,4 +1,5 @@
-import { isOntimeEvent, OntimeEvent, OntimeRundown, OntimeRundownEntry } from 'ontime-types';
+import type { OntimeEvent, OntimeRundown, OntimeRundownEntry } from 'ontime-types';
+import { isOntimeEvent } from 'ontime-types';
 
 import { getFirstEvent, getNextEvent, getPreviousEvent } from '../rundown-utils/rundownUtils.js';
 import { isNumeric } from '../types/types.js';
@@ -24,8 +25,8 @@ export function getIncrement(input: string): string {
       if (decimalPart === '.99') {
         decimalPart = '.100';
       } else {
-        const addDecimal = '0'.repeat(decimalPart.length - 2) + '1';
-        const incrementedDecimal = (Number(decimalPart) + Number('0.' + addDecimal)).toFixed(decimalPart.length - 1);
+        const addDecimal = `${'0'.repeat(decimalPart.length - 2)}1`;
+        const incrementedDecimal = (Number(decimalPart) + Number(`0.${addDecimal}`)).toFixed(decimalPart.length - 1);
         decimalPart = incrementedDecimal.toString().replace('0.', '.');
       }
       return `${prefix}${integerPart}${decimalPart}`;
@@ -35,7 +36,7 @@ export function getIncrement(input: string): string {
     return `${prefix}${integerPart}`;
   }
   // If no number is found, append "2" to the string and return the updated string
-  return input + '2';
+  return `${input}2`;
 }
 
 /**
@@ -84,7 +85,7 @@ export function getCueCandidate(rundown: OntimeRundown, insertAfterId?: string):
     if (previousEvent === null) {
       cue = '0.1';
     } else {
-      cue = previousEvent.cue + '.1';
+      cue = `${previousEvent.cue}.1`;
     }
   }
 

--- a/packages/utils/src/date-utils/timeFormatting.ts
+++ b/packages/utils/src/date-utils/timeFormatting.ts
@@ -1,5 +1,5 @@
 import { DateTime } from 'luxon';
-import { MaybeNumber } from 'ontime-types';
+import type { MaybeNumber } from 'ontime-types';
 
 import { millisToHours, millisToMinutes, millisToSeconds } from './conversionUtils.js';
 

--- a/packages/utils/src/rundown-utils/rundownUtils.test.ts
+++ b/packages/utils/src/rundown-utils/rundownUtils.test.ts
@@ -1,4 +1,5 @@
-import { OntimeEvent, OntimeRundown, SupportedEvent } from 'ontime-types';
+import type { OntimeEvent, OntimeRundown } from 'ontime-types';
+import { SupportedEvent } from 'ontime-types';
 
 import { getLastEvent, getNext, getNextEvent, getPrevious, getPreviousEvent, swapEventData } from './rundownUtils';
 

--- a/packages/utils/src/rundown-utils/rundownUtils.ts
+++ b/packages/utils/src/rundown-utils/rundownUtils.ts
@@ -1,4 +1,5 @@
-import { isOntimeEvent, NormalisedRundown, OntimeEvent, OntimeRundown, OntimeRundownEntry } from 'ontime-types';
+import type { NormalisedRundown, OntimeEvent, OntimeRundown, OntimeRundownEntry } from 'ontime-types';
+import { isOntimeEvent } from 'ontime-types';
 
 /**
  * Gets first event in rundown, if it exists

--- a/packages/utils/src/validate-events/validateEvent.ts
+++ b/packages/utils/src/validate-events/validateEvent.ts
@@ -1,4 +1,5 @@
-import { EndAction, MaybeString, TimerType, TimeStrategy } from 'ontime-types';
+import type { MaybeString } from 'ontime-types';
+import { EndAction, TimerType, TimeStrategy } from 'ontime-types';
 
 /**
  * Check if a given value is a valid type of string, returns null otherwise

--- a/packages/utils/src/validate-times/validateTimes.test.ts
+++ b/packages/utils/src/validate-times/validateTimes.test.ts
@@ -1,4 +1,5 @@
-import { OntimeEvent, TimeStrategy } from 'ontime-types';
+import type { OntimeEvent } from 'ontime-types';
+import { TimeStrategy } from 'ontime-types';
 
 import { dayInMs } from '../timeConstants';
 import { calculateDuration, getLinkedTimes, validateTimes } from './validateTimes';

--- a/packages/utils/src/validate-times/validateTimes.ts
+++ b/packages/utils/src/validate-times/validateTimes.ts
@@ -1,4 +1,5 @@
-import { OntimeEvent, TimeStrategy } from 'ontime-types';
+import type { OntimeEvent } from 'ontime-types';
+import { TimeStrategy } from 'ontime-types';
 
 import { dayInMs } from '../timeConstants.js';
 import { validateTimeStrategy } from '../validate-events/validateEvent.js';


### PR DESCRIPTION
adds `simple-import-sort/imports` and `@typescript-eslint/consistent-type-imports` to the type and utils packages
I think we will have to wait with adding it to server and client until after v3 or at least after beta

do we wan to add it for export as well?

https://typescript-eslint.io/blog/consistent-type-imports-and-exports-why-and-how/