### PR TITLE
refactor: timer overrides do not affect minimal

### DIFF
--- a/apps/client/src/common/components/view-params-editor/constants.ts
+++ b/apps/client/src/common/components/view-params-editor/constants.ts
@@ -231,13 +231,6 @@ export const MINIMAL_TIMER_OPTIONS: ParamField[] = [
     defaultValue: false,
   },
   {
-    id: 'hidemessages',
-    title: 'Hide Message Overlay',
-    description: 'Whether to hide the overlay from showing timer screen messages',
-    type: 'boolean',
-    defaultValue: false,
-  },
-  {
     id: 'hideendmessage',
     title: 'Hide End Message',
     description: 'Whether to hide end message and continue showing the clock if timer is in overtime',

--- a/apps/client/src/features/viewers/minimal-timer/MinimalTimer.scss
+++ b/apps/client/src/features/viewers/minimal-timer/MinimalTimer.scss
@@ -42,42 +42,6 @@
 
   /* =================== OVERLAY ===================*/
 
-  .message-overlay {
-    position: fixed;
-    width: 100%;
-    height: 100%;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background-color: $viewer-overlay-bg-color;
-    z-index: -1;
-    opacity: 0;
-    transition: $viewer-transition-time;
-
-    &--active {
-      opacity: 1;
-      transition: $viewer-transition-time;
-      transition-property: opacity;
-      z-index: 2;
-    }
-  }
-
-  .message {
-    width: inherit;
-    padding: 2vw;
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    color: white;
-    transform: translate(-50%, -50%);
-    -ms-transform: translate(-50%, -50%);
-    font-size: 15vw;
-    line-height: 30vh;
-    text-align: center;
-    font-weight: 600;
-  }
-
   .end-message {
       text-align: center;
       font-size: 12vw;

--- a/apps/client/src/features/viewers/minimal-timer/MinimalTimer.tsx
+++ b/apps/client/src/features/viewers/minimal-timer/MinimalTimer.tsx
@@ -1,5 +1,5 @@
 import { useSearchParams } from 'react-router-dom';
-import { Playback, TimerMessage, TimerType, ViewSettings } from 'ontime-types';
+import { Playback, TimerType, ViewSettings } from 'ontime-types';
 
 import { overrideStylesURL } from '../../../common/api/constants';
 import { MINIMAL_TIMER_OPTIONS } from '../../../common/components/view-params-editor/constants';
@@ -15,13 +15,12 @@ import './MinimalTimer.scss';
 
 interface MinimalTimerProps {
   isMirrored: boolean;
-  pres: TimerMessage;
   time: ViewExtendedTimer;
   viewSettings: ViewSettings;
 }
 
 export default function MinimalTimer(props: MinimalTimerProps) {
-  const { isMirrored, pres, time, viewSettings } = props;
+  const { isMirrored, time, viewSettings } = props;
   const { shouldRender } = useRuntimeStylesheet(viewSettings?.overrideStyles && overrideStylesURL);
   const { getLocalizedString } = useTranslation();
   const [searchParams] = useSearchParams();
@@ -117,9 +116,6 @@ export default function MinimalTimer(props: MinimalTimerProps) {
   const hideOvertime = searchParams.get('hideovertime');
   userOptions.hideOvertime = isStringBoolean(hideOvertime);
 
-  const hideMessagesOverlay = searchParams.get('hidemessages');
-  userOptions.hideMessagesOverlay = isStringBoolean(hideMessagesOverlay);
-
   const hideEndMessage = searchParams.get('hideendmessage');
   userOptions.hideEndMessage = isStringBoolean(hideEndMessage);
 
@@ -128,7 +124,6 @@ export default function MinimalTimer(props: MinimalTimerProps) {
 
   const timerIsTimeOfDay = time.timerType === TimerType.Clock;
 
-  const showOverlay = pres.text !== '' && pres.visible;
   const isPlaying = time.playback !== Playback.Pause;
 
   const showEndMessage = (time.current ?? 0) < 0 && viewSettings.endMessage && !hideEndMessage;
@@ -138,8 +133,6 @@ export default function MinimalTimer(props: MinimalTimerProps) {
   const showProgress = time.playback !== Playback.Stop;
   const showWarning = (time.current ?? 1) < (time.timeWarning ?? 0);
   const showDanger = (time.current ?? 1) < (time.timeDanger ?? 0);
-  const showBlinking = pres.blink;
-  const showBlackout = pres.blackout;
 
   let timerColor = viewSettings.normalColor;
   if (!timerIsTimeOfDay && showProgress && showWarning) timerColor = viewSettings.warningColor;
@@ -155,10 +148,8 @@ export default function MinimalTimer(props: MinimalTimerProps) {
 
   const timerFontSize = (89 / (stageTimerCharacters - 1)) * (userOptions.size || 1);
 
-  const timerClasses = `timer ${!isPlaying ? 'timer--paused' : ''} ${showFinished ? 'timer--finished' : ''} ${
-    showBlinking ? (showOverlay ? '' : 'blink') : ''
-  }`;
-  const baseClasses = `minimal-timer ${isMirrored ? 'mirror' : ''} ${showBlackout ? 'blackout' : ''}`;
+  const timerClasses = `timer ${!isPlaying ? 'timer--paused' : ''} ${showFinished ? 'timer--finished' : ''}`;
+  const baseClasses = `minimal-timer ${isMirrored ? 'mirror' : ''}`;
 
   return (
     <div
@@ -171,15 +162,8 @@ export default function MinimalTimer(props: MinimalTimerProps) {
       data-testid='minimal-timer'
     >
       <ViewParamsEditor paramFields={MINIMAL_TIMER_OPTIONS} />
-      {!hideMessagesOverlay && (
-        <div className={showOverlay ? 'message-overlay message-overlay--active' : 'message-overlay'}>
-          <div className={`message ${showBlinking ? 'blink' : ''}`}>{pres.text}</div>
-        </div>
-      )}
       {showEndMessage ? (
-        <div className={`end-message ${showBlinking ? (showOverlay ? '' : 'blink') : ''}`}>
-          {viewSettings.endMessage}
-        </div>
+        <div className='end-message'>{viewSettings.endMessage}</div>
       ) : (
         <div
           className={timerClasses}


### PR DESCRIPTION
Tidying up behaviour mentioned in https://github.com/cpvalente/ontime/issues/1016#issuecomment-2142585773

The overrides for `message`, `blackout` and `blink` do not apply to `/minimal`
Unfortunately this also means that we need to remove one of the parameters in the `minimal view`. 🤞 