### PR TITLE
make application menu aware of what port should be used in link items

### DIFF
--- a/apps/electron/electron.config.js
+++ b/apps/electron/electron.config.js
@@ -3,8 +3,8 @@ module.exports = {
     shutdownCode: 99,
   },
   reactAppUrl: {
-    development: (port = 4001) => `http://localhost:${port}/editor`,
-    production: (port = 4001) => `http://localhost:${port}/editor`,
+    development: (port = 4001) => `http://localhost:${port}`,
+    production: (port = 4001) => `http://localhost:${port}`,
   },
   server: {
     pathToEntrypoint: '../extraResources/server/index.cjs',

--- a/apps/electron/main.js
+++ b/apps/electron/main.js
@@ -1,6 +1,7 @@
 const { app, BrowserWindow, Menu, globalShortcut, Tray, dialog, ipcMain, shell, Notification } = require('electron');
 const path = require('path');
 const electronConfig = require('./electron.config');
+const { getApplicationMenu } = require('./src/menu/applicationMenu.js');
 
 const env = process.env.NODE_ENV || 'production';
 const isProduction = env === 'production';
@@ -162,8 +163,12 @@ app.whenReady().then(() => {
         ? electronConfig.reactAppUrl.production(port)
         : electronConfig.reactAppUrl.development(port);
 
+      const template = getApplicationMenu(isMac, askToQuit, clientUrl);
+      const menu = Menu.buildFromTemplate(template);
+      Menu.setApplicationMenu(menu);
+
       win
-        .loadURL(clientUrl)
+        .loadURL(`${clientUrl}/editor`)
         .then(() => {
           win.webContents.setBackgroundThrottling(false);
 
@@ -208,12 +213,10 @@ app.whenReady().then(() => {
   const trayMenuTemplate = getTrayMenu(bringToFront, askToQuit);
   const trayContextMenu = Menu.buildFromTemplate(trayMenuTemplate);
   tray.setContextMenu(trayContextMenu);
+
+  
 });
 
-const { getApplicationMenu } = require('./src/menu/applicationMenu.js');
-const template = getApplicationMenu(isMac, askToQuit);
-const menu = Menu.buildFromTemplate(template);
-Menu.setApplicationMenu(menu);
 
 // unregister shortcuts before quitting
 app.once('will-quit', () => {

--- a/apps/electron/src/menu/applicationMenu.js
+++ b/apps/electron/src/menu/applicationMenu.js
@@ -4,7 +4,7 @@ const { shell } = require('electron');
  * @param {boolean} isMac - Whether the target platform is mac
  * @param {function} askToQuit - function for quitting process
  */
-function getApplicationMenu(isMac, askToQuit) {
+function getApplicationMenu(isMac, askToQuit, urlBase) {
   return [
     ...(isMac
       ? [
@@ -63,68 +63,68 @@ function getApplicationMenu(isMac, askToQuit) {
               label: 'Timer',
               accelerator: 'CmdOrCtrl+V',
               click: async () => {
-                await shell.openExternal('http://localhost:4001/timer');
+                await shell.openExternal(`${urlBase}/timer`);
               },
             },
             {
               label: 'Clock',
               click: async () => {
-                await shell.openExternal('http://localhost:4001/clock');
+                await shell.openExternal(`${urlBase}/clock`);
               },
             },
             {
               label: 'Minimal Timer',
               click: async () => {
-                await shell.openExternal('http://localhost:4001/minimal');
+                await shell.openExternal(`${urlBase}/minimal`);
               },
             },
             {
               label: 'Backstage',
               click: async () => {
-                await shell.openExternal('http://localhost:4001/backstage');
+                await shell.openExternal(`${urlBase}/backstage`);
               },
             },
             {
               label: 'Public',
               click: async () => {
-                await shell.openExternal('http://localhost:4001/public');
+                await shell.openExternal(`${urlBase}/public`);
               },
             },
             {
               label: 'Lower Thirds',
               click: async () => {
-                await shell.openExternal('http://localhost:4001/lower');
+                await shell.openExternal(`${urlBase}/lower`);
               },
             },
             {
               label: 'Studio Clock',
               click: async () => {
-                await shell.openExternal('http://localhost:4001/studio');
+                await shell.openExternal(`${urlBase}/studio`);
               },
             },
             {
               label: 'Countdown',
               click: async () => {
-                await shell.openExternal('http://localhost:4001/countdown');
+                await shell.openExternal(`${urlBase}/countdown`);
               },
             },
             { type: 'separator' },
             {
               label: 'Editor',
               click: async () => {
-                await shell.openExternal('http://localhost:4001/editor');
+                await shell.openExternal(`${urlBase}/editor`);
               },
             },
             {
               label: 'Cuesheet',
               click: async () => {
-                await shell.openExternal('http://localhost:4001/cuesheet');
+                await shell.openExternal(`${urlBase}/cuesheet`);
               },
             },
             {
               label: 'Operator',
               click: async () => {
-                await shell.openExternal('http://localhost:4001/operator');
+                await shell.openExternal(`${urlBase}/operator`);
               },
             },
           ],


### PR DESCRIPTION
The links for the application menu are currently hardcoded and this PR addresses issue #871 so that the link for the application menu is related to the port that the backend is running on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the application menu to dynamically construct URLs based on environment settings.
- **Refactor**
	- Streamlined URL generation logic in the electron configuration.
	- Enhanced menu creation process in the main application script for better performance and flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->