### PR TITLE
prevent timer phase errors on no eventNow

### DIFF
--- a/apps/server/src/services/timerUtils.ts
+++ b/apps/server/src/services/timerUtils.ts
@@ -389,12 +389,12 @@ export function getTimerPhase(state: RuntimeState): TimerPhase {
     return TimerPhase.Negative;
   }
 
-  const danger = state.eventNow.timeDanger;
+  const danger = state.eventNow?.timeDanger;
   if (current <= danger) {
     return TimerPhase.Danger;
   }
 
-  const warning = state.eventNow.timeWarning;
+  const warning = state.eventNow?.timeWarning;
   if (current <= warning) {
     return TimerPhase.Warning;
   }


### PR DESCRIPTION
`getTimerPhase`  was assuming that `state.eventNow` was always populated which isn't always the case. This just adds an optional chaining operator so that if it is undefined or null that it does not error.

We could also specifically check if `state.eventNow` is not defined and return a specific `TimerPhase` value.

closes #1042  