### PR TITLE
fix: state stale in integrations

### DIFF
--- a/apps/server/src/services/integration-service/IntegrationService.ts
+++ b/apps/server/src/services/integration-service/IntegrationService.ts
@@ -1,7 +1,7 @@
 import { LogOrigin } from 'ontime-types';
 
 import IIntegration, { TimerLifeCycleKey } from './IIntegration.js';
-import { eventStore } from '../../stores/EventStore.js';
+import { getState } from '../../stores/runtimeState.js';
 import { logger } from '../../classes/Logger.js';
 
 class IntegrationService {
@@ -20,7 +20,14 @@ class IntegrationService {
   }
 
   dispatch(action: TimerLifeCycleKey) {
-    const state = eventStore.poll();
+    /**
+     * We currently get the state from the runtimeState store
+     * This solves an issue where the state is not updated until after the integrations have ran
+     * The workaround solves the issue with the tradeoff of
+     * - we do not have access to data outside runtimeState (eg: messages or auxtimers)
+     * - we couple the integrationService to runtimeState
+     */
+    const state = getState();
     this.integrations.forEach((integration) => {
       integration.dispatch(action, state);
     });

--- a/apps/server/src/services/runtime-service/RuntimeService.ts
+++ b/apps/server/src/services/runtime-service/RuntimeService.ts
@@ -196,6 +196,8 @@ class RuntimeService {
     const success = runtimeState.load(event, timedEvents);
 
     if (success) {
+      // TODO: dispatch should happen after store update
+      // currently store update is handled in TimerService only
       integrationService.dispatch(TimerLifeCycle.onLoad);
       logger.info(LogOrigin.Playback, `Loaded event with ID ${event.id}`);
     }


### PR DESCRIPTION
Fixes the identified issue with stale data in integrations

The tradeoffs are outlined in the code
- we do not have access to data outside runtimeState (eg: messages or auxtimers)
- we couple the integrationService to runtimeState

I feel this is not ideal, but dont want to hold off the release. I think a real fix would involve some re-writing of state management and event scheduling