### PR TITLE
style: simplify background override

### DIFF
--- a/apps/client/src/features/cuesheet/CuesheetWrapper.module.scss
+++ b/apps/client/src/features/cuesheet/CuesheetWrapper.module.scss
@@ -1,4 +1,5 @@
 .tableWrapper {
+  background-color: $ui-black;
   width: 100%;
   height: 100vh;
   padding: 1rem 0.5rem;

--- a/apps/client/src/features/editors/Editor.module.scss
+++ b/apps/client/src/features/editors/Editor.module.scss
@@ -9,7 +9,7 @@ $panel-gap: 0.5rem;
 }
 
 .mainContainer {
-  background: $ui-black;
+  background-color: $ui-black;
   width: 100%;
   height: 100%;
   color: $ui-white;

--- a/apps/client/src/features/operator/Operator.module.scss
+++ b/apps/client/src/features/operator/Operator.module.scss
@@ -2,6 +2,7 @@
   width: 100vw;
   height: 100vh;
 
+  background-color: $ui-black;
   color: $ui-white;
 }
 

--- a/apps/client/src/index.scss
+++ b/apps/client/src/index.scss
@@ -6,8 +6,11 @@
   font-style: normal;
   font-display: swap;
   font-weight: 300;
-  src: url(@fontsource/open-sans/files/open-sans-latin-300-normal.woff2) format('woff2'), url(@fontsource/open-sans/files/open-sans-latin-300-normal.woff) format('woff');
-  unicode-range: U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+2074,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;
+  src:
+    url(@fontsource/open-sans/files/open-sans-latin-300-normal.woff2) format('woff2'),
+    url(@fontsource/open-sans/files/open-sans-latin-300-normal.woff) format('woff');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
 /* open-sans-latin-400-normal */
@@ -16,8 +19,11 @@
   font-style: normal;
   font-display: swap;
   font-weight: 400;
-  src: url(@fontsource/open-sans/files/open-sans-latin-400-normal.woff2) format('woff2'), url(@fontsource/open-sans/files/open-sans-latin-400-normal.woff) format('woff');
-  unicode-range: U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+2074,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;
+  src:
+    url(@fontsource/open-sans/files/open-sans-latin-400-normal.woff2) format('woff2'),
+    url(@fontsource/open-sans/files/open-sans-latin-400-normal.woff) format('woff');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
 /* open-sans-latin-600-normal */
@@ -26,10 +32,12 @@
   font-style: normal;
   font-display: swap;
   font-weight: 600;
-  src: url(@fontsource/open-sans/files/open-sans-latin-600-normal.woff2) format('woff2'), url(@fontsource/open-sans/files/open-sans-latin-600-normal.woff) format('woff');
-  unicode-range: U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+2074,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;
+  src:
+    url(@fontsource/open-sans/files/open-sans-latin-600-normal.woff2) format('woff2'),
+    url(@fontsource/open-sans/files/open-sans-latin-600-normal.woff) format('woff');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
-
 
 $track-color: $white-1;
 $thumb-color: $gray-1100;
@@ -49,11 +57,15 @@ $thumb-color-hover: $gray-900;
   box-sizing: inherit;
 }
 
+body {
+  font-size: 15px;
+  font-family: $ontime-font-family;
+  background-color: var(--background-color-override, $ui-black);
+}
+
 body,
 html,
 .App {
-  font-size: 15px;
-  font-family: $ontime-font-family;
   margin: 0 auto;
   overflow: hidden;
   overflow: clip;
@@ -61,7 +73,6 @@ html,
   -webkit-user-select: none;
   user-select: none;
   -webkit-app-region: drag;
-  background-color: $bg-container-l1;
 }
 
 /* smaller root size for MacOS laptops */


### PR DESCRIPTION
Improves the keying of the views as described in #976 

The app has two levels of background, one set at the body level, and one set at route (page) level

These are effectively the same. It seems the reason the body background was introduced was to prevent a white flash while navigating
This had the unintended consequence of complicating the keying of views.

This PR introduces some changes to improve the ease of configuration:
- use `--background-color-override` with a fallback in body
- simplify selectors in `body` to avoid issues with specificity
- set background and page level in cuesheet and editor to avoid issues with overrides

This means that we avoid the issues with flashing of background colour.
The users only need to override a single variable `--background-color-override` to see their changes.

Note that `--background-color-override` is overriden by the `key` parameter. 
That means that the users can use `--background-color-override` without the `key` to key any view


We will need a follow up in the docs