### PR TITLE
refactor: supress modifiers in count-up timers

### DIFF
--- a/apps/client/src/features/viewers/minimal-timer/MinimalTimer.tsx
+++ b/apps/client/src/features/viewers/minimal-timer/MinimalTimer.tsx
@@ -126,13 +126,14 @@ export default function MinimalTimer(props: MinimalTimerProps) {
 
   const isPlaying = time.playback !== Playback.Pause;
 
+  const shouldShowModifiers = time.timerType !== TimerType.Clock && time.timerType !== TimerType.CountUp;
   const finished = time.phase === TimerPhase.Negative;
   const showEndMessage = finished && viewSettings.endMessage && !hideEndMessage;
-  const showFinished = finished && !userOptions?.hideOvertime && (time.timerType !== TimerType.Clock || showEndMessage);
+  const showFinished = finished && !userOptions?.hideOvertime && (shouldShowModifiers || showEndMessage);
 
   const showProgress = time.playback !== Playback.Stop;
-  const showWarning = time.phase === TimerPhase.Warning;
-  const showDanger = time.phase === TimerPhase.Danger;
+  const showWarning = shouldShowModifiers && time.phase === TimerPhase.Warning;
+  const showDanger = shouldShowModifiers && time.phase === TimerPhase.Danger;
 
   let timerColor = viewSettings.normalColor;
   if (!timerIsTimeOfDay && showProgress && showWarning) timerColor = viewSettings.warningColor;

--- a/apps/client/src/features/viewers/timer/Timer.tsx
+++ b/apps/client/src/features/viewers/timer/Timer.tsx
@@ -114,11 +114,12 @@ export default function Timer(props: TimerProps) {
   const finished = time.phase === TimerPhase.Negative;
   const totalTime = (time.duration ?? 0) + (time.addedTime ?? 0);
 
+  const shouldShowModifiers = time.timerType !== TimerType.Clock && time.timerType !== TimerType.CountUp;
   const showEndMessage = finished && viewSettings.endMessage;
   const showProgress = time.playback !== Playback.Stop;
-  const showFinished = finished && (time.timerType !== TimerType.Clock || showEndMessage);
-  const showWarning = time.phase === TimerPhase.Warning;
-  const showDanger = time.phase === TimerPhase.Danger;
+  const showFinished = finished && (shouldShowModifiers || showEndMessage);
+  const showWarning = shouldShowModifiers && time.phase === TimerPhase.Warning;
+  const showDanger = shouldShowModifiers && time.phase === TimerPhase.Danger;
   const showBlinking = pres.blink;
   const showBlackout = pres.blackout;
   const showClock = time.timerType !== TimerType.Clock;


### PR DESCRIPTION
When a timer is marked as count-up I believe it makes no sense to show the warning, danger times and negative times modifier since we made we made a choice to hide this from the user

This PR changes the minimal and timer views to make sure that count-up timers dont have the colour modifiers

<img width="1507" alt="Screenshot 2024-06-03 at 20 44 56" src="https://github.com/cpvalente/ontime/assets/34649812/c0921764-eda1-490a-ac28-550bb6af8a0d">

@lukestein what do you think?
