### PR TITLE
Fix: custom fields with undefined colour is not accepted by `parseCustomFields`

### DIFF
--- a/apps/server/src/utils/__tests__/parserFunctions.test.ts
+++ b/apps/server/src/utils/__tests__/parserFunctions.test.ts
@@ -87,13 +87,16 @@ describe('sanitiseCustomFields()', () => {
     expect(sanitationResult).toStrictEqual(customFields);
   });
 
-  it('type must match', () => {
+  it('type is forced to be string', () => {
     const customFields: CustomFields = {
       // @ts-expect-error intentional bad data
       test: { label: 'test', type: 'another', colour: 'red' },
     };
+    const expectedCustomFields: CustomFields = {
+      test: { label: 'test', type: 'string', colour: 'red' },
+    };
     const sanitationResult = sanitiseCustomFields(customFields);
-    expect(sanitationResult).toStrictEqual({});
+    expect(sanitationResult).toStrictEqual(expectedCustomFields);
   });
 
   it('colour must be a string', () => {
@@ -125,12 +128,15 @@ describe('sanitiseCustomFields()', () => {
     expect(sanitationResult).toStrictEqual(expectedCustomFields);
   });
 
-  it('enforece name coheation', () => {
+  it('enforece name cohesion', () => {
     const customFields: CustomFields = {
-      test: { label: 'different name', type: 'string', colour: 'red' },
+      test: { label: 'New Name', type: 'string', colour: 'red' },
+    };
+    const expectedCustomFields: CustomFields = {
+      ['new name']: { label: 'New Name', type: 'string', colour: 'red' },
     };
     const sanitationResult = sanitiseCustomFields(customFields);
-    expect(sanitationResult).toStrictEqual({});
+    expect(sanitationResult).toStrictEqual(expectedCustomFields);
   });
 
   it('filters invalid entries', () => {

--- a/apps/server/src/utils/__tests__/parserFunctions.test.ts
+++ b/apps/server/src/utils/__tests__/parserFunctions.test.ts
@@ -1,5 +1,5 @@
-import { HttpSubscription, OscSubscription } from 'ontime-types';
-import { sanitiseHttpSubscriptions, sanitiseOscSubscriptions } from '../parserFunctions.js';
+import { CustomFields, HttpSubscription, OscSubscription } from 'ontime-types';
+import { sanitiseCustomFields, sanitiseHttpSubscriptions, sanitiseOscSubscriptions } from '../parserFunctions.js';
 
 describe('sanitiseOscSubscriptions()', () => {
   it('returns an empty array if not an array', () => {
@@ -69,5 +69,83 @@ describe('sanitiseHttpSubscriptions()', () => {
     ];
     const sanitationResult = sanitiseHttpSubscriptions(httpSubscription as HttpSubscription[]);
     expect(sanitationResult.length).toBe(0);
+  });
+});
+
+describe('sanitiseCustomFields()', () => {
+  it('returns an empty array if not an array', () => {
+    expect(sanitiseCustomFields({})).toEqual({});
+  });
+
+  it('returns an object of valid entries', () => {
+    const customFields: CustomFields = {
+      test: { label: 'test', type: 'string', colour: 'red' },
+      test2: { label: 'test2', type: 'string', colour: 'green' },
+      test3: { label: 'Test3', type: 'string', colour: '' },
+    };
+    const sanitationResult = sanitiseCustomFields(customFields);
+    expect(sanitationResult).toStrictEqual(customFields);
+  });
+
+  it('type must match', () => {
+    const customFields: CustomFields = {
+      // @ts-expect-error intentional bad data
+      test: { label: 'test', type: 'another', colour: 'red' },
+    };
+    const sanitationResult = sanitiseCustomFields(customFields);
+    expect(sanitationResult).toStrictEqual({});
+  });
+
+  it('colour must be a string', () => {
+    const customFields: CustomFields = {
+      // @ts-expect-error intentional bad data
+      test: { label: 'test', type: 'string', colour: 5 },
+    };
+    const sanitationResult = sanitiseCustomFields(customFields);
+    expect(sanitationResult).toStrictEqual({});
+  });
+
+  it('label can not be empty', () => {
+    const customFields: CustomFields = {
+      ['']: { label: '', type: 'string', colour: 'red' },
+    };
+    const sanitationResult = sanitiseCustomFields(customFields);
+    expect(sanitationResult).toStrictEqual({});
+  });
+
+  it('remove extra stuff', () => {
+    const customFields: CustomFields = {
+      // @ts-expect-error intentional bad data
+      test: { label: 'test', type: 'string', colour: 'red', extra: 'should be removed' },
+    };
+    const expectedCustomFields: CustomFields = {
+      test: { label: 'test', type: 'string', colour: 'red' },
+    };
+    const sanitationResult = sanitiseCustomFields(customFields);
+    expect(sanitationResult).toStrictEqual(expectedCustomFields);
+  });
+
+  it('enforece name coheation', () => {
+    const customFields: CustomFields = {
+      test: { label: 'different name', type: 'string', colour: 'red' },
+    };
+    const sanitationResult = sanitiseCustomFields(customFields);
+    expect(sanitationResult).toStrictEqual({});
+  });
+
+  it('filters invalid entries', () => {
+    const customFields: CustomFields = {
+      test: { label: 'test', type: 'string', colour: 'red' },
+      test2: { label: 'test2', type: 'string', colour: 'green' },
+      bad: { label: '', type: 'string', colour: '' },
+      test3: { label: 'Test3', type: 'string', colour: '' },
+    };
+    const expectedCustomFields: CustomFields = {
+      test: { label: 'test', type: 'string', colour: 'red' },
+      test2: { label: 'test2', type: 'string', colour: 'green' },
+      test3: { label: 'Test3', type: 'string', colour: '' },
+    };
+    const sanitationResult = sanitiseCustomFields(customFields);
+    expect(sanitationResult).toStrictEqual(expectedCustomFields);
   });
 });

--- a/apps/server/src/utils/parserFunctions.ts
+++ b/apps/server/src/utils/parserFunctions.ts
@@ -248,17 +248,40 @@ export const parseCustomFields = (data: Partial<DatabaseModel>): CustomFields =>
   if (typeof data.customFields !== 'object') {
     return { ...dbModel.customFields };
   }
-
   console.log('Found Custom Fields, importing...');
 
+  return sanitiseCustomFields(data.customFields);
+};
+
+export const sanitiseCustomFields = (data: object): CustomFields => {
   const newCustomFields: CustomFields = {};
 
-  for (const fieldLabel in data.customFields) {
-    const field = data.customFields[fieldLabel];
+  for (const fieldLabel in data) {
+    const field = data[fieldLabel];
     if (!('label' in field) || !('type' in field) || !('colour' in field)) {
       console.log('ERROR: missing required field, skipping');
       continue;
     }
+    if (typeof field.label != 'string' || typeof field.type != 'string' || typeof field.colour != 'string') {
+      console.log('ERROR: incorrect field type, skipping');
+      continue;
+    }
+
+    if (fieldLabel != field.label.toLowerCase()) {
+      console.log('ERROR: label and id musth match, skipping');
+      continue;
+    }
+
+    if (fieldLabel == '') {
+      console.log('ERROR: label must not be empty, skipping');
+      continue;
+    }
+
+    if (field.type != 'string') {
+      console.log('ERROR: incorrect field type, skipping');
+      continue;
+    }
+
     const key = field.label.toLowerCase();
     newCustomFields[key] = {
       type: field.type,

--- a/apps/server/src/utils/parserFunctions.ts
+++ b/apps/server/src/utils/parserFunctions.ts
@@ -258,33 +258,14 @@ export const sanitiseCustomFields = (data: object): CustomFields => {
 
   for (const fieldLabel in data) {
     const field = data[fieldLabel];
-    if (!('label' in field) || !('type' in field) || !('colour' in field)) {
+    if (!('label' in field) || field.label === '' || !('colour' in field) || typeof field.colour != 'string') {
       console.log('ERROR: missing required field, skipping');
-      continue;
-    }
-    if (typeof field.label != 'string' || typeof field.type != 'string' || typeof field.colour != 'string') {
-      console.log('ERROR: incorrect field type, skipping');
-      continue;
-    }
-
-    if (fieldLabel != field.label.toLowerCase()) {
-      console.log('ERROR: label and id musth match, skipping');
-      continue;
-    }
-
-    if (fieldLabel == '') {
-      console.log('ERROR: label must not be empty, skipping');
-      continue;
-    }
-
-    if (field.type != 'string') {
-      console.log('ERROR: incorrect field type, skipping');
       continue;
     }
 
     const key = field.label.toLowerCase();
     newCustomFields[key] = {
-      type: field.type,
+      type: 'string',
       colour: field.colour,
       label: field.label,
     };

--- a/apps/server/src/utils/parserFunctions.ts
+++ b/apps/server/src/utils/parserFunctions.ts
@@ -255,7 +255,7 @@ export const parseCustomFields = (data: Partial<DatabaseModel>): CustomFields =>
 
   for (const fieldLabel in data.customFields) {
     const field = data.customFields[fieldLabel];
-    if (!field.label || !field.type || !field.colour) {
+    if (!('label' in field) || !('type' in field) || !('colour' in field)) {
       console.log('ERROR: missing required field, skipping');
       continue;
     }


### PR DESCRIPTION
solves #927