### PR TITLE
consider custom fields when loading operator main field

### DIFF
--- a/apps/client/src/features/operator/Operator.tsx
+++ b/apps/client/src/features/operator/Operator.tsx
@@ -171,7 +171,7 @@ export default function Operator() {
               return null;
             }
 
-            const mainField = main ? entry?.[main] || entry.title : entry.title;
+            const mainField = getPropertyValue(entry, main) ?? '';
             const secondaryField = getPropertyValue(entry, secondary) ?? '';
             const subscribedData = entry.custom[subscribe];
 

--- a/apps/client/src/features/operator/Operator.tsx
+++ b/apps/client/src/features/operator/Operator.tsx
@@ -171,7 +171,7 @@ export default function Operator() {
               return null;
             }
 
-            const mainField = getPropertyValue(entry, main) ?? '';
+            const mainField = main ? getPropertyValue(entry, main) ?? '' : entry.title;
             const secondaryField = getPropertyValue(entry, secondary) ?? '';
             const subscribedData = entry.custom[subscribe];
 


### PR DESCRIPTION
The operator view had some different logic for loading the main field that did not consider custom fields. I have aligned the main field population with the secondary field. If this is not the desired behavior then a solution that handles custom fields should be proposed.

Closes #1047 