### PR TITLE
refactor: declare timer phase

### DIFF
--- a/apps/client/src/common/models/TimeManager.type.ts
+++ b/apps/client/src/common/models/TimeManager.type.ts
@@ -1,4 +1,4 @@
-import { MaybeNumber, Playback, TimerType } from 'ontime-types';
+import { MaybeNumber, Playback, TimerPhase, TimerType } from 'ontime-types';
 
 // first set extends TimerState
 export type ViewExtendedTimer = {
@@ -8,12 +8,11 @@ export type ViewExtendedTimer = {
   elapsed: MaybeNumber;
   expectedFinish: MaybeNumber;
   finishedAt: MaybeNumber;
+  phase: TimerPhase;
   playback: Playback;
   secondaryTimer: MaybeNumber;
   startedAt: MaybeNumber;
 
   clock: number;
-  timeDanger: MaybeNumber;
-  timeWarning: MaybeNumber;
   timerType: TimerType;
 };

--- a/apps/client/src/common/stores/runtime.ts
+++ b/apps/client/src/common/stores/runtime.ts
@@ -1,5 +1,5 @@
 import isEqual from 'react-fast-compare';
-import { Playback, RuntimeStore, SimpleDirection, SimplePlayback } from 'ontime-types';
+import { Playback, RuntimeStore, SimpleDirection, SimplePlayback, TimerPhase } from 'ontime-types';
 import { createWithEqualityFn, useStoreWithEqualityFn } from 'zustand/traditional';
 
 export const runtimeStorePlaceholder: RuntimeStore = {
@@ -11,6 +11,7 @@ export const runtimeStorePlaceholder: RuntimeStore = {
     elapsed: null,
     expectedFinish: null,
     finishedAt: null,
+    phase: TimerPhase.None,
     playback: Playback.Stop,
     secondaryTimer: null,
     startedAt: null,

--- a/apps/client/src/declarations/declaration.d.ts
+++ b/apps/client/src/declarations/declaration.d.ts
@@ -17,4 +17,10 @@ declare global {
   }
 }
 
+declare module 'react' {
+  interface CSSProperties {
+    [key: `--${string}`]: string | number;
+  }
+}
+
 export default {};

--- a/apps/client/src/features/control/playback/playback-timer/PlaybackTimer.tsx
+++ b/apps/client/src/features/control/playback/playback-timer/PlaybackTimer.tsx
@@ -1,6 +1,6 @@
 import { PropsWithChildren } from 'react';
 import { Tooltip } from '@chakra-ui/react';
-import { Playback } from 'ontime-types';
+import { Playback, TimerPhase } from 'ontime-types';
 import { dayInMs, millisToMinutes, millisToSeconds, millisToString } from 'ontime-utils';
 
 import { useTimer } from '../../../../common/hooks/useSocket';
@@ -44,7 +44,7 @@ export default function PlaybackTimer(props: PropsWithChildren<PlaybackTimerProp
 
   const isRolling = playback === Playback.Roll;
   const isWaiting = timer.secondaryTimer !== null && timer.secondaryTimer > 0 && timer.current === null;
-  const isOvertime = timer.current !== null && timer.current < 0;
+  const isOvertime = timer.phase === TimerPhase.Negative;
   const hasAddedTime = Boolean(timer.addedTime);
 
   const rollLabel = isRolling ? 'Roll mode active' : '';

--- a/apps/client/src/features/viewers/ViewWrapper.tsx
+++ b/apps/client/src/features/viewers/ViewWrapper.tsx
@@ -82,8 +82,6 @@ const withData = <P extends WithDataProps>(Component: ComponentType<P>) => {
       ...timer,
       clock,
       timerType: eventNow?.timerType ?? null,
-      timeWarning: eventNow?.timeWarning ?? null,
-      timeDanger: eventNow?.timeWarning ?? null,
     };
 
     // prevent render until we get all the data we need

--- a/apps/client/src/features/viewers/minimal-timer/MinimalTimer.scss
+++ b/apps/client/src/features/viewers/minimal-timer/MinimalTimer.scss
@@ -20,11 +20,11 @@
   }
 
   .timer {
+    opacity: 1;
     font-family: var(--font-family-bold-override, $timer-bold-font-family) ;
     font-size: 20vw;
     position: relative;
-    color: var(--timer-color-override, $timer-color);
-    opacity: 1;
+    color: var(--timer-color-override, var(--phase-color));
     transition: $viewer-transition-time;
     transition-property: opacity;
     background-color: transparent;

--- a/apps/client/src/features/viewers/minimal-timer/MinimalTimer.tsx
+++ b/apps/client/src/features/viewers/minimal-timer/MinimalTimer.tsx
@@ -1,5 +1,5 @@
 import { useSearchParams } from 'react-router-dom';
-import { Playback, TimerType, ViewSettings } from 'ontime-types';
+import { Playback, TimerPhase, TimerType, ViewSettings } from 'ontime-types';
 
 import { overrideStylesURL } from '../../../common/api/constants';
 import { MINIMAL_TIMER_OPTIONS } from '../../../common/components/view-params-editor/constants';
@@ -126,13 +126,13 @@ export default function MinimalTimer(props: MinimalTimerProps) {
 
   const isPlaying = time.playback !== Playback.Pause;
 
-  const showEndMessage = (time.current ?? 0) < 0 && viewSettings.endMessage && !hideEndMessage;
-  const finished = time.playback === Playback.Play && (time.current ?? 0) < 0 && time.startedAt;
+  const finished = time.phase === TimerPhase.Negative;
+  const showEndMessage = finished && viewSettings.endMessage && !hideEndMessage;
   const showFinished = finished && !userOptions?.hideOvertime && (time.timerType !== TimerType.Clock || showEndMessage);
 
   const showProgress = time.playback !== Playback.Stop;
-  const showWarning = (time.current ?? 1) < (time.timeWarning ?? 0);
-  const showDanger = (time.current ?? 1) < (time.timeDanger ?? 0);
+  const showWarning = time.phase === TimerPhase.Warning;
+  const showDanger = time.phase === TimerPhase.Danger;
 
   let timerColor = viewSettings.normalColor;
   if (!timerIsTimeOfDay && showProgress && showWarning) timerColor = viewSettings.warningColor;
@@ -150,7 +150,6 @@ export default function MinimalTimer(props: MinimalTimerProps) {
 
   const timerClasses = `timer ${!isPlaying ? 'timer--paused' : ''} ${showFinished ? 'timer--finished' : ''}`;
   const baseClasses = `minimal-timer ${isMirrored ? 'mirror' : ''}`;
-
   return (
     <div
       className={showFinished ? `${baseClasses} minimal-timer--finished` : baseClasses}
@@ -168,12 +167,12 @@ export default function MinimalTimer(props: MinimalTimerProps) {
         <div
           className={timerClasses}
           style={{
-            color: timerColor,
             fontSize: `${timerFontSize}vw`,
             fontFamily: userOptions.font,
             top: userOptions.top,
             left: userOptions.left,
             backgroundColor: userOptions.textBackground,
+            '--phase-color': timerColor,
           }}
         >
           {display}

--- a/apps/client/src/features/viewers/timer/Timer.scss
+++ b/apps/client/src/features/viewers/timer/Timer.scss
@@ -109,7 +109,7 @@
     .timer {
       opacity: 1;
       font-family: var(--font-family-override, $viewer-font-family);
-      color: var(--timer-color-override, $timer-color);
+      color: var(--timer-color-override, var(--phase-color));
       line-height: 0.9em;
       text-align: center;
       letter-spacing: 0.05em;

--- a/apps/client/src/features/viewers/timer/Timer.tsx
+++ b/apps/client/src/features/viewers/timer/Timer.tsx
@@ -7,6 +7,7 @@ import {
   Playback,
   Settings,
   TimerMessage,
+  TimerPhase,
   TimerType,
   ViewSettings,
 } from 'ontime-types';
@@ -110,14 +111,14 @@ export default function Timer(props: TimerProps) {
 
   const timerIsTimeOfDay = time.timerType === TimerType.Clock;
 
-  const finished = time.playback === Playback.Play && (time.current ?? 0) < 0 && time.startedAt;
+  const finished = time.phase === TimerPhase.Negative;
   const totalTime = (time.duration ?? 0) + (time.addedTime ?? 0);
 
-  const showEndMessage = (time.current ?? 1) < 0 && viewSettings.endMessage;
+  const showEndMessage = finished && viewSettings.endMessage;
   const showProgress = time.playback !== Playback.Stop;
   const showFinished = finished && (time.timerType !== TimerType.Clock || showEndMessage);
-  const showWarning = (time.current ?? 1) < (eventNow?.timeWarning ?? 0);
-  const showDanger = (time.current ?? 1) < (eventNow?.timeDanger ?? 0);
+  const showWarning = time.phase === TimerPhase.Warning;
+  const showDanger = time.phase === TimerPhase.Danger;
   const showBlinking = pres.blink;
   const showBlackout = pres.blackout;
   const showClock = time.timerType !== TimerType.Clock;
@@ -173,7 +174,7 @@ export default function Timer(props: TimerProps) {
             className={timerClasses}
             style={{
               fontSize: `${timerFontSize}vw`,
-              color: timerColor,
+              '--phase-color': timerColor,
             }}
           >
             {display}

--- a/apps/server/src/services/__tests__/timerUtils.test.ts
+++ b/apps/server/src/services/__tests__/timerUtils.test.ts
@@ -1,11 +1,12 @@
 import { MILLIS_PER_HOUR, dayInMs, millisToString } from 'ontime-utils';
-import { EndAction, OntimeEvent, Playback, TimeStrategy, TimerType } from 'ontime-types';
+import { EndAction, OntimeEvent, Playback, TimeStrategy, TimerPhase, TimerType } from 'ontime-types';
 
 import {
   getCurrent,
   getExpectedFinish,
   getRollTimers,
   getRuntimeOffset,
+  getTimerPhase,
   getTotalDuration,
   normaliseEndTime,
   skippedOutOfEvent,
@@ -1754,5 +1755,99 @@ describe('getTotalDuration()', () => {
     const daySpan = 2;
     const duration = getTotalDuration(start, end, daySpan);
     expect(millisToString(duration)).toBe('62:00:00');
+  });
+});
+
+describe('getTimerPhase()', () => {
+  it('should be None if the timer is not running', () => {
+    const state = {
+      timer: {
+        addedTime: 0,
+        current: null,
+        duration: null,
+        elapsed: null,
+        expectedFinish: null,
+        finishedAt: null,
+        playback: Playback.Stop,
+        phase: TimerPhase.None,
+        secondaryTimer: null,
+        startedAt: null,
+      },
+    } as RuntimeState;
+
+    const phase = getTimerPhase(state);
+    expect(phase).toBe(TimerPhase.None);
+  });
+
+  it('can be negative', () => {
+    const state = {
+      timer: {
+        addedTime: 0,
+        current: -50,
+        duration: 1000,
+        playback: Playback.Play,
+      },
+      eventNow: {
+        timeDanger: 100,
+        timeWarning: 200,
+      },
+    } as RuntimeState;
+
+    const phase = getTimerPhase(state);
+    expect(phase).toBe(TimerPhase.Negative);
+  });
+
+  it('can be danger', () => {
+    const state = {
+      timer: {
+        addedTime: 0,
+        current: 0,
+        duration: 1000,
+        playback: Playback.Play,
+      },
+      eventNow: {
+        timeDanger: 100,
+        timeWarning: 200,
+      },
+    } as RuntimeState;
+
+    const phase = getTimerPhase(state);
+    expect(phase).toBe(TimerPhase.Danger);
+  });
+
+  it('can be warning', () => {
+    const state = {
+      timer: {
+        addedTime: 0,
+        current: 150,
+        duration: 1000,
+        playback: Playback.Play,
+      },
+      eventNow: {
+        timeDanger: 100,
+        timeWarning: 200,
+      },
+    } as RuntimeState;
+
+    const phase = getTimerPhase(state);
+    expect(phase).toBe(TimerPhase.Warning);
+  });
+
+  it('it default if the timer is playing and there is none of the above', () => {
+    const state = {
+      timer: {
+        addedTime: 0,
+        current: 250,
+        duration: 1000,
+        playback: Playback.Play,
+      },
+      eventNow: {
+        timeDanger: 100,
+        timeWarning: 200,
+      },
+    } as RuntimeState;
+
+    const phase = getTimerPhase(state);
+    expect(phase).toBe(TimerPhase.Default);
   });
 });

--- a/apps/server/src/services/timerUtils.ts
+++ b/apps/server/src/services/timerUtils.ts
@@ -1,4 +1,4 @@
-import { MaybeNumber, MaybeString, OntimeEvent, TimerType } from 'ontime-types';
+import { MaybeNumber, MaybeString, OntimeEvent, Playback, TimerPhase, TimerType } from 'ontime-types';
 import { dayInMs } from 'ontime-utils';
 import { RuntimeState } from '../stores/runtimeState.js';
 import { timerConfig } from '../config/config.js';
@@ -357,4 +357,44 @@ export function getExpectedEnd(state: RuntimeState): MaybeNumber {
     return null;
   }
   return state.runtime.plannedEnd - state.runtime.offset + state._timer.totalDelay;
+}
+
+/**
+ * Utility checks whether the playback is considered to be active
+ * @param state
+ * @returns
+ */
+function isPlaybackActive(state: RuntimeState): boolean {
+  return (
+    state.timer.playback === Playback.Play ||
+    state.timer.playback === Playback.Pause ||
+    state.timer.playback === Playback.Roll
+  );
+}
+
+/**
+ * Checks running timer to see which phase it currently is in
+ * @param state
+ */
+export function getTimerPhase(state: RuntimeState): TimerPhase {
+  if (!isPlaybackActive(state)) {
+    return TimerPhase.None;
+  }
+
+  const current = state.timer.current;
+  if (current < 0) {
+    return TimerPhase.Negative;
+  }
+
+  const danger = state.eventNow.timeDanger;
+  if (current <= danger) {
+    return TimerPhase.Danger;
+  }
+
+  const warning = state.eventNow.timeWarning;
+  if (current <= warning) {
+    return TimerPhase.Warning;
+  }
+
+  return TimerPhase.Default;
 }

--- a/apps/server/src/stores/runtimeState.ts
+++ b/apps/server/src/stores/runtimeState.ts
@@ -1,4 +1,4 @@
-import { MaybeNumber, OntimeEvent, Playback, Runtime, TimerState, TimerType } from 'ontime-types';
+import { MaybeNumber, OntimeEvent, Playback, Runtime, TimerPhase, TimerState, TimerType } from 'ontime-types';
 import { calculateDuration, dayInMs } from 'ontime-utils';
 
 import { clock } from '../services/Clock.js';
@@ -10,6 +10,7 @@ import {
   getExpectedFinish,
   getRollTimers,
   getRuntimeOffset,
+  getTimerPhase,
   skippedOutOfEvent,
   updateRoll,
 } from '../services/timerUtils.js';
@@ -32,6 +33,7 @@ const initialTimer: TimerState = {
   elapsed: null,
   expectedFinish: null, // TODO: expected finish could account for midnight, we cleanup in the clients
   finishedAt: null,
+  phase: TimerPhase.None,
   playback: Playback.Stop,
   secondaryTimer: null,
   startedAt: null,
@@ -300,6 +302,10 @@ export function start(state: RuntimeState = runtimeState): boolean {
     state.runtime.actualStart = state.clock;
   }
 
+  // update timer phase
+  runtimeState.timer.phase = getTimerPhase(runtimeState);
+
+  // update offset
   state.runtime.offset = getRuntimeOffset(state);
   state.runtime.expectedEnd = state.runtime.plannedEnd - state.runtime.offset;
 
@@ -386,6 +392,9 @@ export function update(): UpdateResult {
     runtimeState.timer.current = getCurrent(runtimeState);
     runtimeState.timer.duration = runtimeState.timer.current;
   }
+
+  // update timer phase
+  runtimeState.timer.phase = getTimerPhase(runtimeState);
 
   // update offset
   runtimeState.runtime.offset = getRuntimeOffset(runtimeState);

--- a/packages/types/src/definitions/runtime/TimerState.type.ts
+++ b/packages/types/src/definitions/runtime/TimerState.type.ts
@@ -1,6 +1,14 @@
 import type { MaybeNumber } from '../../index.js';
 import type { Playback } from './Playback.type.js';
 
+export enum TimerPhase {
+  None = 'none',
+  Default = 'default',
+  Warning = 'warning',
+  Danger = 'danger',
+  Negative = 'negative',
+}
+
 export type TimerState = {
   addedTime: number; // time added by user, can be negative
   current: MaybeNumber; // running countdown
@@ -8,6 +16,7 @@ export type TimerState = {
   elapsed: MaybeNumber; // elapsed time in current timer
   expectedFinish: MaybeNumber; // time we expect timer to finish
   finishedAt: MaybeNumber; // only if timer has already finished
+  phase: TimerPhase;
   playback: Playback;
   secondaryTimer: MaybeNumber; // used for roll mode
   startedAt: MaybeNumber; // only if timer has already started

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -60,7 +60,7 @@ export type { Message, TimerMessage, MessageState } from './definitions/runtime/
 
 export type { Runtime } from './definitions/runtime/Runtime.type.js';
 export type { RuntimeStore } from './definitions/runtime/RuntimeStore.type.js';
-export type { TimerState } from './definitions/runtime/TimerState.type.js';
+export { type TimerState, TimerPhase } from './definitions/runtime/TimerState.type.js';
 
 // ---> Extra Timer
 export { type SimpleTimerState, SimplePlayback, SimpleDirection } from './definitions/runtime/AuxTimer.type.js';


### PR DESCRIPTION
This PR exposes a timer phase property on the running timer.

```ts
export enum TimerPhase {
  None = 'none',
  Default = 'default',
  Warning = 'warning',
  Danger = 'danger',
  Negative = 'negative',
}
```

Since we want to make the Danger and Warning thresholds events, it makes sense to calculate this in the server. Might as well expose it.

By exposing it we get the added advantage of providing better feedback to integrations.

Note to reviewer: `TimerPhase` is not a great name, suggestions are welcome 