### PR TITLE
fix for MultiPartProgressBar styling

### DIFF
--- a/apps/client/src/common/components/multi-part-progress-bar/MultiPartProgressBar.scss
+++ b/apps/client/src/common/components/multi-part-progress-bar/MultiPartProgressBar.scss
@@ -7,10 +7,6 @@ $progress-bar-br: 3px;
   position: relative;
   width: 100%;
   height: $progress-bar-size;
-  border-radius: $progress-bar-br;
-  background-color: var(--timer-progress-bg-override, $viewer-card-bg-color);
-  display: flex;
-  overflow: hidden;
 
   &--hidden {
     display: none;
@@ -18,31 +14,36 @@ $progress-bar-br: 3px;
   }
 }
 
+.multiprogress-bar__bg {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  border-radius: $progress-bar-br;
+
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+}
+
 .multiprogress-bar__indicator {
   position: absolute;
-  height: inherit;
-  background-color: black;
+  inset: 0;
+  margin: -1px;
+  margin-left: 0;
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+}
+
+.multiprogress-bar__indicator-bar {
+  background-color: $ui-black;
   opacity: 0.8;
   transition: 1s linear;
   transition-property: width;
-  right: 0;
 }
 
 .multiprogress-bar__bg-normal {
-  position: absolute;
-  height: inherit;
-  right: 0;
-  width: 100%;
+  flex: 1;
 }
-
-.multiprogress-bar__bg-warning {
-  position: absolute;
-  height: inherit;
-  right: 0;
-}
-
-.multiprogress-bar__bg-danger {
-  position: absolute;
-  height: inherit;
-  right: 0;
-}
+// .multiprogress-bar__bg-warning {}
+// .multiprogress-bar__bg-danger {}

--- a/apps/client/src/common/components/multi-part-progress-bar/MultiPartProgressBar.scss
+++ b/apps/client/src/common/components/multi-part-progress-bar/MultiPartProgressBar.scss
@@ -8,7 +8,7 @@ $progress-bar-br: 3px;
   width: 100%;
   height: $progress-bar-size;
 
