### PR TITLE
None colour from API

### DIFF
--- a/apps/server/src/utils/__tests__/coerceType.test.ts
+++ b/apps/server/src/utils/__tests__/coerceType.test.ts
@@ -18,6 +18,13 @@ describe('parses a colour string that is', () => {
   it('not a string', () => {
     expect(() => coerceColour(5)).toThrowError(Error('Invalid colour value received'));
   });
+  it('undefinde and null are not valid', () => {
+    expect(() => coerceColour(null)).toThrowError(Error('Invalid colour value received'));
+    expect(() => coerceColour(undefined)).toThrowError(Error('Invalid colour value received'));
+  });
+  it('empty string is allowed', () => {
+    expect(coerceColour('')).toBe('');
+  });
 });
 
 describe('match a string to an enum that is', () => {

--- a/apps/server/src/utils/coerceType.ts
+++ b/apps/server/src/utils/coerceType.ts
@@ -90,7 +90,12 @@ export function coerceColour(value: unknown): string {
     if (!isColourHex(lowerCaseValue)) {
       throw new Error('Invalid hex colour received');
     }
-  } else if (!(lowerCaseValue in cssColours)) {
+    return lowerCaseValue;
+  }
+  if (lowerCaseValue === 'none') {
+    return ''; // None colour the same as the UI 'Ø' button
+  }
+  if (!(lowerCaseValue in cssColours)) {
     throw new Error('Invalid colour name received');
   }
   return lowerCaseValue;
@@ -98,7 +103,6 @@ export function coerceColour(value: unknown): string {
 
 //https://developer.mozilla.org/en-US/docs/Web/CSS/named-color
 const cssColours = {
-  ['']: '', // None colour the same as the UI 'Ø' button
   aliceblue: '#f0f8ff',
   antiquewhite: '#faebd7',
   aqua: '#00ffff',

--- a/apps/server/src/utils/coerceType.ts
+++ b/apps/server/src/utils/coerceType.ts
@@ -98,6 +98,7 @@ export function coerceColour(value: unknown): string {
 
 //https://developer.mozilla.org/en-US/docs/Web/CSS/named-color
 const cssColours = {
+  ['']: '', // None colour the same as the UI 'Ø' button
   aliceblue: '#f0f8ff',
   antiquewhite: '#faebd7',
   aqua: '#00ffff',

--- a/apps/server/src/utils/coerceType.ts
+++ b/apps/server/src/utils/coerceType.ts
@@ -92,8 +92,8 @@ export function coerceColour(value: unknown): string {
     }
     return lowerCaseValue;
   }
-  if (lowerCaseValue === 'none') {
-    return ''; // None colour the same as the UI 'Ø' button
+  if (lowerCaseValue === '') {
+    return lowerCaseValue; // None colour the same as the UI 'Ø' button
   }
   if (!(lowerCaseValue in cssColours)) {
     throw new Error('Invalid colour name received');


### PR DESCRIPTION
Allow the api to set the event colour to '' by calling 'none'
Otherwise there is no way for the api to match the UI button

![image](https://github.com/cpvalente/ontime/assets/19875125/36aca795-2f70-4204-b261-2e8c3ad86502)
