### PR TITLE
fix: correct key on shortcuts

### DIFF
--- a/apps/client/src/common/utils/deviceUtils.ts
+++ b/apps/client/src/common/utils/deviceUtils.ts
@@ -3,6 +3,6 @@ export function isMacOS() {
   return userAgent.includes('macintosh') || userAgent.includes('mac os');
 }
 
-export const deviceAlt = isMacOS() ? '⌥' : 'Alt';
+export const deviceAlt = isMacOS() ? 'Option' : 'Alt';
 
-export const deviceMod = isMacOS() ? '⌘' : 'Ctrl';
+export const deviceMod = isMacOS() ? 'Cmd' : 'Ctrl';

--- a/apps/client/src/features/rundown/event-editor/EventEditorEmpty.tsx
+++ b/apps/client/src/features/rundown/event-editor/EventEditorEmpty.tsx
@@ -40,7 +40,7 @@ function EventEditorEmpty() {
                 <AuxKey>+</AuxKey>
                 <Kbd>↑</Kbd>
                 <AuxKey>/</AuxKey>
-                <Kbd>↑</Kbd>
+                <Kbd>↓</Kbd>
               </td>
             </tr>
             <tr>
@@ -56,7 +56,7 @@ function EventEditorEmpty() {
               <td>
                 <Kbd>{deviceMod}</Kbd>
                 <AuxKey>+</AuxKey>
-                <Kbd>↑</Kbd>
+                <Kbd>Shift</Kbd>
                 <AuxKey>+</AuxKey>
                 <Kbd>V</Kbd>
               </td>
@@ -74,7 +74,7 @@ function EventEditorEmpty() {
               <td>
                 <Kbd>{deviceMod}</Kbd>
                 <AuxKey>+</AuxKey>
-                <Kbd>⌫</Kbd>
+                <Kbd>Backspace</Kbd>
               </td>
             </tr>
             <tr className={style.spacer} />
@@ -91,7 +91,7 @@ function EventEditorEmpty() {
               <td>
                 <Kbd>{deviceAlt}</Kbd>
                 <AuxKey>+</AuxKey>
-                <Kbd>↑</Kbd>
+                <Kbd>Shift</Kbd>
                 <AuxKey>+</AuxKey>
                 <Kbd>E</Kbd>
               </td>
@@ -109,7 +109,7 @@ function EventEditorEmpty() {
               <td>
                 <Kbd>{deviceAlt}</Kbd>
                 <AuxKey>+</AuxKey>
-                <Kbd>↑</Kbd>
+                <Kbd>Shift</Kbd>
                 <AuxKey>+</AuxKey>
                 <Kbd>B</Kbd>
               </td>
@@ -127,7 +127,7 @@ function EventEditorEmpty() {
               <td>
                 <Kbd>{deviceAlt}</Kbd>
                 <AuxKey>+</AuxKey>
-                <Kbd>↑</Kbd>
+                <Kbd>Shift</Kbd>
                 <AuxKey>+</AuxKey>
                 <Kbd>D</Kbd>
               </td>


### PR DESCRIPTION
- fixes an issue with wrong arrow direction in shortcuts
- fixes issues with using arrows instead of shift key

I have decided to spell out the keys rather than having symbols. I believe this makes it clearer even it it is more noisy (maybe)

<img width="424" alt="Screenshot 2024-05-29 at 21 59 39" src="https://github.com/cpvalente/ontime/assets/34649812/0933c312-c7a7-4a37-a906-5660f7d6dc10">

@lukestein what do you think?
