### PR TITLE
refactor: allow hiding sidebar

### DIFF
--- a/apps/client/src/features/rundown/RundownExport.tsx
+++ b/apps/client/src/features/rundown/RundownExport.tsx
@@ -2,6 +2,7 @@ import { memo } from 'react';
 import { IoArrowUp } from '@react-icons/all-files/io5/IoArrowUp';
 
 import ErrorBoundary from '../../common/components/error-boundary/ErrorBoundary';
+import { useAppMode } from '../../common/stores/appModeStore';
 import { handleLinks } from '../../common/utils/linkUtils';
 import { cx } from '../../common/utils/styleUtils';
 
@@ -12,6 +13,8 @@ import style from './RundownExport.module.scss';
 
 const RundownExport = () => {
   const isExtracted = window.location.pathname.includes('/rundown');
+  const appMode = useAppMode((state) => state.mode);
+  const hideSideBar = isExtracted && appMode === 'run';
 
   const classes = cx([style.rundownExport, isExtracted && style.extracted]);
 
@@ -24,11 +27,13 @@ const RundownExport = () => {
             <RundownWrapper />
           </ErrorBoundary>
         </div>
-        <div className={style.side}>
-          <ErrorBoundary>
-            <EventEditor />
-          </ErrorBoundary>
-        </div>
+        {!hideSideBar && (
+          <div className={style.side}>
+            <ErrorBoundary>
+              <EventEditor />
+            </ErrorBoundary>
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
Proposal implementation for hiding the side bar once the rundown is extracted. Here we do this by adding a parameter to the URL #997 #989 .

![Screenshot 2024-05-24 at 13 23 16](https://github.com/cpvalente/ontime/assets/34649812/ee41c6e6-cd8b-438f-abf3-5d4b6b736550)


This is a familiar pattern in the app, however I am not particularly happy here since it is not self documenting
ie: the user would have to know the parameter to use

I have also considered adding a toggle button, however this clutters the interface. I am not inclined to want a settings panel here as we have in cuesheet or on the views. Unsure on the best way forwards

Any ideas @alex-Ar @jwetzell @lukestein 