### PR TITLE
fix: prevent stale selection

### DIFF
--- a/apps/server/src/stores/runtimeState.ts
+++ b/apps/server/src/stores/runtimeState.ts
@@ -81,6 +81,7 @@ export function clear() {
   runtimeState.runtime.offset = null;
   runtimeState.runtime.actualStart = null;
   runtimeState.runtime.expectedEnd = null;
+  runtimeState.runtime.selectedEventIndex = null;
 
   runtimeState.timer.playback = Playback.Stop;
   runtimeState.clock = clock.timeNow();


### PR DESCRIPTION
Fixes an issue where the `selectedEventIndex` was not cleared on stop

Steps to reproduce:
- Clear rundown
- Make a single event
- Start event
- Stop Event

All the buttons in the playback (apart from Roll) should be disabled now 