### PR TITLE
refactor: cap timer values

### DIFF
--- a/apps/client/src/common/hooks/useEventAction.ts
+++ b/apps/client/src/common/hooks/useEventAction.ts
@@ -1,7 +1,14 @@
 import { useCallback } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { isOntimeEvent, MaybeString, OntimeEvent, OntimeRundownEntry, RundownCached } from 'ontime-types';
-import { getLinkedTimes, getPreviousEventNormal, reorderArray, swapEventData } from 'ontime-utils';
+import {
+  dayInMs,
+  getLinkedTimes,
+  getPreviousEventNormal,
+  MILLIS_PER_SECOND,
+  reorderArray,
+  swapEventData,
+} from 'ontime-utils';
 
 import { RUNDOWN } from '../api/constants';
 import {
@@ -215,9 +222,12 @@ export const useEventAction = () => {
         newValMillis = forgivingStringToMillis(value);
       }
 
+      // dont allow timer values over 23:59:59
+      const cappedMillis = Math.min(newValMillis, dayInMs - MILLIS_PER_SECOND);
+
       const newEvent = {
         id: eventId,
-        [field]: newValMillis,
+        [field]: cappedMillis,
       };
       try {
         await _updateEventMutation.mutateAsync(newEvent);

--- a/apps/client/src/features/control/playback/add-time/AddTime.tsx
+++ b/apps/client/src/features/control/playback/add-time/AddTime.tsx
@@ -2,7 +2,7 @@ import { Tooltip } from '@chakra-ui/react';
 import { IoAdd } from '@react-icons/all-files/io5/IoAdd';
 import { IoRemove } from '@react-icons/all-files/io5/IoRemove';
 import { Playback } from 'ontime-types';
-import { MILLIS_PER_SECOND } from 'ontime-utils';
+import { MILLIS_PER_HOUR, MILLIS_PER_SECOND } from 'ontime-utils';
 
 import TimeInput from '../../../../common/components/input/time-input/TimeInput';
 import { useLocalStorage } from '../../../../common/hooks/useLocalStorage';
@@ -23,7 +23,8 @@ export default function AddTime(props: AddTimeProps) {
 
   const handleTimeChange = (_field: string, value: string) => {
     const newTime = forgivingStringToMillis(value);
-    setTime(newTime);
+    // cap add time to 1 hour
+    setTime(Math.min(newTime, MILLIS_PER_HOUR));
   };
 
   const handleAddTime = (direction: 'add' | 'remove') => {

--- a/apps/server/src/api-integration/integration.controller.ts
+++ b/apps/server/src/api-integration/integration.controller.ts
@@ -1,4 +1,5 @@
 import { DeepPartial, MessageState, OntimeEvent, SimpleDirection, SimplePlayback } from 'ontime-types';
+import { MILLIS_PER_HOUR, MILLIS_PER_SECOND } from 'ontime-utils';
 
 import { ONTIME_VERSION } from '../ONTIME_VERSION.js';
 import { auxTimerService } from '../services/aux-timer-service/AuxTimerService.js';
@@ -177,7 +178,13 @@ const actionHandlers: Record<string, ActionHandler> = {
     if (time === 0) {
       return { payload: 'success' };
     }
-    runtimeService.addTime(time * 1000); //frontend is seconds based
+
+    const timeToAdd = time * MILLIS_PER_SECOND; // frontend is seconds based
+    if (Math.abs(timeToAdd) > MILLIS_PER_HOUR) {
+      throw new Error(`Payload too large: ${time}`);
+    }
+
+    runtimeService.addTime(timeToAdd);
     return { payload: 'success' };
   },
   /* Extra timers */

--- a/apps/server/src/api-integration/integration.utils.ts
+++ b/apps/server/src/api-integration/integration.utils.ts
@@ -1,11 +1,10 @@
 import { OntimeEvent, isKeyOfType, isOntimeEvent } from 'ontime-types';
-import { MILLIS_PER_SECOND } from 'ontime-utils';
+import { MILLIS_PER_SECOND, maxDuration } from 'ontime-utils';
 
 import { DataProvider } from '../classes/data-provider/DataProvider.js';
 import { editEvent } from '../services/rundown-service/RundownService.js';
 import { getEventWithId } from '../services/rundown-service/rundownUtils.js';
 import { coerceBoolean, coerceColour, coerceNumber, coerceString } from '../utils/coerceType.js';
-import { maxDuration } from '../../../../packages/utils/src/date-utils/conversionUtils.js';
 
 const whitelistedPayload = {
   title: coerceString,

--- a/apps/server/src/api-integration/integration.utils.ts
+++ b/apps/server/src/api-integration/integration.utils.ts
@@ -1,16 +1,18 @@
 import { OntimeEvent, isKeyOfType, isOntimeEvent } from 'ontime-types';
+import { MILLIS_PER_SECOND } from 'ontime-utils';
 
 import { DataProvider } from '../classes/data-provider/DataProvider.js';
 import { editEvent } from '../services/rundown-service/RundownService.js';
 import { getEventWithId } from '../services/rundown-service/rundownUtils.js';
 import { coerceBoolean, coerceColour, coerceNumber, coerceString } from '../utils/coerceType.js';
+import { maxDuration } from '../../../../packages/utils/src/date-utils/conversionUtils.js';
 
 const whitelistedPayload = {
   title: coerceString,
   note: coerceString,
   cue: coerceString,
 
-  duration: (value: unknown) => coerceNumber(value) * 1000,
+  duration: (value: unknown) => Math.max(coerceNumber(value) * MILLIS_PER_SECOND, maxDuration),
 
   isPublic: coerceBoolean,
   skip: coerceBoolean,

--- a/apps/server/src/utils/time.ts
+++ b/apps/server/src/utils/time.ts
@@ -1,9 +1,5 @@
-import { MILLIS_PER_MINUTE } from 'ontime-utils';
+import { MILLIS_PER_HOUR, MILLIS_PER_MINUTE, MILLIS_PER_SECOND } from 'ontime-utils';
 import { isISO8601 } from '../../../../packages/utils/src/date-utils/isTimeString.js';
-
-const mts = 1000; // millis to seconds
-const mtm = 1000 * 60; // millis to minutes
-const mth = 1000 * 60 * 60; // millis to hours
 
 export const timeFormat = 'HH:mm';
 export const timeFormatSeconds = 'HH:mm:ss';
@@ -20,7 +16,7 @@ export const dateToMillis = (date: Date): number => {
   const m = date.getMinutes();
   const s = date.getSeconds();
 
-  return h * mth + m * mtm + s * mts;
+  return h * MILLIS_PER_HOUR + m * MILLIS_PER_MINUTE + s * MILLIS_PER_SECOND;
 };
 
 /**
@@ -60,7 +56,7 @@ export const forgivingStringToMillis = (value: string): number => {
 
   //if past noon indicated add 12 hours
   if (pastNoon) {
-    millis = mth * 12;
+    millis = MILLIS_PER_HOUR * 12;
   }
   // split string at known separators    : , .
   const separatorRegex = /[\s,:.]+/;
@@ -68,9 +64,9 @@ export const forgivingStringToMillis = (value: string): number => {
 
   if (first != null && second != null && third != null) {
     // if string has three sections, treat as [hours] [minutes] [seconds]
-    millis += parse(first) * mth;
-    millis += parse(second) * mtm;
-    millis += parse(third) * mts;
+    millis += parse(first) * MILLIS_PER_HOUR;
+    millis += parse(second) * MILLIS_PER_MINUTE;
+    millis += parse(third) * MILLIS_PER_SECOND;
   } else if (first != null && second == null && third == null) {
     // if string has one section,
     // could be a complete string like 121010 - 12:10:10
@@ -78,18 +74,18 @@ export const forgivingStringToMillis = (value: string): number => {
       const hours = first.substring(0, 2);
       const minutes = first.substring(2, 4);
       const seconds = first.substring(4);
-      millis += parse(hours) * mth;
-      millis += parse(minutes) * mtm;
-      millis += parse(seconds) * mts;
+      millis += parse(hours) * MILLIS_PER_HOUR;
+      millis += parse(minutes) * MILLIS_PER_MINUTE;
+      millis += parse(seconds) * MILLIS_PER_SECOND;
     } else {
       // otherwise lets treat as [minutes]
-      millis += parse(first) * mtm;
+      millis += parse(first) * MILLIS_PER_MINUTE;
     }
   }
   if (first != null && second != null && third == null) {
     // if string has two sections  treat as [hours] [minutes]
-    millis += parse(first) * mth;
-    millis += parse(second) * mtm;
+    millis += parse(first) * MILLIS_PER_HOUR;
+    millis += parse(second) * MILLIS_PER_MINUTE;
   }
   return millis;
 };

--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -26,8 +26,9 @@ export {
   swapEventData,
 } from './src/rundown-utils/rundownUtils.js';
 
-// format utils
+// time format utils
 export {
+  dayInMs,
   MILLIS_PER_HOUR,
   MILLIS_PER_MINUTE,
   MILLIS_PER_SECOND,
@@ -45,9 +46,6 @@ export {
 } from './src/date-utils/timeFormatting.js';
 export { isAlphanumeric } from './src/regex-utils/isAlphanumeric.js';
 export { isColourHex } from './src/regex-utils/isColourHex.js';
-
-// time utils
-export { dayInMs, mts } from './src/timeConstants.js';
 
 // helpers from externals
 export { deepmerge } from './src/externals/deepmerge.js';

--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -29,6 +29,7 @@ export {
 // time format utils
 export {
   dayInMs,
+  maxDuration,
   MILLIS_PER_HOUR,
   MILLIS_PER_MINUTE,
   MILLIS_PER_SECOND,

--- a/packages/utils/src/date-utils/conversionUtils.ts
+++ b/packages/utils/src/date-utils/conversionUtils.ts
@@ -4,6 +4,9 @@ export const MILLIS_PER_SECOND = 1000;
 export const MILLIS_PER_MINUTE = 1000 * 60;
 export const MILLIS_PER_HOUR = 1000 * 60 * 60;
 
+export const dayInMs = 86400000;
+export const maxDuration = dayInMs - MILLIS_PER_SECOND;
+
 function convertMillis(millis: MaybeNumber, conversion: number) {
   if (!millis) {
     return 0;

--- a/packages/utils/src/date-utils/timeFormatting.test.ts
+++ b/packages/utils/src/date-utils/timeFormatting.test.ts
@@ -1,5 +1,4 @@
-import { dayInMs } from '../timeConstants';
-import { MILLIS_PER_HOUR } from './conversionUtils';
+import { dayInMs, MILLIS_PER_HOUR } from './conversionUtils';
 import { formatFromMillis, millisToString, removeLeadingZero } from './timeFormatting';
 
 describe('millisToString()', () => {

--- a/packages/utils/src/timeConstants.ts
+++ b/packages/utils/src/timeConstants.ts
@@ -1,9 +1,0 @@
-/**
- * Milliseconds in a second
- */
-export const mts = 1000;
-
-/**
- * Milliseconds in a day
- */
-export const dayInMs = 86400000;

--- a/packages/utils/src/validate-times/validateTimes.test.ts
+++ b/packages/utils/src/validate-times/validateTimes.test.ts
@@ -1,7 +1,7 @@
 import type { OntimeEvent } from 'ontime-types';
 import { TimeStrategy } from 'ontime-types';
 
-import { dayInMs } from '../timeConstants';
+import { dayInMs } from '../date-utils/conversionUtils';
 import { calculateDuration, getLinkedTimes, validateTimes } from './validateTimes';
 
 describe('validateTimes()', () => {

--- a/packages/utils/src/validate-times/validateTimes.ts
+++ b/packages/utils/src/validate-times/validateTimes.ts
@@ -1,7 +1,7 @@
 import type { OntimeEvent } from 'ontime-types';
 import { TimeStrategy } from 'ontime-types';
 
-import { dayInMs } from '../timeConstants.js';
+import { dayInMs } from '../date-utils/conversionUtils.js';
 import { validateTimeStrategy } from '../validate-events/validateEvent.js';
 
 export function getLinkedTimes(


### PR DESCRIPTION
Currently, users can add whatever they want in the time fields.
eg: 1000:01:01 is totally acceptable as 1000 hours 1 minute and 1 second

This has the potential of causing issues for us, at the same time, we dont see that it brings value to users

This PR caps all timer values for a single event to 24 hours, both in the interface and using the change endpoint

Note to reviewer:
I have opted for leave the parser code untouched. This is because the logic is complex and I would like to find a good way to handle edge cases
I suggest moving time parsing improvements to another PR