### PR TITLE
refactor: rundown must be in order

### DIFF
--- a/apps/server/src/services/timerUtils.ts
+++ b/apps/server/src/services/timerUtils.ts
@@ -1,5 +1,5 @@
 import { MaybeNumber, MaybeString, OntimeEvent, TimerType } from 'ontime-types';
-import { dayInMs, sortArrayByProperty } from 'ontime-utils';
+import { dayInMs } from 'ontime-utils';
 import { RuntimeState } from '../stores/runtimeState.js';
 import { timerConfig } from '../config/config.js';
 
@@ -129,8 +129,7 @@ export const getRollTimers = (rundown: OntimeEvent[], timeNow: number): RollTime
   let timeToNext: number | null = null; // counter: time for next event
   let publicTimeToNext: number | null = null; // counter: time for next public event
 
-  const orderedEvents = sortArrayByProperty(rundown, 'timeStart');
-  const lastEvent = orderedEvents[orderedEvents.length - 1];
+  const lastEvent = rundown[rundown.length - 1];
   const lastNormalEnd = normaliseEndTime(lastEvent.timeStart, lastEvent.timeEnd);
 
   let nextEvent: OntimeEvent | null = null;
@@ -142,7 +141,7 @@ export const getRollTimers = (rundown: OntimeEvent[], timeNow: number): RollTime
     // we are past last end
     // preload first and find next
 
-    const firstEvent = orderedEvents[0];
+    const firstEvent = rundown[0];
     nextIndex = 0;
     nextEvent = firstEvent;
     timeToNext = firstEvent.timeStart + dayInMs - timeNow;
@@ -154,7 +153,7 @@ export const getRollTimers = (rundown: OntimeEvent[], timeNow: number): RollTime
       // look for next public
       // dev note: we feel that this is more efficient than filtering
       // since the next event will likely be close to the one playing
-      for (const event of orderedEvents) {
+      for (const event of rundown) {
         if (event.isPublic) {
           nextPublicEvent = event;
           // we need the index before this was sorted
@@ -169,7 +168,7 @@ export const getRollTimers = (rundown: OntimeEvent[], timeNow: number): RollTime
     // keep track of the end times when looking for public
     let publicTime = -1;
 
-    for (const event of orderedEvents) {
+    for (const event of rundown) {
       // When does the event end (handle midnight)
       const normalEnd = normaliseEndTime(event.timeStart, event.timeEnd);
 

--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -52,7 +52,7 @@ export { dayInMs, mts } from './src/timeConstants.js';
 export { deepmerge } from './src/externals/deepmerge.js';
 
 // array utils
-export { deleteAtIndex, insertAtIndex, reorderArray, sortArrayByProperty } from './src/array-utils/arrayUtils.js';
+export { deleteAtIndex, insertAtIndex, reorderArray } from './src/array-utils/arrayUtils.js';
 
 // generic utilities
 export { getErrorMessage } from './src/generic/generic.js';

--- a/packages/utils/src/array-utils/arrayUtils.test.ts
+++ b/packages/utils/src/array-utils/arrayUtils.test.ts
@@ -1,4 +1,4 @@
-import { insertAtIndex, reorderArray, sortArrayByProperty } from './arrayUtils.js';
+import { insertAtIndex, reorderArray } from './arrayUtils.js';
 
 describe('insertAtIndex', () => {
   it('should insert an item at the beginning of the array', () => {
@@ -50,39 +50,5 @@ describe('reorderArray', () => {
     const array = ['a', 'b', 'c'];
     const result = reorderArray(array, 0, 2);
     expect(result).toEqual(['b', 'c', 'a']);
-  });
-});
-
-describe('sortArrayByProperty()', () => {
-  it('sort array 1-5', () => {
-    const arr1 = [{ timeStart: 1 }, { timeStart: 5 }, { timeStart: 3 }, { timeStart: 2 }, { timeStart: 4 }];
-
-    const arr1Expected = [{ timeStart: 1 }, { timeStart: 2 }, { timeStart: 3 }, { timeStart: 4 }, { timeStart: 5 }];
-
-    const sorted = sortArrayByProperty(arr1, 'timeStart');
-    expect(sorted).toStrictEqual(arr1Expected);
-  });
-
-  it('sort array 1-5 with null', () => {
-    const arr1 = [
-      { timeStart: 1 },
-      { timeStart: 5 },
-      { timeStart: 3 },
-      { timeStart: 2 },
-      { timeStart: 4 },
-      { timeStart: null },
-    ];
-
-    const arr1Expected = [
-      { timeStart: null },
-      { timeStart: 1 },
-      { timeStart: 2 },
-      { timeStart: 3 },
-      { timeStart: 4 },
-      { timeStart: 5 },
-    ];
-
-    const sorted = sortArrayByProperty(arr1, 'timeStart');
-    expect(sorted).toStrictEqual(arr1Expected);
   });
 });

--- a/packages/utils/src/array-utils/arrayUtils.ts
+++ b/packages/utils/src/array-utils/arrayUtils.ts
@@ -48,18 +48,3 @@ export function reorderArray<T>(array: T[], fromIndex: number, toIndex: number) 
   modifiedArray.splice(toIndex, 0, reorderedItem);
   return modifiedArray;
 }
-
-/**
- * @description Sorts an array of objects by given property
- * @param {array} arr - array to be sorted
- * @param {string} property - property to compare
- * @returns {array} copy of array sorted in ascending order
- */
-
-export const sortArrayByProperty = <T>(arr: T[], property: string): T[] => {
-  return [...arr].sort((a, b) => {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore -- its ok
-    return a[property] - b[property];
-  });
-};


### PR DESCRIPTION
This PR scope is to cleanup logic behind Roll
This is an important feature of Ontime I would like to improve it in the future

Currently, the feature is complex to maintain due to the fact that it can resolve a rundown out of order.
While this is nice for the user, I believe the best way forwards is to expect that the order is correct