-  &.hidden {
+  &--hidden {
     display: none;
     transition: display 0.5s;
   }
@@ -18,7 +18,7 @@ $progress-bar-br: 3px;
   position: absolute;
   inset: 0;
   overflow: hidden;
-  border-radius: $progress-bar-br;
+  border-radius: var(--progress-bar-br, $progress-bar-br);
 
   display: flex;
   flex-direction: row;
@@ -41,7 +41,7 @@ $progress-bar-br: 3px;
   transition: 1s linear;
   transition-property: width;
 
-  .ignore-css-override & {
+  .multiprogress-bar--ignore-css-override & {
     background-color: $ui-black;
   }
 }
@@ -49,8 +49,6 @@ $progress-bar-br: 3px;
 .multiprogress-bar__bg-normal {
   flex: 1;
 }
-
-// .multiprogress-bar__bg-warning {}
 
 .multiprogress-bar__bg-danger {
   flex-shrink: 0;

--- a/apps/client/src/common/components/multi-part-progress-bar/MultiPartProgressBar.scss
+++ b/apps/client/src/common/components/multi-part-progress-bar/MultiPartProgressBar.scss
@@ -45,5 +45,9 @@ $progress-bar-br: 3px;
 .multiprogress-bar__bg-normal {
   flex: 1;
 }
+
 // .multiprogress-bar__bg-warning {}
-// .multiprogress-bar__bg-danger {}
+
+.multiprogress-bar__bg-danger {
+  flex-shrink: 0;
+}

--- a/apps/client/src/common/components/multi-part-progress-bar/MultiPartProgressBar.scss
+++ b/apps/client/src/common/components/multi-part-progress-bar/MultiPartProgressBar.scss
@@ -8,7 +8,7 @@ $progress-bar-br: 3px;
   width: 100%;
   height: $progress-bar-size;
 
-  &--hidden {
+  &.hidden {
     display: none;
     transition: display 0.5s;
   }
@@ -40,6 +40,10 @@ $progress-bar-br: 3px;
   opacity: 0.8;
   transition: 1s linear;
   transition-property: width;
+
+  .ignore-css-override & {
+    background-color: $ui-black;
+  }
 }
 
 .multiprogress-bar__bg-normal {

--- a/apps/client/src/common/components/multi-part-progress-bar/MultiPartProgressBar.scss
+++ b/apps/client/src/common/components/multi-part-progress-bar/MultiPartProgressBar.scss
@@ -36,7 +36,7 @@ $progress-bar-br: 3px;
 }
 
 .multiprogress-bar__indicator-bar {
-  background-color: $ui-black;
+  background-color: var(--background-color-override, $ui-black);
   opacity: 0.8;
   transition: 1s linear;
   transition-property: width;

--- a/apps/client/src/common/components/multi-part-progress-bar/MultiPartProgressBar.tsx
+++ b/apps/client/src/common/components/multi-part-progress-bar/MultiPartProgressBar.tsx
@@ -28,16 +28,20 @@ export default function MultiPartProgressBar(props: MultiPartProgressBar) {
     <div className={`multiprogress-bar ${hidden ? 'multiprogress-bar--hidden' : ''} ${className}`}>
       {now !== null && (
         <>
-          <div className='multiprogress-bar__bg-normal' style={{ backgroundColor: normalColor }} />
-          <div
-            className='multiprogress-bar__bg-warning'
-            style={{ width: `${warningWidth}%`, backgroundColor: warningColor }}
-          />
-          <div
-            className='multiprogress-bar__bg-danger'
-            style={{ width: `${dangerWidth}%`, backgroundColor: dangerColor }}
-          />
-          <div className='multiprogress-bar__indicator' style={{ width: `${percentRemaining}%` }} />
+          <div className='multiprogress-bar__bg'>
+            <div className='multiprogress-bar__bg-normal' style={{ backgroundColor: normalColor }} />
+            <div
+              className='multiprogress-bar__bg-warning'
+              style={{ width: `${warningWidth - dangerWidth}%`, backgroundColor: warningColor }}
+            />
+            <div
+              className='multiprogress-bar__bg-danger'
+              style={{ width: `${dangerWidth}%`, backgroundColor: dangerColor }}
+            />
+          </div>
+          <div className='multiprogress-bar__indicator'>
+            <div className='multiprogress-bar__indicator-bar' style={{ width: `${percentRemaining}%` }}></div>
+          </div>
         </>
       )}
     </div>

--- a/apps/client/src/common/components/multi-part-progress-bar/MultiPartProgressBar.tsx
+++ b/apps/client/src/common/components/multi-part-progress-bar/MultiPartProgressBar.tsx
@@ -13,11 +13,23 @@ interface MultiPartProgressBar {
   danger?: MaybeNumber;
   dangerColor: string;
   hidden?: boolean;
+  ignoreCssOverride?: boolean;
   className?: string;
 }
 
 export default function MultiPartProgressBar(props: MultiPartProgressBar) {
-  const { now, complete, normalColor, warning, warningColor, danger, dangerColor, hidden, className = '' } = props;
+  const {
+    now,
+    complete,
+    normalColor,
+    warning,
+    warningColor,
+    danger,
+    dangerColor,
+    hidden,
+    ignoreCssOverride,
+    className = '',
+  } = props;
 
   const percentRemaining = complete === 0 ? 0 : 100 - clamp(100 - (Math.max(now ?? 0, 0) * 100) / complete, 0, 100);
 
@@ -25,7 +37,11 @@ export default function MultiPartProgressBar(props: MultiPartProgressBar) {
   const warningWidth = warning ? clamp((warning / complete) * 100 - dangerWidth, 0, 100) : 0;
 
   return (
-    <div className={`multiprogress-bar ${hidden ? 'multiprogress-bar--hidden' : ''} ${className}`}>
+    <div
+      className={`multiprogress-bar ${hidden ? 'hidden' : ''} ${
+        ignoreCssOverride ? 'ignore-css-override' : ''
+      } ${className}`}
+    >
       {now !== null && (
         <>
           <div className='multiprogress-bar__bg'>

--- a/apps/client/src/common/components/multi-part-progress-bar/MultiPartProgressBar.tsx
+++ b/apps/client/src/common/components/multi-part-progress-bar/MultiPartProgressBar.tsx
@@ -22,7 +22,7 @@ export default function MultiPartProgressBar(props: MultiPartProgressBar) {
   const percentRemaining = complete === 0 ? 0 : 100 - clamp(100 - (Math.max(now ?? 0, 0) * 100) / complete, 0, 100);
 
   const dangerWidth = danger ? clamp((danger / complete) * 100, 0, 100) : 0;
-  const warningWidth = warning ? clamp((warning / complete) * 100, 0, 100) : 0;
+  const warningWidth = warning ? clamp((warning / complete) * 100 - dangerWidth, 0, 100) : 0;
 
   return (
     <div className={`multiprogress-bar ${hidden ? 'multiprogress-bar--hidden' : ''} ${className}`}>
@@ -32,7 +32,7 @@ export default function MultiPartProgressBar(props: MultiPartProgressBar) {
             <div className='multiprogress-bar__bg-normal' style={{ backgroundColor: normalColor }} />
             <div
               className='multiprogress-bar__bg-warning'
-              style={{ width: `${warningWidth - dangerWidth}%`, backgroundColor: warningColor }}
+              style={{ width: `${warningWidth}%`, backgroundColor: warningColor }}
             />
             <div
               className='multiprogress-bar__bg-danger'

--- a/apps/client/src/common/components/multi-part-progress-bar/MultiPartProgressBar.tsx
+++ b/apps/client/src/common/components/multi-part-progress-bar/MultiPartProgressBar.tsx
@@ -38,8 +38,8 @@ export default function MultiPartProgressBar(props: MultiPartProgressBar) {
 
   return (
     <div
-      className={`multiprogress-bar ${hidden ? 'hidden' : ''} ${
-        ignoreCssOverride ? 'ignore-css-override' : ''
+      className={`multiprogress-bar ${hidden ? 'multiprogress-bar--hidden' : ''} ${
+        ignoreCssOverride ? 'multiprogress-bar--ignore-css-override' : ''
       } ${className}`}
     >
       {now !== null && (

--- a/apps/client/src/common/components/multi-part-progress-bar/MultiPartProgressBar.tsx
+++ b/apps/client/src/common/components/multi-part-progress-bar/MultiPartProgressBar.tsx
@@ -40,7 +40,7 @@ export default function MultiPartProgressBar(props: MultiPartProgressBar) {
             />
           </div>
           <div className='multiprogress-bar__indicator'>
-            <div className='multiprogress-bar__indicator-bar' style={{ width: `${percentRemaining}%` }}></div>
+            <div className='multiprogress-bar__indicator-bar' style={{ width: `${percentRemaining}%` }} />
           </div>
         </>
       )}

--- a/apps/client/src/features/cuesheet/cuesheet-progress/CuesheetProgress.tsx
+++ b/apps/client/src/features/cuesheet/cuesheet-progress/CuesheetProgress.tsx
@@ -19,6 +19,7 @@ export default function CuesheetProgress() {
       danger={timeDanger}
       dangerColor={data!.dangerColor}
       className={styles.progressOverride}
+      ignoreCssOverride
     />
   );
 }

--- a/apps/client/src/features/operator/status-bar/StatusBar.module.scss
+++ b/apps/client/src/features/operator/status-bar/StatusBar.module.scss
@@ -105,5 +105,7 @@
 }
 
 .progressOverride {
-  border-radius: 0;
+  & :global(.multiprogress-bar__bg) {
+    border-radius: 0;
+  }
 }

--- a/apps/client/src/features/operator/status-bar/StatusBar.module.scss
+++ b/apps/client/src/features/operator/status-bar/StatusBar.module.scss
@@ -105,7 +105,5 @@
 }
 
 .progressOverride {
-  & :global(.multiprogress-bar__bg) {
-    border-radius: 0;
-  }
+  --progress-bar-br: 0;
 }

--- a/apps/client/src/features/operator/status-bar/StatusBarProgress.tsx
+++ b/apps/client/src/features/operator/status-bar/StatusBarProgress.tsx
@@ -24,6 +24,7 @@ export default function StatusBarProgress(props: StatusBarProgressProps) {
       danger={timeDanger}
       dangerColor={viewSettings.dangerColor}
       className={styles.progressOverride}
+      ignoreCssOverride
     />
   );
 }


### PR DESCRIPTION
**this is a fix for #900**

Hey, new user here really enjoying the app! I saw this issue was very similar to something I ran into recently, so throwing in this potential solution. As I understand it this has to do with sub-pixel rendering issues in the browser when using `overflow: hidden` to clip corners, where multiple elements being clipped always come out slightly differently due to anti-aliasing.

I reworked the HTML a little bit so that the colored backgrounds don't overlap, which solves most of this. But the indicator has to overlap with them to work, so I made it match the background color and go 1px beyond the edge of the status bar. This works, but should be noted it would look terrible on any other background color unless the component was fed the new background color as well. Hope that's still helpful!