### PR TITLE
fix: account for skip in rundown calculations

### DIFF
--- a/apps/server/src/services/rundown-service/__tests__/rundownCache.test.ts
+++ b/apps/server/src/services/rundown-service/__tests__/rundownCache.test.ts
@@ -161,12 +161,13 @@ describe('generate()', () => {
     const testRundown: OntimeRundown = [
       { type: SupportedEvent.Event, id: '1', timeStart: 100, timeEnd: 200 } as OntimeEvent,
       { type: SupportedEvent.Event, id: '2', timeStart: 200, timeEnd: 300 } as OntimeEvent,
-      { type: SupportedEvent.Event, id: '3', timeStart: 300, timeEnd: 400 } as OntimeEvent,
+      { type: SupportedEvent.Event, id: 'skipped', skip: true, timeStart: 300, timeEnd: 400 } as OntimeEvent,
+      { type: SupportedEvent.Event, id: '3', timeStart: 400, timeEnd: 500 } as OntimeEvent,
     ];
 
     const initResult = generate(testRundown);
-    expect(initResult.order.length).toBe(3);
-    expect(initResult.totalDuration).toBe(400 - 100);
+    expect(initResult.order.length).toBe(4);
+    expect(initResult.totalDuration).toBe(500 - 100);
   });
 
   it('calculates total duration across days with gap', () => {

--- a/apps/server/src/services/rundown-service/rundownCache.ts
+++ b/apps/server/src/services/rundown-service/rundownCache.ts
@@ -102,17 +102,20 @@ export function generate(
       // update the persisted event
       initialRundown[i] = updatedEvent;
 
-      // update rundown duration
-      if (firstStart === null) {
-        firstStart = updatedEvent.timeStart;
-      }
-      lastEnd = updatedEvent.timeEnd;
+      // we need to generate the skip event, but dont want to use its times
+      if (!updatedEvent.skip) {
+        // update rundown duration
+        if (firstStart === null) {
+          firstStart = updatedEvent.timeStart;
+        }
+        lastEnd = updatedEvent.timeEnd;
 
-      // check if we go over midnight, account for eventual gaps
-      const gapOverMidnight = previousStart !== null && checkIsNextDay(previousStart, updatedEvent.timeStart);
-      const durationOverMidnight = updatedEvent.timeStart > updatedEvent.timeEnd;
-      if (gapOverMidnight || durationOverMidnight) {
-        daySpan++;
+        // check if we go over midnight, account for eventual gaps
+        const gapOverMidnight = previousStart !== null && checkIsNextDay(previousStart, updatedEvent.timeStart);
+        const durationOverMidnight = updatedEvent.timeStart > updatedEvent.timeEnd;
+        if (gapOverMidnight || durationOverMidnight) {
+          daySpan++;
+        }
       }
     }
 
@@ -120,7 +123,7 @@ export function generate(
     // !!! this must happen after handling the links
     if (isOntimeDelay(updatedEvent)) {
       accumulatedDelay += updatedEvent.duration;
-    } else if (isOntimeEvent(updatedEvent)) {
+    } else if (isOntimeEvent(updatedEvent) && !updatedEvent.skip) {
       const eventStart = updatedEvent.timeStart;
 
       // we only affect positive delays (time forwards)


### PR DESCRIPTION
Fixing an issue where skipped elements will still be counted for planned start and planned end