### PR TITLE
Rundown api

### DIFF
--- a/apps/server/src/api-data/rundown/rundown.router.ts
+++ b/apps/server/src/api-data/rundown/rundown.router.ts
@@ -5,8 +5,9 @@ import {
   rundownApplyDelay,
   rundownBatchPut,
   rundownDelete,
-  rundownGetAll,
+  rundownGetById,
   rundownGetNormalised,
+  rundownGetPaginated,
   rundownPost,
   rundownPut,
   rundownReorder,
@@ -16,6 +17,7 @@ import {
   paramsMustHaveEventId,
   rundownArrayOfIds,
   rundownBatchPutValidator,
+  rundownGetPaginatedQueryParams,
   rundownPostValidator,
   rundownPutValidator,
   rundownReorderValidator,
@@ -24,8 +26,9 @@ import {
 
 export const router = express.Router();
 
-router.get('/', rundownGetAll); // not used in Ontime frontend
+router.get('/', rundownGetPaginatedQueryParams, rundownGetPaginated); // not used in Ontime frontend
 router.get('/normalised', rundownGetNormalised);
+router.get('/:eventId', paramsMustHaveEventId, rundownGetById); // not used in Ontime frontend
 
 router.post('/', rundownPostValidator, rundownPost);
 

--- a/apps/server/src/api-data/rundown/rundown.validation.ts
+++ b/apps/server/src/api-data/rundown/rundown.validation.ts
@@ -1,4 +1,4 @@
-import { body, param, validationResult } from 'express-validator';
+import { body, param, query, validationResult } from 'express-validator';
 import { Request, Response, NextFunction } from 'express';
 
 export const rundownPostValidator = [
@@ -68,6 +68,17 @@ export const paramsMustHaveEventId = [
 export const rundownArrayOfIds = [
   body('ids').isArray().exists(),
   body('ids.*').isString(),
+
+  (req: Request, res: Response, next: NextFunction) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) return res.status(422).json({ errors: errors.array() });
+    next();
+  },
+];
+
+export const rundownGetPaginatedQueryParams = [
+  query('offset').isNumeric().optional(),
+  query('limit').isNumeric().optional(),
 
   (req: Request, res: Response, next: NextFunction) => {
     const errors = validationResult(req);

--- a/apps/server/src/services/rundown-service/RundownService.ts
+++ b/apps/server/src/services/rundown-service/RundownService.ts
@@ -245,7 +245,7 @@ function notifyChanges(options: { timer?: boolean | string[]; external?: boolean
 
   if (options.external) {
     // advice socket subscribers of change
-    sendRefetch();
+    sendRefetch(Array.isArray(options.timer) ? options.timer : undefined);
   }
 }
 

--- a/apps/server/src/services/rundown-service/__tests__/rundownUtils.test.ts
+++ b/apps/server/src/services/rundown-service/__tests__/rundownUtils.test.ts
@@ -1,0 +1,39 @@
+import { OntimeRundown } from 'ontime-types';
+import { getPaginated } from '../rundownUtils.js';
+
+describe('getPaginated', () => {
+  // mock cache so we dont run data functions
+  beforeAll(() => {
+    vi.mock('../rundownCache.js', () => ({}));
+  });
+
+  // @ts-expect-error -- we know this is not correct, but good enough for the test
+  const getData = () => [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] as OntimeRundown;
+
+  it('should return the correct paginated rundown', () => {
+    const offset = 0;
+    const limit = 1;
+    const result = getPaginated(offset, limit, getData);
+
+    expect(result.rundown).toHaveLength(1);
+    expect(result.total).toBe(10);
+  });
+
+  it('should handle overflows', () => {
+    const offset = 0;
+    const limit = 20;
+    const result = getPaginated(offset, limit, getData);
+
+    expect(result.rundown).toHaveLength(10);
+    expect(result.total).toBe(10);
+  });
+
+  it('should handle out of range', () => {
+    const offset = 11;
+    const limit = Infinity;
+    const result = getPaginated(offset, limit, getData);
+
+    expect(result.rundown).toHaveLength(0);
+    expect(result.total).toBe(10);
+  });
+});

--- a/apps/server/src/services/rundown-service/rundownUtils.ts
+++ b/apps/server/src/services/rundown-service/rundownUtils.ts
@@ -1,4 +1,4 @@
-import { OntimeEvent, OntimeRundown, isOntimeEvent, RundownCached } from 'ontime-types';
+import { OntimeEvent, OntimeRundown, isOntimeEvent, RundownCached, OntimeRundownEntry } from 'ontime-types';
 
 import * as cache from './rundownCache.js';
 
@@ -53,9 +53,9 @@ export function getEventAtIndex(eventIndex: number): OntimeEvent | undefined {
  * @param {string} eventId
  * @return {object | undefined}
  */
-export function getEventWithId(eventId: string): OntimeEvent | undefined {
-  const timedEvents = getTimedEvents();
-  return timedEvents.find((event) => event.id === eventId);
+export function getEventWithId(eventId: string): OntimeRundownEntry | undefined {
+  const rundown = getRundown();
+  return rundown.find((event) => event.id === eventId);
 }
 
 /**
@@ -116,4 +116,20 @@ export function findNext(currentEventId?: string): OntimeEvent | null {
   const newIndex = currentIndex + 1;
   const nextEvent = timedEvents.at(newIndex);
   return nextEvent ?? null;
+}
+
+/**
+ * Returns a paginated rundown
+ * Exposes a getter function for the rundown for testing
+ */
+export function getPaginated(
+  offset: number,
+  limit: number,
+  source = getRundown,
+): { rundown: OntimeRundownEntry[]; total: number } {
+  const rundown = source();
+  return {
+    rundown: rundown.slice(Math.min(offset, rundown.length), Math.min(offset + limit, rundown.length)),
+    total: rundown.length,
+  };
 }

--- a/apps/server/src/services/runtime-service/RuntimeService.ts
+++ b/apps/server/src/services/runtime-service/RuntimeService.ts
@@ -1,5 +1,6 @@
 import {
   EndAction,
+  isOntimeEvent,
   LogOrigin,
   MaybeNumber,
   OntimeEvent,
@@ -225,6 +226,9 @@ class RuntimeService {
       }
       // load stuff again, but keep running if our events still exist
       const eventNow = getEventWithId(state.eventNow.id);
+      if (!isOntimeEvent(eventNow)) {
+        return;
+      }
       const onlyChangedNow = affectedIds?.length === 1 && affectedIds.at(0) === eventNow.id;
       if (onlyChangedNow) {
         runtimeState.reload(eventNow);
@@ -272,7 +276,7 @@ class RuntimeService {
    */
   startById(eventId: string): boolean {
     const event = getEventWithId(eventId);
-    if (!event) {
+    if (!event || !isOntimeEvent(event)) {
       return false;
     }
     const loaded = this.loadEvent(event);
@@ -323,7 +327,7 @@ class RuntimeService {
    */
   loadById(eventId: string): boolean {
     const event = getEventWithId(eventId);
-    if (!event) {
+    if (!event || !isOntimeEvent(event)) {
       return false;
     }
     return this.loadEvent(event);
@@ -523,7 +527,7 @@ class RuntimeService {
     // the db would have to change for the event not to exist
     // we do not kow the reason for the crash, so we check anyway
     const event = getEventWithId(selectedEventId);
-    if (!event) {
+    if (!event || !isOntimeEvent(event)) {
       return;
     }
 

--- a/packages/types/src/api/ontime-controller/BackendResponse.type.ts
+++ b/packages/types/src/api/ontime-controller/BackendResponse.type.ts
@@ -1,4 +1,5 @@
 import type { OSCSettings } from '../../definitions/core/OscSettings.type.js';
+import type { OntimeRundown } from '../../definitions/core/Rundown.type.js';
 
 export type NetworkInterface = {
   name: string;
@@ -32,3 +33,8 @@ export type MessageResponse = {
 export type ErrorResponse = MessageResponse;
 
 export type AuthenticationStatus = 'authenticated' | 'not_authenticated' | 'pending';
+
+export type RundownPaginated = {
+  rundown: OntimeRundown;
+  total: number;
+};

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -49,6 +49,7 @@ export type {
   ErrorResponse,
   ProjectFileListResponse,
   MessageResponse,
+  RundownPaginated,
 } from './api/ontime-controller/BackendResponse.type.js';
 export type { RundownCached, NormalisedRundown } from './api/rundown-controller/BackendResponse.type.js';
 


### PR DESCRIPTION
This PR exposes the list of changes in the refetch message.
This means that consumers can know which events are affected by a change

In addition, we also add a few endpoints for granular rundown getting
- paginated query params for rundown
- getEventById