### PR TITLE
fix: excel parsing

### DIFF
--- a/apps/server/src/utils/__tests__/time.test.ts
+++ b/apps/server/src/utils/__tests__/time.test.ts
@@ -1,3 +1,4 @@
+import { MILLIS_PER_MINUTE } from 'ontime-utils';
 import { parseExcelDate } from '../time.js';
 
 describe('parseExcelDate', () => {
@@ -46,8 +47,18 @@ describe('parseExcelDate', () => {
     });
   });
 
+  describe('uses numeric fields as minutes', () => {
+    const invalidFields = [1, 10, 100];
+    invalidFields.forEach((field) => {
+      it(`handles ${field}`, () => {
+        const millis = parseExcelDate(field);
+        expect(millis).toBe(field * MILLIS_PER_MINUTE);
+      });
+    });
+  });
+
   describe('returns 0 on other strings', () => {
-    const invalidFields = ['10', 'test', ''];
+    const invalidFields = ['test', ''];
     invalidFields.forEach((field) => {
       it(`handles ${field}`, () => {
         const millis = parseExcelDate(field);

--- a/apps/server/src/utils/parser.ts
+++ b/apps/server/src/utils/parser.ts
@@ -43,6 +43,10 @@ type ExcelData = Pick<DatabaseModel, 'rundown' | 'customFields'> & {
 };
 
 function parseBooleanString(value: unknown): boolean {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
   // falsy values would be nullish or empty string
   if (!value || typeof value !== 'string') {
     return false;

--- a/packages/utils/src/date-utils/isTimeString.test.ts
+++ b/packages/utils/src/date-utils/isTimeString.test.ts
@@ -1,4 +1,4 @@
-import { isTimeString } from './isTimeString';
+import { isISO8601, isTimeString } from './isTimeString';
 
 describe('test isTimeString() function', () => {
   it('it validates time strings', () => {
@@ -32,4 +32,17 @@ describe('test isTimeString() function handle AM/PM', () => {
       expect(isTimeString(s)).toBe(true);
     });
   }
+});
+
+describe('isISO8601()', () => {
+  it('returns true for valid ISO 8601 date-time strings', () => {
+    expect(isISO8601('1899-12-30T08:30:00.000Z')).toBe(true);
+    expect(isISO8601('2022-01-01T00:00:00.000Z')).toBe(true);
+  });
+
+  it('returns false for invalid ISO 8601 date-time strings', () => {
+    expect(isISO8601('not a date')).toBe(false);
+    expect(isISO8601('1899-12-30T08:30:00Z')).toBe(false); // missing milliseconds
+    expect(isISO8601('1899-12-30 08:30:00.000Z')).toBe(false); // space instead of 'T'
+  });
 });

--- a/packages/utils/src/date-utils/isTimeString.ts
+++ b/packages/utils/src/date-utils/isTimeString.ts
@@ -1,9 +1,15 @@
 /**
  * @description Validates a time string
- * @param {string} text - time string "23:00:12"
- * @returns {boolean} string represents time
  */
-export const isTimeString = (text: string): boolean => {
+export function isTimeString(text: string): boolean {
   const regex = /^(?:(?:([01]?\d|2[0-3])[:,.])?([0-5]?\d)[:,.])?([0-5]?\d)?(\s)?([APap][Mm])?$/;
   return regex.test(text);
-};
+}
+
+/**
+ * @description Validates a ISO8601 date-time string
+ */
+export function isISO8601(text: string): boolean {
+  const regex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+  return regex.test(text);
+}


### PR DESCRIPTION
Investigating the issues raised in #971 

This far, the issue encountered were related to unexpected data types.
I have made some small code changes and a test to support the bug report

**time warning `15` gets parsed as `0`**
in the time fields, we expect a string which is either a ISO 8601 date string or a string which includes a timestamp (eg `"09:00:00"`). In some cases the value was a number such as `15`, which was ignored by our parser

**duration `"60"` gets parsed as `0`**
the documentation suggests that the parsing of time strings is the same as the interface. this is almost correct, we first try to create a date from the string, if that fails we attempt parsing the string according to the UI rules. Unfortunately `"60"` is a valid input to the Date constructor and makes our logic fail. I have attempted to use a regex to look for ISO 8601 strings and parse the string using the `forgivingTimeString()` otherwise

**boolean `true` gets parsed as `false`**
it seems that we never expected to receive a boolean value from excel