### PR TITLE
Custom fields cleanup

### DIFF
--- a/apps/server/src/api-integration/integration.controller.ts
+++ b/apps/server/src/api-integration/integration.controller.ts
@@ -46,7 +46,8 @@ const actionHandlers: Record<string, ActionHandler> = {
       if (typeof property !== 'string' || value === undefined) {
         throw new Error('Invalid property or value');
       }
-      const newObjectProperty = parseProperty(property, value);
+      // all custom fields keys are lowercase
+      const newObjectProperty = parseProperty(property.toLowerCase(), value);
 
       if (patchEvent.custom && newObjectProperty.custom) {
         Object.assign(patchEvent.custom, newObjectProperty.custom);

--- a/apps/server/src/api-integration/integration.utils.ts
+++ b/apps/server/src/api-integration/integration.utils.ts
@@ -27,7 +27,7 @@ export function parseProperty(property: string, value: unknown) {
       throw new Error(`Custom field ${customKey} not found`);
     }
     const parserFn = whitelistedPayload.custom;
-    return { custom: { [customKey]: { value: parserFn(value) } } };
+    return { custom: { [customKey]: parserFn(value) } };
   }
 
   if (!isKeyOfType(property, whitelistedPayload)) {

--- a/apps/server/src/utils/parserFunctions.ts
+++ b/apps/server/src/utils/parserFunctions.ts
@@ -259,7 +259,8 @@ export const parseCustomFields = (data: Partial<DatabaseModel>): CustomFields =>
       console.log('ERROR: missing required field, skipping');
       continue;
     }
-    newCustomFields[field.label] = {
+    const key = field.label.toLowerCase();
+    newCustomFields[key] = {
       type: field.type,
       colour: field.colour,
       label: field.label,


### PR DESCRIPTION
This PR fixes the issues with the custom fields receiving an object

It seems that it was due to the removal of the nested {value: <string>} which wasnt done in the changes payload parser

It also fixes an issue where the custom fields are rebuilt on startup without forcing the key to be lower case