### PR TITLE
fix: duplicate validation

### DIFF
--- a/apps/server/src/api-data/db/db.router.ts
+++ b/apps/server/src/api-data/db/db.router.ts
@@ -18,6 +18,7 @@ import {
   validatePatchProject,
   validateFilenameBody,
   validateFilenameParam,
+  validateNewFilenameBody,
 } from './db.validation.js';
 
 export const router = express.Router();
@@ -31,7 +32,7 @@ router.post('/new', validateFilenameBody, validateNewProject, createProjectFile)
 router.get('/all', listProjects);
 
 router.post('/load', validateFilenameBody, loadProject);
-router.post('/:filename/duplicate', validateFilenameParam, validateFilenameBody, duplicateProjectFile);
+router.post('/:filename/duplicate', validateFilenameParam, validateNewFilenameBody, duplicateProjectFile);
 router.put('/:filename/rename', validateFilenameParam, validateFilenameBody, renameProjectFile);
 router.delete('/:filename', validateFilenameParam, deleteProjectFile);
 

--- a/apps/server/src/api-data/db/db.validation.ts
+++ b/apps/server/src/api-data/db/db.validation.ts
@@ -42,6 +42,30 @@ export const validatePatchProject = [
 ];
 
 /**
+ * @description Validates request with newFilename in the body.
+ */
+export const validateNewFilenameBody = [
+  body('newFilename')
+    .exists()
+    .isString()
+    .trim()
+    .customSanitizer((input: string) => sanitize(input))
+    .withMessage('Failed to sanitize the filename')
+    .notEmpty()
+    .withMessage('Filename was empty or contained only invalid characters')
+    .customSanitizer((input: string) => ensureJsonExtension(input)),
+
+  (req: Request, res: Response, next: NextFunction) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(422).json({ errors: errors.array() });
+    }
+
+    next();
+  },
+];
+
+/**
  * @description Validates request with filename in the body.
  */
 export const validateFilenameBody = [


### PR DESCRIPTION
Fixes an issue where we were validating the wrong parameter in the duplicate endpoint

In short: we sent a `newFilename` property but expected the existence of a `filename`