### PR TITLE
fix TimerPahse difference from load and reload

### DIFF
--- a/apps/server/src/services/runtime-service/RuntimeService.ts
+++ b/apps/server/src/services/runtime-service/RuntimeService.ts
@@ -252,10 +252,10 @@ class RuntimeService {
         const onlyChangedNow = affectedIds?.length === 1 && affectedIds.at(0) === eventNow.id;
 
         if (onlyChangedNow) {
-          runtimeState.reload(eventNow);
+          runtimeState.updateLoaded(eventNow);
         } else {
           const rundown = getRundown();
-          runtimeState.reloadAll(rundown);
+          runtimeState.updateAll(rundown);
         }
         return;
       }

--- a/apps/server/src/services/runtime-service/RuntimeService.ts
+++ b/apps/server/src/services/runtime-service/RuntimeService.ts
@@ -544,14 +544,9 @@ class RuntimeService {
   public reload() {
     const state = runtimeState.getState();
     if (state.eventNow) {
-      const eventId = runtimeState.reload();
-      if (eventId) {
-        logger.info(LogOrigin.Playback, `Loaded event with ID ${eventId}`);
-        process.nextTick(() => {
-          integrationService.dispatch(TimerLifeCycle.onLoad);
-        });
-      }
+      return this.loadEvent(state.eventNow);
     }
+    return false;
   }
 
   /**

--- a/apps/server/src/stores/runtimeState.ts
+++ b/apps/server/src/stores/runtimeState.ts
@@ -307,7 +307,7 @@ export function resume(restorePoint: RestorePoint, event: PlayableEvent, rundown
  * We only pass an event if we are hot reloading
  * @param {PlayableEvent} event only passed if we are changing the data if a playing timer
  */
-export function reload(event?: PlayableEvent): string | undefined {
+export function updateLoaded(event?: PlayableEvent): string | undefined {
   // if there is no event loaded, nothing to do
   if (runtimeState.eventNow === null) {
     return;
@@ -363,11 +363,11 @@ export function reload(event?: PlayableEvent): string | undefined {
 /**
  * Used in situations when we want to hot-reload all events without interrupting timer
  */
-export function reloadAll(rundown: OntimeRundown) {
+export function updateAll(rundown: OntimeRundown) {
   const timedEvents = filterTimedEvents(rundown);
   loadNow(timedEvents);
   loadNext(timedEvents);
-  reload(runtimeState.eventNow ?? undefined);
+  updateLoaded(runtimeState.eventNow ?? undefined);
 }
 
 export function start(state: RuntimeState = runtimeState): boolean {


### PR DESCRIPTION
TimerPahse when loading and reloading from a playing event is different

uses the same function path for load and reload

optionally, also renamed runtimeState functions to better reflect their use, but this could be rolled back
 `runtimeState.reload` -> `runtimeState.updateLoaded`   (maybe refresh is better?)
`runtimeState.reloadAll` -> `runtimeState.updateAll`

