### PR TITLE
refactor: only broadcast public

### DIFF
--- a/apps/server/src/services/rundown-service/RundownService.ts
+++ b/apps/server/src/services/rundown-service/RundownService.ts
@@ -241,7 +241,7 @@ function notifyChanges(options: { timer?: boolean | string[]; external?: boolean
       // notify timer service of changed events
       // timer can be true or an array of changed IDs
       const affected = Array.isArray(options.timer) ? options.timer : undefined;
-      runtimeService.maybeUpdate(affected);
+      runtimeService.notifyOfChangedEvents(affected);
     }
   }
 


### PR DESCRIPTION
The code changes make it so that only functions that are exposed to be externally consumed broadcast their result

This means cleaner outputs in compound functions like `startNext` and `loadNext`