### PR TITLE
refactor: recover day after indicator

### DIFF
--- a/apps/client/src/features/rundown/event-block/EventBlock.utils.ts
+++ b/apps/client/src/features/rundown/event-block/EventBlock.utils.ts
@@ -1,5 +1,5 @@
 import { MaybeNumber } from 'ontime-types';
-import { dayInMs, millisToString, removeLeadingZero, removeTrailingZero } from 'ontime-utils';
+import { checkIsNextDay, dayInMs, millisToString, removeLeadingZero, removeTrailingZero } from 'ontime-utils';
 
 export function formatDelay(timeStart: number, delay: number): string | undefined {
   if (!delay) return;
@@ -8,20 +8,6 @@ export function formatDelay(timeStart: number, delay: number): string | undefine
 
   const timeTag = removeTrailingZero(millisToString(delayedStart));
   return `New start ${timeTag}`;
-}
-
-/**
- * Utility function checks whether a given event is the day after from its predecessor
- * We consider an event to be the day after, if it begins before the start of the previous
- * @example day after
- * // 09:00 - 10:00
- * // 08:00 - 10:30 <--- day after
- * @example same day
- * // 09:00 - 10:00
- * // 09:30 - 10:30 <--- same day
- */
-function checkIsNextDay(previousStart: number, timeStart: number): boolean {
-  return timeStart < previousStart;
 }
 
 export function formatOverlap(

--- a/apps/server/src/services/rundown-service/rundownCache.ts
+++ b/apps/server/src/services/rundown-service/rundownCache.ts
@@ -9,7 +9,7 @@ import {
   OntimeRundown,
   OntimeRundownEntry,
 } from 'ontime-types';
-import { generateId, deleteAtIndex, insertAtIndex, reorderArray, swapEventData } from 'ontime-utils';
+import { generateId, deleteAtIndex, insertAtIndex, reorderArray, swapEventData, checkIsNextDay } from 'ontime-utils';
 
 import { DataProvider } from '../../classes/data-provider/DataProvider.js';
 import { createPatch } from '../../utils/parser.js';
@@ -85,6 +85,7 @@ export function generate(
 
   let accumulatedDelay = 0;
   let daySpan = 0;
+  let previousStart: MaybeNumber = null;
   let previousEnd: MaybeNumber = null;
 
   for (let i = 0; i < initialRundown.length; i++) {
@@ -108,7 +109,7 @@ export function generate(
       lastEnd = updatedEvent.timeEnd;
 
       // check if we go over midnight, account for eventual gaps
-      const gapOverMidnight = previousEnd !== null && previousEnd > updatedEvent.timeStart;
+      const gapOverMidnight = previousStart !== null && checkIsNextDay(previousStart, updatedEvent.timeStart);
       const durationOverMidnight = updatedEvent.timeStart > updatedEvent.timeEnd;
       if (gapOverMidnight || durationOverMidnight) {
         daySpan++;
@@ -128,6 +129,7 @@ export function generate(
         accumulatedDelay = Math.max(accumulatedDelay - gap, 0);
       }
       updatedEvent.delay = accumulatedDelay;
+      previousStart = updatedEvent.timeStart;
       previousEnd = updatedEvent.timeEnd;
     }
 

--- a/apps/server/src/stores/runtimeState.ts
+++ b/apps/server/src/stores/runtimeState.ts
@@ -121,7 +121,7 @@ export function updateRundownData(rundownData: RundownData) {
 
   runtimeState.runtime.numEvents = rundownData.numEvents;
   runtimeState.runtime.plannedStart = rundownData.firstStart;
-  runtimeState.runtime.plannedEnd = rundownData.lastEnd;
+  runtimeState.runtime.plannedEnd = rundownData.firstStart + rundownData.totalDuration;
   runtimeState.runtime.expectedEnd = getExpectedEnd(runtimeState);
 }
 

--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -65,6 +65,9 @@ export { validateEndAction, validateTimerType } from './src/validate-events/vali
 
 // feature business logic
 
+// feature business logic - rundown
+export { checkIsNextDay } from './src/date-utils/checkIsNextDay.js';
+
 // feature business logic - spreadsheet import
 export {
   type ImportCustom,

--- a/packages/utils/src/date-utils/checkIsNextDay.ts
+++ b/packages/utils/src/date-utils/checkIsNextDay.ts
@@ -1,0 +1,13 @@
+/**
+ * Utility function checks whether a given event is the day after from its predecessor
+ * We consider an event to be the day after, if it begins before the start of the previous
+ * @example day after
+ * 09:00 - 10:00
+ * 08:00 - 10:30
+ * @example same day
+ * 09:00 - 10:00
+ * 09:30 - 10:30
+ */
+export function checkIsNextDay(previousStart: number, timeStart: number): boolean {
+  return timeStart <= previousStart;
+}


### PR DESCRIPTION
This recovers the day after indicator by fixing the out of sync logic in UI and server regarding what makes something being the day after.

It is a follow up of #952  and is discussed in #951 