### PR TITLE
Suggestion

### DIFF
--- a/apps/server/src/services/runtime-service/RuntimeService.ts
+++ b/apps/server/src/services/runtime-service/RuntimeService.ts
@@ -66,7 +66,6 @@ class RuntimeService {
   @broadcastResult
   checkTimerUpdate({ hasTimerFinished, hasSecondaryTimerFinished }: runtimeState.UpdateResult) {
     const newState = runtimeState.getState();
-
     // 1. find if we need to dispatch integrations related to the phase
     const timerPhaseChanged = RuntimeService.previousState.timer?.phase !== newState.timer.phase;
     if (timerPhaseChanged) {

--- a/packages/utils/src/rundown-utils/rundownUtils.ts
+++ b/packages/utils/src/rundown-utils/rundownUtils.ts
@@ -303,20 +303,21 @@ export function getEventWithId(rundown: OntimeRundown, id: string): OntimeRundow
  * Gets relevant block element for a given ID
  */
 export function getRelevantBlock(rundown: OntimeRundown, currentId: string): OntimeBlock | null {
-  let inBlock = false;
+  let foundCurrentEvent = false;
   // Iterate backwards through the rundown to find the current event
   for (let i = rundown.length - 1; i >= 0; i--) {
     const entry = rundown[i];
-    if (entry.id === currentId) {
-      //set the flag when the current event is found
-      inBlock = true;
+    if (!foundCurrentEvent && entry.id === currentId) {
+      // set the flag when the current event is found
+      foundCurrentEvent = true;
+      continue;
     }
-    //the first block before the current event is the relevant one
-    if (inBlock && isOntimeBlock(entry)) {
+    // the first block before the current event is the relevant one
+    if (foundCurrentEvent && isOntimeBlock(entry)) {
       return entry;
     }
   }
-  //no blocks exist before current event
+  // no blocks exist before current event
   return null;
 }
 


### PR DESCRIPTION
This is a suggestion for how to reset state when block loading

The idea being, that the consumer function is the one that contains the context as to why we need to persist after clear, so it makes sense to leave this knowledge there

Otherwise, the logic hasnt been changed

I have also noticed that in the UI, the time in block starts on -1, I am assuming this is likely an issue with the `block.startedAt` and `clock` being out of sync for an update.
We should do something to prevent this as a negative value is not valid in this context