### PR TITLE
refactor: improve console visibility

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -81,6 +81,9 @@ From the project root, run the following commands
 
 The build distribution assets will be at `.apps/electron/dist`
 
+Note: The MacOS build will only work in CI, locally it will fail due to notarisation issues.
+Use the `turbo dist-mac:local` command to build a MacOS distribution locally.
+
 ## DOCKER
 
 Ontime provides a docker-compose file to aid with building and running docker images.

--- a/apps/electron/main.js
+++ b/apps/electron/main.js
@@ -30,6 +30,10 @@ let win;
 let splash;
 let tray = null;
 
+/**
+ * Coordinates the node process startup
+ * @returns {number} server port - the port at which the backend has been started at
+ */
 async function startBackend() {
   // in dev mode, we expect both UI and server to be running
   if (!isProduction) {
@@ -62,6 +66,9 @@ function showNotification(title, text) {
   }).show();
 }
 
+/**
+ * Terminate node service and close electron app
+ */
 function appShutdown() {
   // terminate node service
   (async () => {
@@ -76,19 +83,28 @@ function appShutdown() {
   app.quit();
 }
 
+/**
+ * Sets Ontime window in focus
+ */
 function bringToFront() {
   win.show();
   win.focus();
 }
 
+/**
+ * Coordinates the shutdown process
+ */
 function askToQuit() {
   bringToFront();
   win.send('user-request-shutdown');
 }
 
+/**
+ * Allows processes to escalate errors to be shown in electron
+ * @param {string} error
+ */
 function escalateError(error) {
   dialog.showErrorBox('An unrecoverable error occurred', error);
-  app.quit();
 }
 
 // Ensure there isn't another instance of the app running already
@@ -108,6 +124,9 @@ if (!lock) {
   });
 }
 
+/**
+ * Coordinates creation of electron windows (splash and main)
+ */
 function createWindow() {
   splash = new BrowserWindow({
     width: 333,
@@ -196,12 +215,16 @@ app.whenReady().then(() => {
       console.log('ERROR: Ontime failed to start', error);
     });
 
-  // recreate window if no others open
+  /**
+   * recreate window if no others open
+   */
   app.on('activate', () => {
     win.show();
   });
 
-  // Hide on close
+  /**
+   * Hide on close
+   */
   win.on('close', function (event) {
     event.preventDefault();
     if (!isQuitting) {
@@ -220,7 +243,9 @@ app.whenReady().then(() => {
   tray.setContextMenu(trayContextMenu);
 });
 
-// unregister shortcuts before quitting
+/**
+ * Unregister shortcuts before quitting
+ */
 app.once('will-quit', () => {
   globalShortcut.unregisterAll();
 });
@@ -237,7 +262,9 @@ ipcMain.on('shutdown', () => {
   appShutdown();
 });
 
-// Window manipulation
+/**
+ * Handles requests to set window properties
+ */
 ipcMain.on('set-window', (event, arg) => {
   switch (arg) {
     case 'show-dev':
@@ -248,7 +275,9 @@ ipcMain.on('set-window', (event, arg) => {
   }
 });
 
-// Open links external
+/**
+ * Handles requests to open external links
+ */
 ipcMain.on('send-to-link', (event, arg) => {
   shell.openExternal(arg);
 });

--- a/apps/electron/main.js
+++ b/apps/electron/main.js
@@ -41,7 +41,7 @@ async function startBackend() {
 
   await initAssets();
 
-  const result = await startServer();
+  const result = await startServer(escalateError);
   loaded = result.message;
 
   await startIntegrations();
@@ -84,6 +84,11 @@ function bringToFront() {
 function askToQuit() {
   bringToFront();
   win.send('user-request-shutdown');
+}
+
+function escalateError(error) {
+  dialog.showErrorBox('An unrecoverable error occurred', error);
+  app.quit();
 }
 
 // Ensure there isn't another instance of the app running already
@@ -213,10 +218,7 @@ app.whenReady().then(() => {
   const trayMenuTemplate = getTrayMenu(bringToFront, askToQuit);
   const trayContextMenu = Menu.buildFromTemplate(trayMenuTemplate);
   tray.setContextMenu(trayContextMenu);
-
-  
 });
-
 
 // unregister shortcuts before quitting
 app.once('will-quit', () => {

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -22,9 +22,10 @@
     "postinstall": "",
     "lint": "eslint . --quiet",
     "lint-staged": "eslint",
-    "dev:electron": "cross-env NODE_ENV=development electron .",
+    "dev": "cross-env NODE_ENV=development electron .",
     "dist-win": "electron-builder --publish=never --x64 --win",
     "dist-mac": "electron-builder --publish=never --mac",
+    "dist-mac:local": "electron-builder --publish=never --mac -c.mac.identity=null",
     "dist-linux": "electron-builder --publish=never --x64 --linux",
     "cleanup": "rm -rf .turbo && rm -rf node_modules && rm -rf dist"
   },

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -20,7 +20,7 @@ import {
   clearUploadfolder,
 } from './setup/index.js';
 import { ONTIME_VERSION } from './ONTIME_VERSION.js';
-import { consoleGreen } from './utils/console.js';
+import { consoleSuccess, consoleHighlight } from './utils/console.js';
 
 // Import Routers
 import { appRouter } from './api-data/index.js';
@@ -47,7 +47,8 @@ import { initRundown } from './services/rundown-service/RundownService.js';
 import { generateCrashReport } from './utils/generateCrashReport.js';
 import { getNetworkInterfaces } from './utils/networkInterfaces.js';
 
-console.log(`Starting Ontime version ${ONTIME_VERSION}`);
+console.log('\n');
+consoleHighlight(`Starting Ontime version ${ONTIME_VERSION}`);
 
 if (!isProduction) {
   console.log(`Ontime running in ${environment} environment`);
@@ -205,8 +206,9 @@ export const startServer = async (
 
   expressServer.listen(serverPort, '0.0.0.0', () => {
     const nif = getNetworkInterfaces();
+    consoleSuccess(`Local: http://localhost:${serverPort}/editor`);
     for (const key of Object.keys(nif)) {
-      consoleGreen(`Ontime running on: http://${nif[key].address}:${serverPort}`);
+      consoleSuccess(`Network: http://${nif[key].address}:${serverPort}/editor`);
     }
   });
 
@@ -252,7 +254,7 @@ export const startIntegrations = async (config?: { osc: OSCSettings; http: HttpS
  * @return {Promise<void>}
  */
 export const shutdown = async (exitCode = 0) => {
-  console.log(`Ontime shutting down with code ${exitCode}`);
+  consoleHighlight(`Ontime shutting down with code ${exitCode}`);
 
   // clear the restore file if it was a normal exit
   // 0 means it was a SIGNAL
@@ -270,7 +272,7 @@ export const shutdown = async (exitCode = 0) => {
   process.exit(exitCode);
 };
 
-process.on('exit', (code) => console.log(`Ontime shutdown with code: ${code}`));
+process.on('exit', (code) => consoleHighlight(`Ontime shutdown with code: ${code}`));
 
 process.on('unhandledRejection', async (error) => {
   generateCrashReport(error);

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -50,7 +50,8 @@ import { getNetworkInterfaces } from './utils/networkInterfaces.js';
 console.log('\n');
 consoleHighlight(`Starting Ontime version ${ONTIME_VERSION}`);
 
-if (!isProduction) {
+const canLog = isProduction;
+if (!canLog) {
   console.log(`Ontime running in ${environment} environment`);
   console.log(`Ontime directory at ${srcDirectory} `);
   console.log(`Ontime database at ${resolveDbPath}`);
@@ -59,7 +60,7 @@ if (!isProduction) {
 // Create express APP
 const app = express();
 if (process.env.NODE_ENV === 'development') {
-  // log more serever timings
+  // log server timings to requests
   app.use(serverTiming());
 }
 app.disable('x-powered-by');

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -153,9 +153,10 @@ export const initAssets = async () => {
 
 /**
  * Starts servers
- * @return {Promise<string>}
  */
-export const startServer = async () => {
+export const startServer = async (
+  escalateErrorFn?: (error: string) => void,
+): Promise<{ message: string; serverPort: number }> => {
   checkStart(OntimeStartOrder.InitServer);
 
   const { serverPort } = DataProvider.getSettings();
@@ -184,6 +185,9 @@ export const startServer = async () => {
       direction: SimpleDirection.CountDown,
     },
   });
+
+  // initialise logging service, escalateErrorFn is only exists in electron
+  logger.init(escalateErrorFn);
 
   // initialise rundown service
   const persistedRundown = DataProvider.getRundown();

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -270,13 +270,13 @@ process.on('exit', (code) => console.log(`Ontime shutdown with code: ${code}`));
 
 process.on('unhandledRejection', async (error) => {
   generateCrashReport(error);
-  logger.error(LogOrigin.Server, `Uncaught exception | ${error}`);
+  logger.crash(LogOrigin.Server, `Uncaught exception | ${error}`);
   await shutdown(1);
 });
 
 process.on('uncaughtException', async (error) => {
   generateCrashReport(error);
-  logger.error(LogOrigin.Server, `Uncaught exception | ${error}`);
+  logger.crash(LogOrigin.Server, `Uncaught exception | ${error}`);
   await shutdown(1);
 });
 

--- a/apps/server/src/classes/Logger.ts
+++ b/apps/server/src/classes/Logger.ts
@@ -35,8 +35,8 @@ class Logger {
    * @param log
    */
   private _push(log: Log) {
-    if (!isProduction || log.level === LogLevel.Error) {
-      if (log.level === LogLevel.Error) {
+    if (!isProduction || log.level === LogLevel.Severe) {
+      if (log.level === LogLevel.Severe) {
         consoleRed(`[${log.level}] \t ${log.origin} \t ${log.text}`);
       } else {
         // eslint-disable-next-line no-console
@@ -96,6 +96,15 @@ class Logger {
    */
   error(origin: string, text: string) {
     this.emit(LogLevel.Error, origin, text);
+  }
+
+  /**
+   * Utility to emit logging message of type SEVERE
+   * @param origin
+   * @param text
+   */
+  crash(origin: string, text: string) {
+    this.emit(LogLevel.Severe, origin, text);
   }
 
   /**

--- a/apps/server/src/classes/Logger.ts
+++ b/apps/server/src/classes/Logger.ts
@@ -4,7 +4,7 @@ import { generateId, millisToString } from 'ontime-utils';
 import { clock } from '../services/Clock.js';
 import { isProduction } from '../setup/index.js';
 import { socket } from '../adapters/WebsocketAdapter.js';
-import { consoleRed } from '../utils/console.js';
+import { consoleSubdued, consoleRed } from '../utils/console.js';
 
 class Logger {
   private queue: Log[];
@@ -47,8 +47,7 @@ class Logger {
       if (log.level === LogLevel.Severe) {
         consoleRed(`[${log.level}] \t ${log.origin} \t ${log.text}`);
       } else {
-        // eslint-disable-next-line no-console
-        console.log(`[${log.level}] \t ${log.origin} \t ${log.text}`);
+        consoleSubdued(`[${log.level}] \t ${log.origin} \t ${log.text}`);
       }
     }
 

--- a/apps/server/src/classes/Logger.ts
+++ b/apps/server/src/classes/Logger.ts
@@ -8,19 +8,26 @@ import { consoleRed } from '../utils/console.js';
 
 class Logger {
   private queue: Log[];
+  private escalateErrorFn: (error: string) => void | null;
 
   constructor() {
     this.queue = [];
+    this.escalateErrorFn = null;
   }
 
   /**
    * Enabling setup logger after init
    */
-  init() {
+  init(escalateErrorFn: (error: string) => void) {
     this.queue.forEach((log) => {
       this._push(log);
     });
     this.queue = [];
+
+    // we only get this when running in electron
+    if (escalateErrorFn) {
+      this.escalateErrorFn = escalateErrorFn;
+    }
   }
 
   private addToQueue(log: Log) {
@@ -105,6 +112,7 @@ class Logger {
    */
   crash(origin: string, text: string) {
     this.emit(LogLevel.Severe, origin, text);
+    this.escalateErrorFn?.(text);
   }
 
   /**

--- a/apps/server/src/classes/Logger.ts
+++ b/apps/server/src/classes/Logger.ts
@@ -19,6 +19,7 @@ class Logger {
    * Enabling setup logger after init
    */
   init(escalateErrorFn: (error: string) => void) {
+    // flush logs from queue
     this.queue.forEach((log) => {
       this._push(log);
     });

--- a/apps/server/src/classes/Logger.ts
+++ b/apps/server/src/classes/Logger.ts
@@ -9,10 +9,12 @@ import { consoleSubdued, consoleRed } from '../utils/console.js';
 class Logger {
   private queue: Log[];
   private escalateErrorFn: (error: string) => void | null;
+  private canLog = false;
 
   constructor() {
     this.queue = [];
     this.escalateErrorFn = null;
+    this.canLog = !isProduction;
   }
 
   /**
@@ -43,7 +45,7 @@ class Logger {
    * @param log
    */
   private _push(log: Log) {
-    if (!isProduction || log.level === LogLevel.Severe) {
+    if (this.canLog || log.level === LogLevel.Severe) {
       if (log.level === LogLevel.Severe) {
         consoleRed(`[${log.level}] \t ${log.origin} \t ${log.text}`);
       } else {

--- a/apps/server/src/classes/Logger.ts
+++ b/apps/server/src/classes/Logger.ts
@@ -4,6 +4,7 @@ import { generateId, millisToString } from 'ontime-utils';
 import { clock } from '../services/Clock.js';
 import { isProduction } from '../setup/index.js';
 import { socket } from '../adapters/WebsocketAdapter.js';
+import { consoleRed } from '../utils/console.js';
 
 class Logger {
   private queue: Log[];
@@ -34,8 +35,13 @@ class Logger {
    * @param log
    */
   private _push(log: Log) {
-    if (!isProduction) {
-      console.log(`[${log.level}] \t ${log.origin} \t ${log.text}`);
+    if (!isProduction || log.level === LogLevel.Error) {
+      if (log.level === LogLevel.Error) {
+        consoleRed(`[${log.level}] \t ${log.origin} \t ${log.text}`);
+      } else {
+        // eslint-disable-next-line no-console
+        console.log(`[${log.level}] \t ${log.origin} \t ${log.text}`);
+      }
     }
 
     try {
@@ -96,7 +102,6 @@ class Logger {
    * Shutdown logger
    */
   shutdown() {
-    console.log('Shutting down logger');
     this.queue = [];
   }
 }

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,16 +1,22 @@
 /* eslint-disable no-console */
+import { consoleHighlight, consoleRed } from './utils/console.js';
 import { initAssets, startIntegrations, startServer } from './app.js';
 
 async function startOntime() {
   try {
-    console.log('Request: Initialise assets...');
+    console.log('\n');
+    consoleHighlight('Request: Initialise assets...');
     await initAssets();
-    console.log('Request: Start server...');
+
+    console.log('\n');
+    consoleHighlight('Request: Start server...');
     await startServer();
-    console.log('Request: Start integrations...');
+
+    console.log('\n');
+    consoleHighlight('Request: Start integrations...');
     await startIntegrations();
   } catch (error) {
-    console.log(`Request failed: ${error}`);
+    consoleRed(`Request failed: ${error}`);
   }
 }
 

--- a/apps/server/src/utils/console.ts
+++ b/apps/server/src/utils/console.ts
@@ -1,0 +1,15 @@
+/* eslint-disable no-console */
+
+/**
+ * Utility function to log messages in green
+ */
+export function consoleGreen(message: string) {
+  console.log(`\x1b[32m${message}\x1b[0m`);
+}
+
+/**
+ * Utility function to log messages in red
+ */
+export function consoleRed(message: string) {
+  console.error(`\x1b[31m${message}\x1b[0m`);
+}

--- a/apps/server/src/utils/console.ts
+++ b/apps/server/src/utils/console.ts
@@ -3,13 +3,55 @@
 /**
  * Utility function to log messages in green
  */
-export function consoleGreen(message: string) {
-  console.log(`\x1b[32m${message}\x1b[0m`);
+export function consoleSuccess(message: string) {
+  console.log(inGreen(message));
 }
 
 /**
  * Utility function to log messages in red
  */
 export function consoleRed(message: string) {
-  console.error(`\x1b[31m${message}\x1b[0m`);
+  console.error(inRed(message));
+}
+
+/**
+ * Utility function to log messages with dimmed appearance
+ */
+export function consoleHighlight(message: string) {
+  console.log(inCyan(message));
+}
+
+/**
+ * Utility function to log messages with dimmed appearance
+ */
+export function consoleSubdued(message: string) {
+  console.log(inGray(message));
+}
+
+/**
+ * Utility function for console, styles text in green
+ */
+function inGreen(message: string): string {
+  return `\x1b[32m${message}\x1b[0m`;
+}
+
+/**
+ * Utility function for console, styles text in red
+ */
+function inRed(message: string): string {
+  return `\x1b[31m${message}\x1b[0m`;
+}
+
+/**
+ * Utility function for console, styles text in cyan
+ */
+function inCyan(message: string): string {
+  return `\x1b[96m${message}\x1b[0m`;
+}
+
+/**
+ * Utility function for console, styles text in gray
+ */
+function inGray(message: string): string {
+  return `\x1b[2m${message}\x1b[0m`;
 }

--- a/packages/types/src/definitions/runtime/Logger.type.ts
+++ b/packages/types/src/definitions/runtime/Logger.type.ts
@@ -2,6 +2,7 @@ export enum LogLevel {
   Info = 'INFO',
   Warn = 'WARN',
   Error = 'ERROR',
+  Severe = 'SEVERE',
 }
 
 export type Log = {

--- a/turbo.json
+++ b/turbo.json
@@ -31,6 +31,7 @@
     },
     "dist-win": {},
     "dist-mac": {},
+    "dist-mac:local": {},
     "dist-linux": {},
     "cleanup": {}
   }


### PR DESCRIPTION
since so many users are consuming Ontime headless, I thought we should look into improving the visibility of messages in terminal

In this PR I am just adding visibility for critical operations
- where is ontime running
- did ontime crash

TODO:
- [x] style console to help visibility 
- [x] create a SEVERE log level for unrecoverable datasets
- [x] SEVERE logs should be escalated to electron process
- [x] clarify app init in console to distinguish across boots

Suggestions for improvement are welcome