### PR TITLE
refactor: cuesheet header

### DIFF
--- a/apps/client/src/features/cuesheet/Cuesheet.module.scss
+++ b/apps/client/src/features/cuesheet/Cuesheet.module.scss
@@ -47,11 +47,13 @@ $table-header-font-size: calc(1rem - 3px);
   position: sticky;
   top: 0;
   z-index: 10;
-  background-color: $gray-1300;
 
   font-size: $table-header-font-size;
   color: $gray-700;
-  font-weight: 400;
+
+  th {
+      background-color: $gray-1300;
+  }
 }
 
 .eventRow {

--- a/apps/client/src/features/cuesheet/cuesheetCols.tsx
+++ b/apps/client/src/features/cuesheet/cuesheetCols.tsx
@@ -117,5 +117,3 @@ export function makeCuesheetColumns(customFields: CustomFields): ColumnDef<Ontim
     ...dynamicCustomFields,
   ];
 }
-
-export const initialColumnOrder: string[] = makeCuesheetColumns({}).map((column) => column.id as string);

--- a/apps/client/src/features/cuesheet/useColumnManager.tsx
+++ b/apps/client/src/features/cuesheet/useColumnManager.tsx
@@ -1,0 +1,46 @@
+import { useCallback, useEffect } from 'react';
+import { useLocalStorage } from '@mantine/hooks';
+import { ColumnDef } from '@tanstack/react-table';
+import { OntimeRundownEntry } from 'ontime-types';
+
+export default function useColumnManager(columns: ColumnDef<OntimeRundownEntry>[]) {
+  const [columnVisibility, setColumnVisibility] = useLocalStorage({ key: 'table-hidden', defaultValue: {} });
+  const [columnOrder, saveColumnOrder] = useLocalStorage<string[]>({
+    key: 'table-order',
+    defaultValue: columns.map((col) => col.id as string),
+  });
+  const [columnSizing, setColumnSizing] = useLocalStorage({ key: 'table-sizes', defaultValue: {} });
+
+  // if the columns change, we update the dataset
+  useEffect(() => {
+    let shouldReplace = false;
+    const newColumns: string[] = [];
+
+    // iterate through columns to see if there are new ids
+    columns.forEach((column) => {
+      const columnnId = column.id as string;
+      if (!shouldReplace && !columnOrder.includes(columnnId)) {
+        shouldReplace = true;
+      }
+      newColumns.push(columnnId);
+    });
+
+    if (shouldReplace) {
+      saveColumnOrder(newColumns);
+    }
+  }, [columnOrder, columns, saveColumnOrder]);
+
+  const resetColumnOrder = useCallback(() => {
+    saveColumnOrder(columns.map((col) => col.id as string));
+  }, [columns, saveColumnOrder]);
+
+  return {
+    columnVisibility,
+    columnOrder,
+    columnSizing,
+    resetColumnOrder,
+    setColumnVisibility,
+    saveColumnOrder,
+    setColumnSizing,
+  };
+}


### PR DESCRIPTION
small fixes to the ordering and visibility of columns in the cuesheet

Testing:

You should be able to reorder columns. Leave the page and come back and everything looks the same 