### PR TITLE
refactor: improve payload type

### DIFF
--- a/apps/client/src/common/utils/regex.ts
+++ b/apps/client/src/common/utils/regex.ts
@@ -9,4 +9,5 @@ export const startsWithHttp = /^http:\/\//;
 export const startsWithSlash = /^\//;
 export const isAlphanumeric = /^[a-z0-9]+$/i;
 export const isASCII = /^[ -~]+$/; //https://catonmat.net/my-favorite-regex
+export const isASCIIorEmpty = /^$|^[ -~]+$/; //https://catonmat.net/my-favorite-regex
 export const isNotEmpty = /\S/;

--- a/apps/client/src/features/app-settings/panel/integrations-panel/OscIntegrations.tsx
+++ b/apps/client/src/features/app-settings/panel/integrations-panel/OscIntegrations.tsx
@@ -221,7 +221,7 @@ export default function OscIntegrations() {
                 <th>Enabled</th>
                 <th>Cycle</th>
                 <th className={style.halfWidth}>Address</th>
-                <th className={style.halfWidth}>Payload</th>
+                <th className={style.halfWidth}>Arguments</th>
                 <th />
               </tr>
             </thead>
@@ -277,7 +277,7 @@ export default function OscIntegrations() {
                         {...register(`subscriptions.${index}.payload`, {
                           validate: {
                             oscStringIsAscii: (value) =>
-                              isASCIIorEmpty.test(value) || 'OSC payloads only allow ASCII characters',
+                              isASCIIorEmpty.test(value) || 'OSC arguments only allow ASCII characters',
                           },
                         })}
                       />

--- a/apps/client/src/features/app-settings/panel/integrations-panel/OscIntegrations.tsx
+++ b/apps/client/src/features/app-settings/panel/integrations-panel/OscIntegrations.tsx
@@ -8,7 +8,7 @@ import { generateId } from 'ontime-utils';
 import { maybeAxiosError } from '../../../../common/api/utils';
 import useOscSettings, { useOscSettingsMutation } from '../../../../common/hooks-query/useOscSettings';
 import { isKeyEscape } from '../../../../common/utils/keyEvent';
-import { isASCII, isIPAddress, isOnlyNumbers, startsWithSlash } from '../../../../common/utils/regex';
+import { isASCII, isASCIIorEmpty, isIPAddress, isOnlyNumbers, startsWithSlash } from '../../../../common/utils/regex';
 import * as Panel from '../PanelUtils';
 
 import { cycles } from './integrationUtils';
@@ -277,7 +277,7 @@ export default function OscIntegrations() {
                         {...register(`subscriptions.${index}.payload`, {
                           validate: {
                             oscStringIsAscii: (value) =>
-                              isASCII.test(value) || 'OSC payloads only allow ASCII characters',
+                              isASCIIorEmpty.test(value) || 'OSC payloads only allow ASCII characters',
                           },
                         })}
                       />

--- a/apps/server/src/services/integration-service/OscIntegration.ts
+++ b/apps/server/src/services/integration-service/OscIntegration.ts
@@ -110,7 +110,7 @@ export class OscIntegration implements IIntegration<OscSubscription, OSCSettings
     }
   }
 
-  private stringToOSCArgs(argsString): ArgumentType[] {
+  private stringToOSCArgs(argsString: string): ArgumentType[] {
 
     // NOTE: regex taken from https://stackoverflow.com/questions/4031900/split-a-string-by-whitespace-keeping-quoted-segments-allowing-escaped-quotes
     const parseRegex = /[\w.]+|"(?:\\"|[^"])+"/g;

--- a/apps/server/src/services/integration-service/OscIntegration.ts
+++ b/apps/server/src/services/integration-service/OscIntegration.ts
@@ -111,17 +111,16 @@ export class OscIntegration implements IIntegration<OscSubscription, OSCSettings
   }
 
   private stringToOSCArgs(argsString: string): ArgumentType[] {
-
     // NOTE: regex taken from https://stackoverflow.com/questions/4031900/split-a-string-by-whitespace-keeping-quoted-segments-allowing-escaped-quotes
     const parseRegex = /[\w.]+|"(?:\\"|[^"])+"/g;
 
     const matches = argsString.match(parseRegex);
 
-    const parsedArguments = []
+    const parsedArguments = [];
 
-    if(!matches){
-      parsedArguments.push({type: 's', value: argsString})
-      return parsedArguments 
+    if (!matches) {
+      parsedArguments.push({ type: 's', value: argsString });
+      return parsedArguments;
     }
 
     matches.forEach((argString: string) => {

--- a/apps/server/src/services/integration-service/OscIntegration.ts
+++ b/apps/server/src/services/integration-service/OscIntegration.ts
@@ -111,10 +111,12 @@ export class OscIntegration implements IIntegration<OscSubscription, OSCSettings
     }
   }
 
-  private stringToOSCArgs(argsString: string): ArgumentType[] {
-    const matches = splitWhitespace(argsString);
-
+  private stringToOSCArgs(argsString: string | undefined): ArgumentType[] {
     const parsedArguments = new Array<ArgumentType>();
+    if (typeof argsString === 'undefined') {
+      return parsedArguments;
+    }
+    const matches = splitWhitespace(argsString);
 
     if (!matches) {
       parsedArguments.push({ type: 's', value: argsString });

--- a/apps/server/src/services/integration-service/OscIntegration.ts
+++ b/apps/server/src/services/integration-service/OscIntegration.ts
@@ -70,15 +70,13 @@ export class OscIntegration implements IIntegration<OscSubscription, OSCSettings
     }
   }
 
-  emit(address: string, args?: ArgumentType[]) {
+  emit(address: string, args: ArgumentType[]) {
     if (!this.oscClient) {
       return;
     }
 
     const message = new Message(address);
-    if (args) {
-      message.append(args);
-    }
+    message.append(args);
 
     this.oscClient.send(message);
   }
@@ -112,37 +110,26 @@ export class OscIntegration implements IIntegration<OscSubscription, OSCSettings
   }
 
   private stringToOSCArgs(argsString: string | undefined): ArgumentType[] {
-    const parsedArguments = new Array<ArgumentType>();
     if (typeof argsString === 'undefined') {
-      return parsedArguments;
+      return new Array<ArgumentType>();
     }
     const matches = splitWhitespace(argsString);
 
-    if (!matches) {
-      parsedArguments.push({ type: 's', value: argsString });
-      return parsedArguments;
-    }
-
-    matches.forEach((argString: string) => {
-      const argAsNum = Number(argString);
-
-      let argType: 'i' | 'f' | 's' = 's';
-      let argValue: string | number = argString;
-
-      // NOTE: number like: 1 2.0 33333
-      if (!Number.isNaN(argAsNum)) {
-        argValue = argAsNum;
-        argType = argString.includes('.') ? 'f' : 'i';
-      } else if (argString.startsWith('"') && argString.endsWith('"')) {
-        // NOTE: "quoted string"
-        argValue = argString.substring(1, argString.length - 1).replaceAll('\\"', '"');
+    const parsedArguments = matches.map((argString: string) => {
+      const maybeNumber = Number(argString);
+      if (!Number.isNaN(maybeNumber)) {
+        //NOTE: number like: 1 2.0 33333
+        return maybeNumber;
       }
 
-      parsedArguments.push({
-        type: argType,
-        value: argValue,
-      });
+      if (argString.startsWith('"') && argString.endsWith('"')) {
+        // NOTE: "quoted string" or "1234"
+        return argString.substring(1, argString.length - 1);
+      }
+
+      return argString;
     });
+
     return parsedArguments;
   }
 

--- a/apps/server/src/services/integration-service/OscIntegration.ts
+++ b/apps/server/src/services/integration-service/OscIntegration.ts
@@ -59,7 +59,14 @@ export class OscIntegration implements IIntegration<OscSubscription, OSCSettings
         continue;
       }
       const parsedAddress = parseTemplateNested(address, state || {});
-      const parsedPayload = payload ? parseTemplateNested(payload, state || {}) : undefined;
+      let parsedPayload = payload ? parseTemplateNested(payload, state || {}) : undefined;
+
+      try {
+        const maybePayload = JSON.parse(parsedPayload);
+        parsedPayload = maybePayload;
+      } catch (_) {
+        /* we dont handle errors */
+      }
       try {
         this.emit(parsedAddress, parsedPayload);
       } catch (error) {

--- a/apps/server/src/services/integration-service/OscIntegration.ts
+++ b/apps/server/src/services/integration-service/OscIntegration.ts
@@ -5,6 +5,7 @@ import IIntegration, { TimerLifeCycleKey } from './IIntegration.js';
 import { parseTemplateNested } from './integrationUtils.js';
 import { logger } from '../../classes/Logger.js';
 import { OscServer } from '../../adapters/OscAdapter.js';
+import { splitWhitespace } from 'ontime-utils';
 
 /**
  * @description Class contains logic towards outgoing OSC communications
@@ -111,12 +112,9 @@ export class OscIntegration implements IIntegration<OscSubscription, OSCSettings
   }
 
   private stringToOSCArgs(argsString: string): ArgumentType[] {
-    // NOTE: regex taken from https://stackoverflow.com/questions/4031900/split-a-string-by-whitespace-keeping-quoted-segments-allowing-escaped-quotes
-    const parseRegex = /[\w.]+|"(?:\\"|[^"])+"/g;
+    const matches = splitWhitespace(argsString);
 
-    const matches = argsString.match(parseRegex);
-
-    const parsedArguments = [];
+    const parsedArguments = new Array<ArgumentType>();
 
     if (!matches) {
       parsedArguments.push({ type: 's', value: argsString });

--- a/apps/server/src/services/integration-service/OscIntegration.ts
+++ b/apps/server/src/services/integration-service/OscIntegration.ts
@@ -59,7 +59,6 @@ export class OscIntegration implements IIntegration<OscSubscription, OSCSettings
       }
       const parsedAddress = parseTemplateNested(address, state || {});
       const parsedPayload = payload ? parseTemplateNested(payload, state || {}) : undefined;
-
       const parsedArguments = this.stringToOSCArgs(parsedPayload);
 
       try {
@@ -114,7 +113,7 @@ export class OscIntegration implements IIntegration<OscSubscription, OSCSettings
   private stringToOSCArgs(argsString): ArgumentType[] {
 
     // NOTE: regex taken from https://stackoverflow.com/questions/4031900/split-a-string-by-whitespace-keeping-quoted-segments-allowing-escaped-quotes
-    const parseRegex = /\w+|"(?:\\"|[^"])+"/g;
+    const parseRegex = /[\w.]+|"(?:\\"|[^"])+"/g;
 
     const parsedArguments = argsString.match(parseRegex).map((argString: string) => {
       const argAsNum = Number(argString);

--- a/apps/server/src/services/integration-service/OscIntegration.ts
+++ b/apps/server/src/services/integration-service/OscIntegration.ts
@@ -134,10 +134,8 @@ export class OscIntegration implements IIntegration<OscSubscription, OSCSettings
       if (!Number.isNaN(argAsNum)) {
         argValue = argAsNum;
         argType = argString.includes('.') ? 'f' : 'i';
-      }
-
-      // NOTE: "quoted string"
-      if (argString.startsWith('"') && argString.endsWith('"')) {
+      } else if (argString.startsWith('"') && argString.endsWith('"')) {
+        // NOTE: "quoted string"
         argValue = argString.substring(1, argString.length - 1).replaceAll('\\"', '"');
       }
 

--- a/apps/server/src/services/integration-service/OscIntegration.ts
+++ b/apps/server/src/services/integration-service/OscIntegration.ts
@@ -115,35 +115,36 @@ export class OscIntegration implements IIntegration<OscSubscription, OSCSettings
     // NOTE: regex taken from https://stackoverflow.com/questions/4031900/split-a-string-by-whitespace-keeping-quoted-segments-allowing-escaped-quotes
     const parseRegex = /[\w.]+|"(?:\\"|[^"])+"/g;
 
-    const parsedArguments = argsString.match(parseRegex).map((argString: string) => {
+    const matches = argsString.match(parseRegex);
+
+    const parsedArguments = []
+
+    if(!matches){
+      parsedArguments.push({type: 's', value: argsString})
+      return parsedArguments 
+    }
+
+    matches.forEach((argString: string) => {
       const argAsNum = Number(argString);
+
+      let argType: 'i' | 'f' | 's' = 's';
+      let argValue: string | number = argString;
 
       // NOTE: number like: 1 2.0 33333
       if (!Number.isNaN(argAsNum)) {
-        if (argString.includes('.')) {
-          return {
-            type: 'f',
-            value: argAsNum,
-          };
-        } else {
-          return {
-            type: 'i',
-            value: argAsNum,
-          };
-        }
+        argValue = argAsNum;
+        argType = argString.includes('.') ? 'f' : 'i';
       }
 
+      // NOTE: "quoted string"
       if (argString.startsWith('"') && argString.endsWith('"')) {
-        // NOTE: "quoted string"
-        return {
-          type: 's',
-          value: argString.substring(1, argString.length - 1).replaceAll('\\"', '"'),
-        };
+        argValue = argString.substring(1, argString.length - 1).replaceAll('\\"', '"');
       }
-      return {
-        type: 's',
-        value: argString,
-      };
+
+      parsedArguments.push({
+        type: argType,
+        value: argValue,
+      });
     });
     return parsedArguments;
   }

--- a/apps/server/src/services/integration-service/integrationUtils.test.ts
+++ b/apps/server/src/services/integration-service/integrationUtils.test.ts
@@ -1,3 +1,4 @@
+import { stringToOSCArgs } from '../../utils/oscArgParser.js';
 import { parseTemplateNested } from './integrationUtils.js';
 
 describe('parseTemplateNested()', () => {
@@ -94,5 +95,63 @@ describe('parseNestedTemplate() -> resolveAliasData()', () => {
 
     const easyParse = parseTemplateNested('{{other.value}} to {{human.easy}} {{human.not.found}}', data, aliases);
     expect(easyParse).toBe('5 to testing-3 {{human.not.found}}');
+  });
+});
+
+describe('parseNestedTemplate() -> stringToOSCArgs()', () => {
+  it('specific osc requirements', () => {
+    const data = {
+      not: {
+        so: {
+          easy: 'data with space',
+          empty: '',
+          number: 1234,
+          stringNumber: '1234',
+        },
+      },
+    };
+
+    const payloads = [
+      {
+        test: '"string with space and {{not.so.easy}}"',
+        expect: [{ type: 'string', value: 'string with space and data with space' }],
+      },
+      {
+        test: '"string with space and {{not.so.empty}}"',
+        expect: [{ type: 'string', value: 'string with space and ' }],
+      },
+      {
+        test: '"string with space and {{not.so.number}}"',
+        expect: [{ type: 'string', value: 'string with space and 1234' }],
+      },
+      {
+        test: '"string with space and {{not.so.stringNumber}}"',
+        expect: [{ type: 'string', value: 'string with space and 1234' }],
+      },
+      {
+        test: '"{{not.so.easy}}" 1',
+        expect: [
+          { type: 'string', value: 'data with space' },
+          { type: 'integer', value: 1 },
+        ],
+      },
+      {
+        test: '"{{not.so.empty}}" 1',
+        expect: [
+          { type: 'string', value: '' },
+          { type: 'integer', value: 1 },
+        ],
+      },
+      {
+        test: '',
+        expect: [],
+      },
+    ];
+
+    payloads.forEach((payload) => {
+      const parsedPayload = parseTemplateNested(payload.test, data);
+      const parsedArguments = stringToOSCArgs(parsedPayload);
+      expect(parsedArguments).toStrictEqual(payload.expect);
+    });
   });
 });

--- a/apps/server/src/utils/__tests__/oscArgParser.test.ts
+++ b/apps/server/src/utils/__tests__/oscArgParser.test.ts
@@ -4,9 +4,9 @@ describe('test stringToOSCArgs()', () => {
   it('all types', () => {
     const test = 'test 1111 0.1111 TRUE FALSE';
     const expected = [
-      { type: 's', value: 'test' },
-      { type: 'i', value: 1111 },
-      { type: 'f', value: 0.1111 },
+      { type: 'string', value: 'test' },
+      { type: 'integer', value: 1111 },
+      { type: 'float', value: 0.1111 },
       { type: 'T', value: true },
       { type: 'F', value: false },
     ];
@@ -16,11 +16,11 @@ describe('test stringToOSCArgs()', () => {
   it('keep other types in strings', () => {
     const test = 'test "1111" "0.1111" "TRUE" "FALSE"';
     const expected = [
-      { type: 's', value: 'test' },
-      { type: 's', value: '1111' },
-      { type: 's', value: '0.1111' },
-      { type: 's', value: 'TRUE' },
-      { type: 's', value: 'FALSE' },
+      { type: 'string', value: 'test' },
+      { type: 'string', value: '1111' },
+      { type: 'string', value: '0.1111' },
+      { type: 'string', value: 'TRUE' },
+      { type: 'string', value: 'FALSE' },
     ];
     expect(stringToOSCArgs(test)).toStrictEqual(expected);
   });
@@ -28,9 +28,9 @@ describe('test stringToOSCArgs()', () => {
   it('keep spaces in quoted strings', () => {
     const test = '"test space" 1111 0.1111 TRUE FALSE';
     const expected = [
-      { type: 's', value: 'test space' },
-      { type: 'i', value: 1111 },
-      { type: 'f', value: 0.1111 },
+      { type: 'string', value: 'test space' },
+      { type: 'integer', value: 1111 },
+      { type: 'float', value: 0.1111 },
       { type: 'T', value: true },
       { type: 'F', value: false },
     ];
@@ -40,9 +40,9 @@ describe('test stringToOSCArgs()', () => {
   it('keep spaces escaped quotes', () => {
     const test = '"test \\" space" 1111 0.1111 TRUE FALSE';
     const expected = [
-      { type: 's', value: 'test " space' },
-      { type: 'i', value: 1111 },
-      { type: 'f', value: 0.1111 },
+      { type: 'string', value: 'test " space' },
+      { type: 'integer', value: 1111 },
+      { type: 'float', value: 0.1111 },
       { type: 'T', value: true },
       { type: 'F', value: false },
     ];

--- a/apps/server/src/utils/__tests__/oscArgParser.test.ts
+++ b/apps/server/src/utils/__tests__/oscArgParser.test.ts
@@ -3,25 +3,41 @@ import { stringToOSCArgs } from '../oscArgParser.js';
 describe('url is correctly formatted', () => {
   it('all types', () => {
     const test = 'test 1111 0.1111';
-    const expected = ['test', 1111, 0.1111];
+    const expected = [
+      { type: 's', value: 'test' },
+      { type: 'i', value: 1111 },
+      { type: 'f', value: 0.1111 },
+    ];
     expect(stringToOSCArgs(test)).toStrictEqual(expected);
   });
 
   it('keep numbers in strings', () => {
     const test = 'test "1111" "0.1111"';
-    const expected = ['test', '1111', '0.1111'];
+    const expected = [
+      { type: 's', value: 'test' },
+      { type: 's', value: '1111' },
+      { type: 's', value: '0.1111' },
+    ];
     expect(stringToOSCArgs(test)).toStrictEqual(expected);
   });
 
   it('keep spaces in quoted strings', () => {
-    const test = '"test space" "1111" "0.1111"';
-    const expected = ['test space', '1111', '0.1111'];
+    const test = '"test space" 1111 0.1111';
+    const expected = [
+      { type: 's', value: 'test space' },
+      { type: 'i', value: 1111 },
+      { type: 'f', value: 0.1111 },
+    ];
     expect(stringToOSCArgs(test)).toStrictEqual(expected);
   });
 
   it('keep spaces escaped quotes', () => {
-    const test = '"test \\" space" "1111" "0.1111"';
-    const expected = ['test " space', '1111', '0.1111'];
+    const test = '"test \\" space" 1111 0.1111';
+    const expected = [
+      { type: 's', value: 'test " space' },
+      { type: 'i', value: 1111 },
+      { type: 'f', value: 0.1111 },
+    ];
     expect(stringToOSCArgs(test)).toStrictEqual(expected);
   });
 });

--- a/apps/server/src/utils/__tests__/oscArgParser.test.ts
+++ b/apps/server/src/utils/__tests__/oscArgParser.test.ts
@@ -1,0 +1,27 @@
+import { stringToOSCArgs } from '../oscArgParser.js';
+
+describe('url is correctly formatted', () => {
+  it('all types', () => {
+    const test = 'test 1111 0.1111';
+    const expected = ['test', 1111, 0.1111];
+    expect(stringToOSCArgs(test)).toStrictEqual(expected);
+  });
+
+  it('keep numbers in strings', () => {
+    const test = 'test "1111" "0.1111"';
+    const expected = ['test', '1111', '0.1111'];
+    expect(stringToOSCArgs(test)).toStrictEqual(expected);
+  });
+
+  it('keep spaces in quoted strings', () => {
+    const test = '"test space" "1111" "0.1111"';
+    const expected = ['test space', '1111', '0.1111'];
+    expect(stringToOSCArgs(test)).toStrictEqual(expected);
+  });
+
+  it('keep spaces escaped quotes', () => {
+    const test = '"test \\" space" "1111" "0.1111"';
+    const expected = ['test " space', '1111', '0.1111'];
+    expect(stringToOSCArgs(test)).toStrictEqual(expected);
+  });
+});

--- a/apps/server/src/utils/__tests__/oscArgParser.test.ts
+++ b/apps/server/src/utils/__tests__/oscArgParser.test.ts
@@ -19,6 +19,12 @@ describe('test stringToOSCArgs()', () => {
     expect(stringToOSCArgs(test)).toStrictEqual(expected);
   });
 
+  it('empty is nothing', () => {
+    const test = '';
+    const expected = [];
+    expect(stringToOSCArgs(test)).toStrictEqual(expected);
+  });
+
   it('keep other types in strings', () => {
     const test = 'test "1111" "0.1111" "TRUE" "FALSE"';
     const expected = [

--- a/apps/server/src/utils/__tests__/oscArgParser.test.ts
+++ b/apps/server/src/utils/__tests__/oscArgParser.test.ts
@@ -2,41 +2,49 @@ import { stringToOSCArgs } from '../oscArgParser.js';
 
 describe('url is correctly formatted', () => {
   it('all types', () => {
-    const test = 'test 1111 0.1111';
+    const test = 'test 1111 0.1111 TRUE FALSE';
     const expected = [
       { type: 's', value: 'test' },
       { type: 'i', value: 1111 },
       { type: 'f', value: 0.1111 },
+      { type: 'T', value: true },
+      { type: 'F', value: false },
     ];
     expect(stringToOSCArgs(test)).toStrictEqual(expected);
   });
 
-  it('keep numbers in strings', () => {
-    const test = 'test "1111" "0.1111"';
+  it('keep other types in strings', () => {
+    const test = 'test "1111" "0.1111" "TRUE" "FALSE"';
     const expected = [
       { type: 's', value: 'test' },
       { type: 's', value: '1111' },
       { type: 's', value: '0.1111' },
+      { type: 's', value: 'TRUE' },
+      { type: 's', value: 'FALSE' },
     ];
     expect(stringToOSCArgs(test)).toStrictEqual(expected);
   });
 
   it('keep spaces in quoted strings', () => {
-    const test = '"test space" 1111 0.1111';
+    const test = '"test space" 1111 0.1111 TRUE FALSE';
     const expected = [
       { type: 's', value: 'test space' },
       { type: 'i', value: 1111 },
       { type: 'f', value: 0.1111 },
+      { type: 'T', value: true },
+      { type: 'F', value: false },
     ];
     expect(stringToOSCArgs(test)).toStrictEqual(expected);
   });
 
   it('keep spaces escaped quotes', () => {
-    const test = '"test \\" space" 1111 0.1111';
+    const test = '"test \\" space" 1111 0.1111 TRUE FALSE';
     const expected = [
       { type: 's', value: 'test " space' },
       { type: 'i', value: 1111 },
       { type: 'f', value: 0.1111 },
+      { type: 'T', value: true },
+      { type: 'F', value: false },
     ];
     expect(stringToOSCArgs(test)).toStrictEqual(expected);
   });

--- a/apps/server/src/utils/__tests__/oscArgParser.test.ts
+++ b/apps/server/src/utils/__tests__/oscArgParser.test.ts
@@ -1,6 +1,6 @@
 import { stringToOSCArgs } from '../oscArgParser.js';
 
-describe('url is correctly formatted', () => {
+describe('test stringToOSCArgs()', () => {
   it('all types', () => {
     const test = 'test 1111 0.1111 TRUE FALSE';
     const expected = [

--- a/apps/server/src/utils/__tests__/oscArgParser.test.ts
+++ b/apps/server/src/utils/__tests__/oscArgParser.test.ts
@@ -13,6 +13,12 @@ describe('test stringToOSCArgs()', () => {
     expect(stringToOSCArgs(test)).toStrictEqual(expected);
   });
 
+  it('empty is nothing', () => {
+    const test = undefined;
+    const expected = [];
+    expect(stringToOSCArgs(test)).toStrictEqual(expected);
+  });
+
   it('keep other types in strings', () => {
     const test = 'test "1111" "0.1111" "TRUE" "FALSE"';
     const expected = [
@@ -41,6 +47,17 @@ describe('test stringToOSCArgs()', () => {
     const test = '"test \\" space" 1111 0.1111 TRUE FALSE';
     const expected = [
       { type: 'string', value: 'test " space' },
+      { type: 'integer', value: 1111 },
+      { type: 'float', value: 0.1111 },
+      { type: 'T', value: true },
+      { type: 'F', value: false },
+    ];
+    expect(stringToOSCArgs(test)).toStrictEqual(expected);
+  });
+
+  it('2 spaces', () => {
+    const test = '1111   0.1111 TRUE FALSE';
+    const expected = [
       { type: 'integer', value: 1111 },
       { type: 'float', value: 0.1111 },
       { type: 'T', value: true },

--- a/apps/server/src/utils/oscArgParser.ts
+++ b/apps/server/src/utils/oscArgParser.ts
@@ -1,26 +1,26 @@
-import { ArgumentType } from 'node-osc';
+import { Argument } from 'node-osc';
 import { splitWhitespace } from 'ontime-utils';
 
-export function stringToOSCArgs(argsString: string | undefined): ArgumentType[] {
+export function stringToOSCArgs(argsString: string | undefined): Argument[] {
   if (typeof argsString === 'undefined') {
-    return new Array<ArgumentType>();
+    return new Array<Argument>();
   }
   const matches = splitWhitespace(argsString);
 
-  const parsedArguments = matches.map((argString: string) => {
-    const maybeNumber = Number(argString);
-    if (!Number.isNaN(maybeNumber)) {
-      //NOTE: number like: 1 2.0 33333
-      //TODO: we cant foce a float with our current osc lib
-      return maybeNumber;
+  const parsedArguments: Argument[] = matches.map((argString: string) => {
+    const argAsNum = Number(argString);
+    // NOTE: number like: 1 2.0 33333
+    if (!Number.isNaN(argAsNum)) {
+      return { type: argString.includes('.') ? 'f' : 'i', value: argAsNum };
     }
 
     if (argString.startsWith('"') && argString.endsWith('"')) {
-      // NOTE: "quoted string" or "1234"
-      return argString.substring(1, argString.length - 1);
+      // NOTE: "quoted string"
+      return { type: 's', value: argString.substring(1, argString.length - 1) };
     }
 
-    return argString;
+    // NOTE: string
+    return { type: 's', value: argString };
   });
 
   return parsedArguments;

--- a/apps/server/src/utils/oscArgParser.ts
+++ b/apps/server/src/utils/oscArgParser.ts
@@ -2,7 +2,7 @@ import { Argument } from 'node-osc';
 import { splitWhitespace } from 'ontime-utils';
 
 export function stringToOSCArgs(argsString: string | undefined): Argument[] {
-  if (typeof argsString === 'undefined') {
+  if (typeof argsString === 'undefined' || argsString === '') {
     return new Array<Argument>();
   }
   const matches = splitWhitespace(argsString);

--- a/apps/server/src/utils/oscArgParser.ts
+++ b/apps/server/src/utils/oscArgParser.ts
@@ -19,6 +19,16 @@ export function stringToOSCArgs(argsString: string | undefined): Argument[] {
       return { type: 's', value: argString.substring(1, argString.length - 1) };
     }
 
+    if (argString === 'TRUE') {
+      // NOTE: Boolean true
+      return { type: 'T', value: true };
+    }
+
+    if (argString === 'FALSE') {
+      // NOTE: Boolean false
+      return { type: 'F', value: false };
+    }
+
     // NOTE: string
     return { type: 's', value: argString };
   });

--- a/apps/server/src/utils/oscArgParser.ts
+++ b/apps/server/src/utils/oscArgParser.ts
@@ -1,0 +1,27 @@
+import { ArgumentType } from 'node-osc';
+import { splitWhitespace } from 'ontime-utils';
+
+export function stringToOSCArgs(argsString: string | undefined): ArgumentType[] {
+  if (typeof argsString === 'undefined') {
+    return new Array<ArgumentType>();
+  }
+  const matches = splitWhitespace(argsString);
+
+  const parsedArguments = matches.map((argString: string) => {
+    const maybeNumber = Number(argString);
+    if (!Number.isNaN(maybeNumber)) {
+      //NOTE: number like: 1 2.0 33333
+      //TODO: we cant foce a float with our current osc lib
+      return maybeNumber;
+    }
+
+    if (argString.startsWith('"') && argString.endsWith('"')) {
+      // NOTE: "quoted string" or "1234"
+      return argString.substring(1, argString.length - 1);
+    }
+
+    return argString;
+  });
+
+  return parsedArguments;
+}

--- a/apps/server/src/utils/oscArgParser.ts
+++ b/apps/server/src/utils/oscArgParser.ts
@@ -11,12 +11,12 @@ export function stringToOSCArgs(argsString: string | undefined): Argument[] {
     const argAsNum = Number(argString);
     // NOTE: number like: 1 2.0 33333
     if (!Number.isNaN(argAsNum)) {
-      return { type: argString.includes('.') ? 'f' : 'i', value: argAsNum };
+      return { type: argString.includes('.') ? 'float' : 'integer', value: argAsNum };
     }
 
     if (argString.startsWith('"') && argString.endsWith('"')) {
       // NOTE: "quoted string"
-      return { type: 's', value: argString.substring(1, argString.length - 1) };
+      return { type: 'string', value: argString.substring(1, argString.length - 1) };
     }
 
     if (argString === 'TRUE') {
@@ -30,7 +30,7 @@ export function stringToOSCArgs(argsString: string | undefined): Argument[] {
     }
 
     // NOTE: string
-    return { type: 's', value: argString };
+    return { type: 'string', value: argString };
   });
 
   return parsedArguments;

--- a/packages/types/src/definitions/core/OscSettings.type.ts
+++ b/packages/types/src/definitions/core/OscSettings.type.ts
@@ -4,7 +4,7 @@ export type OscSubscription = {
   id: string;
   cycle: TimerLifeCycleKey;
   address: string;
-  payload: string;
+  payload: string; // TODO: we should be using arguments to keep in line with protocol language
   enabled: boolean;
 };
 

--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -45,6 +45,7 @@ export {
 } from './src/date-utils/timeFormatting.js';
 export { isAlphanumeric } from './src/regex-utils/isAlphanumeric.js';
 export { isColourHex } from './src/regex-utils/isColourHex.js';
+export { splitWhitespace } from './src/regex-utils/splitWhitespace.js';
 
 // time utils
 export { dayInMs, mts } from './src/timeConstants.js';

--- a/packages/utils/src/regex-utils/splitWhitespace.test.ts
+++ b/packages/utils/src/regex-utils/splitWhitespace.test.ts
@@ -1,0 +1,38 @@
+import { splitWhitespace } from './splitWhitespace';
+
+describe('test splitWhitespace() function', () => {
+  it('empty string', () => {
+    const test = '';
+    expect(splitWhitespace(test)).toStrictEqual(null);
+  });
+
+  it('1 item', () => {
+    const test = 'test';
+    expect(splitWhitespace(test)).toStrictEqual(['test']);
+  });
+
+  it('2 items', () => {
+    const test = 'test test';
+    expect(splitWhitespace(test)).toStrictEqual(['test', 'test']);
+  });
+
+  it('2 items and quoted string', () => {
+    const test = 'test test "more test"';
+    expect(splitWhitespace(test)).toStrictEqual(['test', 'test', 'more test']);
+  });
+
+  it('escaped quotes', () => {
+    const test = 'test test "more \\" test"';
+    expect(splitWhitespace(test)).toStrictEqual(['test', 'test', 'more " test']);
+  });
+
+  it('missing end quotes', () => {
+    const test = 'test test "more test';
+    expect(splitWhitespace(test)).toStrictEqual(['test', 'test', 'more test']);
+  });
+
+  it('missing start quotes', () => {
+    const test = 'test test more test"';
+    expect(splitWhitespace(test)).toStrictEqual(['test', 'test', 'more', 'test']);
+  });
+});

--- a/packages/utils/src/regex-utils/splitWhitespace.test.ts
+++ b/packages/utils/src/regex-utils/splitWhitespace.test.ts
@@ -18,21 +18,26 @@ describe('test splitWhitespace() function', () => {
 
   it('2 items and quoted string', () => {
     const test = 'test test "more test"';
-    expect(splitWhitespace(test)).toStrictEqual(['test', 'test', 'more test']);
+    expect(splitWhitespace(test)).toStrictEqual(['test', 'test', '"more test"']);
+  });
+
+  it('quotes without spaces', () => {
+    const test = 'test test "moreTest"';
+    expect(splitWhitespace(test)).toStrictEqual(['test', 'test', '"moreTest"']);
   });
 
   it('escaped quotes', () => {
     const test = 'test test "more \\" test"';
-    expect(splitWhitespace(test)).toStrictEqual(['test', 'test', 'more " test']);
+    expect(splitWhitespace(test)).toStrictEqual(['test', 'test', '"more " test"']);
   });
 
   it('missing end quotes', () => {
     const test = 'test test "more test';
-    expect(splitWhitespace(test)).toStrictEqual(['test', 'test', 'more test']);
+    expect(splitWhitespace(test)).toStrictEqual(['test', 'test', '"more test']);
   });
 
   it('missing start quotes', () => {
     const test = 'test test more test"';
-    expect(splitWhitespace(test)).toStrictEqual(['test', 'test', 'more', 'test']);
+    expect(splitWhitespace(test)).toStrictEqual(['test', 'test', 'more', 'test"']);
   });
 });

--- a/packages/utils/src/regex-utils/splitWhitespace.test.ts
+++ b/packages/utils/src/regex-utils/splitWhitespace.test.ts
@@ -6,6 +6,11 @@ describe('test splitWhitespace() function', () => {
     expect(splitWhitespace(test)).toStrictEqual(null);
   });
 
+  it('just space', () => {
+    const test = ' ';
+    expect(splitWhitespace(test)).toStrictEqual(null);
+  });
+
   it('1 item', () => {
     const test = 'test';
     expect(splitWhitespace(test)).toStrictEqual(['test']);
@@ -19,6 +24,11 @@ describe('test splitWhitespace() function', () => {
   it('2 items and quoted string', () => {
     const test = 'test test "more test"';
     expect(splitWhitespace(test)).toStrictEqual(['test', 'test', '"more test"']);
+  });
+
+  it('2 sapces', () => {
+    const test = 'test  test  "more  test"';
+    expect(splitWhitespace(test)).toStrictEqual(['test', 'test', '"more  test"']);
   });
 
   it('quotes without spaces', () => {

--- a/packages/utils/src/regex-utils/splitWhitespace.ts
+++ b/packages/utils/src/regex-utils/splitWhitespace.ts
@@ -1,0 +1,30 @@
+// const parseRegex = /[\w.]+|"(?:\\"|[^"])+"/g;
+const splitRegex = /\\?.|^$/g;
+
+/**
+ * [link](https://stackoverflow.com/questions/4031900/split-a-string-by-whitespace-keeping-quoted-segments-allowing-escaped-quotes)
+ * @param str string to split
+ * @returns
+ */
+export const splitWhitespace = (str: string): null | string[] => {
+  const match = str.match(splitRegex);
+  if (!match || match[0] == '') {
+    return null;
+  }
+  const { array } = match.reduce(
+    (accumulator, current) => {
+      if (current === '"') {
+        accumulator.inQuotes ^= 1;
+      } else if (!accumulator.inQuotes && current === ' ') {
+        accumulator.array.push('');
+      } else {
+        accumulator.array[accumulator.array.length - 1] += current.replace(/\\(.)/, '$1');
+      }
+      return accumulator;
+    },
+    { array: [''], inQuotes: 0 },
+  );
+
+  return array;
+};
+// export const splitWhitespace = (str: string): null | string[] => str.match(parseRegex);

--- a/packages/utils/src/regex-utils/splitWhitespace.ts
+++ b/packages/utils/src/regex-utils/splitWhitespace.ts
@@ -6,7 +6,7 @@ const splitRegex = /\\?.|^$/g;
  * @param str string to split
  * @returns
  */
-export const splitWhitespace = (str: string): null | string[] => {
+export const splitWhitespace = (str: string, keepQuotes = true): null | string[] => {
   const match = str.match(splitRegex);
   if (!match || match[0] == '') {
     return null;
@@ -15,6 +15,9 @@ export const splitWhitespace = (str: string): null | string[] => {
     (accumulator, current) => {
       if (current === '"') {
         accumulator.inQuotes ^= 1;
+        if (keepQuotes) {
+          accumulator.array[accumulator.array.length - 1] += current.replace(/\\(.)/, '$1');
+        }
       } else if (!accumulator.inQuotes && current === ' ') {
         accumulator.array.push('');
       } else {

--- a/packages/utils/src/regex-utils/splitWhitespace.ts
+++ b/packages/utils/src/regex-utils/splitWhitespace.ts
@@ -1,8 +1,7 @@
-// const parseRegex = /[\w.]+|"(?:\\"|[^"])+"/g;
 const splitRegex = /\\?.|^$/g;
 
 /**
- * [link](https://stackoverflow.com/questions/4031900/split-a-string-by-whitespace-keeping-quoted-segments-allowing-escaped-quotes)
+ * adapted from {@link https://stackoverflow.com/questions/4031900/split-a-string-by-whitespace-keeping-quoted-segments-allowing-escaped-quotes this}
  * @param str string to split
  * @returns
  */
@@ -30,4 +29,3 @@ export const splitWhitespace = (str: string, keepQuotes = true): null | string[]
 
   return array;
 };
-// export const splitWhitespace = (str: string): null | string[] => str.match(parseRegex);

--- a/packages/utils/src/regex-utils/splitWhitespace.ts
+++ b/packages/utils/src/regex-utils/splitWhitespace.ts
@@ -10,22 +10,28 @@ export const splitWhitespace = (str: string, keepQuotes = true): null | string[]
   if (!match || match[0] == '') {
     return null;
   }
-  const { array } = match.reduce(
-    (accumulator, current) => {
-      if (current === '"') {
-        accumulator.inQuotes ^= 1;
-        if (keepQuotes) {
+  const array = match
+    .reduce(
+      (accumulator, current) => {
+        if (current === '"') {
+          accumulator.inQuotes ^= 1;
+          if (keepQuotes) {
+            accumulator.array[accumulator.array.length - 1] += current.replace(/\\(.)/, '$1');
+          }
+        } else if (!accumulator.inQuotes && current === ' ') {
+          accumulator.array.push('');
+        } else {
           accumulator.array[accumulator.array.length - 1] += current.replace(/\\(.)/, '$1');
         }
-      } else if (!accumulator.inQuotes && current === ' ') {
-        accumulator.array.push('');
-      } else {
-        accumulator.array[accumulator.array.length - 1] += current.replace(/\\(.)/, '$1');
-      }
-      return accumulator;
-    },
-    { array: [''], inQuotes: 0 },
-  );
+        return accumulator;
+      },
+      { array: [''], inQuotes: 0 },
+    )
+    .array.filter((value) => value != '');
+
+  if (!array.length) {
+    return null;
+  }
 
   return array;
 };


### PR DESCRIPTION
This is a quick test to solve the issue described by the user

There are two points of improvement here
- we should attempt keeping the types defined by the user
- we should allow sending multiple commands

For the user defined case, where we want to send two integers `1` `1`, I believe the easiest case is to wrap this in an array  `[1,1]`, so that we can treat the arguments individually

We should take some time investigating to make sure there are no unintended side effects

Closes #953 