### PR TITLE
fix: handle multiple days

### DIFF
--- a/apps/client/src/common/hooks/useSocket.ts
+++ b/apps/client/src/common/hooks/useSocket.ts
@@ -187,15 +187,6 @@ export const useRuntimePlaybackOverview = () => {
   return useRuntimeStore(featureSelector);
 };
 
-export const useTimelineOverview = () => {
-  const featureSelector = (state: RuntimeStore) => ({
-    plannedStart: state.runtime.plannedStart,
-    plannedEnd: state.runtime.plannedEnd,
-  });
-
-  return useRuntimeStore(featureSelector);
-};
-
 export const useTimelineStatus = () => {
   const featureSelector = (state: RuntimeStore) => ({
     clock: state.clock,

--- a/apps/client/src/features/viewers/timeline/Timeline.tsx
+++ b/apps/client/src/features/viewers/timeline/Timeline.tsx
@@ -3,33 +3,33 @@ import { useViewportSize } from '@mantine/hooks';
 import { isOntimeEvent, isPlayableEvent, MaybeNumber, OntimeRundown } from 'ontime-types';
 import { checkIsNextDay, dayInMs, getLastEvent, MILLIS_PER_HOUR } from 'ontime-utils';
 
-import { useTimelineOverview } from '../../../common/hooks/useSocket';
-
 import TimelineMarkers from './timeline-markers/TimelineMarkers';
-import ProgressBar from './timeline-progress-bar/TimelineProgressBar';
+import TimelineProgressBar from './timeline-progress-bar/TimelineProgressBar';
 import { getElementPosition, getEndHour, getStartHour } from './timeline.utils';
 import { ProgressStatus, TimelineEntry } from './TimelineEntry';
 
 import style from './Timeline.module.scss';
 
 interface TimelineProps {
-  selectedEventId: string | null;
+  firstStart: number;
   rundown: OntimeRundown;
+  selectedEventId: string | null;
+  totalDuration: number;
 }
 
 export default memo(Timeline);
 
 function Timeline(props: TimelineProps) {
-  const { selectedEventId, rundown } = props;
+  const { firstStart, rundown, selectedEventId, totalDuration } = props;
   const { width: screenWidth } = useViewportSize();
-  const { plannedStart, plannedEnd } = useTimelineOverview();
 
-  if (plannedStart === null || plannedEnd === null) {
+  if (totalDuration === 0) {
     return null;
   }
+
   const { lastEvent } = getLastEvent(rundown);
-  const startHour = getStartHour(plannedStart);
-  const endHour = getEndHour(plannedEnd + (lastEvent?.delay ?? 0));
+  const startHour = getStartHour(firstStart);
+  const endHour = getEndHour(firstStart + totalDuration + (lastEvent?.delay ?? 0));
 
   let previousEventStartTime: MaybeNumber = null;
   // we use selectedEventId as a signifier on whether the timeline is live
@@ -39,7 +39,7 @@ function Timeline(props: TimelineProps) {
   return (
     <div className={style.timeline}>
       <TimelineMarkers startHour={startHour} endHour={endHour} />
-      <ProgressBar startHour={startHour} endHour={endHour} />
+      <TimelineProgressBar startHour={startHour} endHour={endHour} />
       <div className={style.timelineEvents}>
         {rundown.map((event) => {
           // for now we dont render delays and blocks

--- a/apps/client/src/features/viewers/timeline/TimelinePage.tsx
+++ b/apps/client/src/features/viewers/timeline/TimelinePage.tsx
@@ -35,7 +35,7 @@ export default function TimelinePage(props: TimelinePageProps) {
   const { backstageEvents, general, selectedId, settings, time, viewSettings } = props;
   const { shouldRender } = useRuntimeStylesheet(viewSettings?.overrideStyles && overrideStylesURL);
   // holds copy of the rundown with only relevant events
-  const scopedRundown = useScopedRundown(backstageEvents, selectedId);
+  const { scopedRundown, firstStart, totalDuration } = useScopedRundown(backstageEvents, selectedId);
   const { getLocalizedString } = useTranslation();
   const clock = formatTime(time.clock);
 
@@ -82,7 +82,12 @@ export default function TimelinePage(props: TimelinePageProps) {
           category='next'
         />
       </div>
-      <Timeline selectedEventId={selectedId} rundown={scopedRundown} />
+      <Timeline
+        firstStart={firstStart}
+        rundown={scopedRundown}
+        selectedEventId={selectedId}
+        totalDuration={totalDuration}
+      />
     </div>
   );
 }

--- a/apps/client/src/features/viewers/timeline/TimelinePage.tsx
+++ b/apps/client/src/features/viewers/timeline/TimelinePage.tsx
@@ -13,7 +13,7 @@ import SuperscriptTime from '../common/superscript-time/SuperscriptTime';
 import Section from './timeline-section/TimelineSection';
 import Timeline from './Timeline';
 import { getTimelineOptions } from './timeline.options';
-import { getFormattedTimeToStart, getScopedRundown, getUpcomingEvents } from './timeline.utils';
+import { getFormattedTimeToStart, getUpcomingEvents, useScopedRundown } from './timeline.utils';
 
 import './TimelinePage.scss';
 
@@ -34,14 +34,10 @@ interface TimelinePageProps {
 export default function TimelinePage(props: TimelinePageProps) {
   const { backstageEvents, general, selectedId, settings, time, viewSettings } = props;
   const { shouldRender } = useRuntimeStylesheet(viewSettings?.overrideStyles && overrideStylesURL);
-
+  // holds copy of the rundown with only relevant events
+  const scopedRundown = useScopedRundown(backstageEvents, selectedId);
   const { getLocalizedString } = useTranslation();
   const clock = formatTime(time.clock);
-
-  // holds copy of the rundown with only relevant events
-  const scopedRundown = useMemo(() => {
-    return getScopedRundown(backstageEvents, selectedId);
-  }, [backstageEvents, selectedId]);
 
   const { now, next, followedBy } = useMemo(() => {
     return getUpcomingEvents(scopedRundown, selectedId);

--- a/apps/client/src/features/viewers/timeline/timeline.utils.ts
+++ b/apps/client/src/features/viewers/timeline/timeline.utils.ts
@@ -126,13 +126,12 @@ export function getUpcomingEvents(events: OntimeRundown, selectedId: MaybeString
     return { now: null, next: null, followedBy: null };
   }
 
-  const now = selectedId ? getEventWithId(events, selectedId) : getFirstEvent(events)?.firstEvent;
-
+  let now = selectedId ? getEventWithId(events, selectedId) : null;
   if (!isOntimeEvent(now)) {
-    return { now: null, next: null, followedBy: null };
+    now = null;
   }
 
-  const next = getNextEvent(events, now.id)?.nextEvent;
+  const next = now ? getNextEvent(events, now.id)?.nextEvent : getFirstEvent(events).firstEvent;
   const followedBy = next ? getNextEvent(events, next.id)?.nextEvent : null;
 
   // Return the titles, handling nulls appropriately

--- a/apps/client/src/features/viewers/timeline/timeline.utils.ts
+++ b/apps/client/src/features/viewers/timeline/timeline.utils.ts
@@ -1,4 +1,4 @@
-import { isOntimeEvent, MaybeString, OntimeEvent } from 'ontime-types';
+import { isOntimeEvent, MaybeString, OntimeEvent, OntimeRundown } from 'ontime-types';
 import {
   dayInMs,
   getEventWithId,
@@ -87,7 +87,7 @@ export function getStatusLabel(timeToStart: number, status: ProgressStatus): str
   return formatDuration(timeToStart);
 }
 
-export function getScopedRundown(rundown: OntimeEvent[], selectedEventId: MaybeString): OntimeEvent[] {
+export function getScopedRundown(rundown: OntimeRundown, selectedEventId: MaybeString): OntimeRundown {
   if (rundown.length === 0) {
     return [];
   }
@@ -106,7 +106,7 @@ export function getScopedRundown(rundown: OntimeEvent[], selectedEventId: MaybeS
   }
 
   if (hideBackstage) {
-    scopedRundown = scopedRundown.filter((event) => event.isPublic);
+    scopedRundown = scopedRundown.filter((event) => !isOntimeEvent(event) || event.isPublic);
   }
 
   return scopedRundown;
@@ -121,7 +121,7 @@ type UpcomingEvents = {
 /**
  * Returns upcoming events from current: now, next and followedBy
  */
-export function getUpcomingEvents(events: OntimeEvent[], selectedId: MaybeString): UpcomingEvents {
+export function getUpcomingEvents(events: OntimeRundown, selectedId: MaybeString): UpcomingEvents {
   if (events.length === 0) {
     return { now: null, next: null, followedBy: null };
   }

--- a/apps/client/src/features/viewers/timeline/timeline.utils.ts
+++ b/apps/client/src/features/viewers/timeline/timeline.utils.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { isOntimeEvent, MaybeString, OntimeEvent, OntimeRundown } from 'ontime-types';
 import {
   dayInMs,
@@ -87,29 +89,34 @@ export function getStatusLabel(timeToStart: number, status: ProgressStatus): str
   return formatDuration(timeToStart);
 }
 
-export function getScopedRundown(rundown: OntimeRundown, selectedEventId: MaybeString): OntimeRundown {
-  if (rundown.length === 0) {
-    return [];
-  }
+export function useScopedRundown(rundown: OntimeRundown, selectedEventId: MaybeString): OntimeRundown {
+  const [searchParams] = useSearchParams();
 
-  const params = new URL(document.location.href).searchParams;
-  const hideBackstage = isStringBoolean(params.get('hideBackstage'));
-  const hidePast = isStringBoolean(params.get('hidePast'));
-
-  let scopedRundown = [...rundown];
-
-  if (hidePast && selectedEventId) {
-    const currentIndex = rundown.findIndex((event) => event.id === selectedEventId);
-    if (currentIndex >= 0) {
-      scopedRundown = scopedRundown.slice(currentIndex);
+  const data = useMemo(() => {
+    if (rundown.length === 0) {
+      return [];
     }
-  }
 
-  if (hideBackstage) {
-    scopedRundown = scopedRundown.filter((event) => !isOntimeEvent(event) || event.isPublic);
-  }
+    const hideBackstage = isStringBoolean(searchParams.get('hideBackstage'));
+    const hidePast = isStringBoolean(searchParams.get('hidePast'));
 
-  return scopedRundown;
+    let scopedRundown = [...rundown];
+
+    if (hidePast && selectedEventId) {
+      const currentIndex = rundown.findIndex((event) => event.id === selectedEventId);
+      if (currentIndex >= 0) {
+        scopedRundown = scopedRundown.slice(currentIndex);
+      }
+    }
+
+    if (hideBackstage) {
+      scopedRundown = scopedRundown.filter((event) => !isOntimeEvent(event) || event.isPublic);
+    }
+
+    return scopedRundown;
+  }, [rundown, searchParams, selectedEventId]);
+
+  return data;
 }
 
 type UpcomingEvents = {

--- a/packages/types/src/utils/guards.ts
+++ b/packages/types/src/utils/guards.ts
@@ -11,7 +11,7 @@ export function isOntimeEvent(event: MaybeEvent): event is OntimeEvent {
 }
 
 export function isPlayableEvent(event: OntimeEvent): event is PlayableEvent {
-  return !event.skip;
+  return !event?.skip;
 }
 
 export function isOntimeDelay(event: MaybeEvent): event is OntimeDelay {

--- a/packages/types/src/utils/guards.ts
+++ b/packages/types/src/utils/guards.ts
@@ -11,7 +11,7 @@ export function isOntimeEvent(event: MaybeEvent): event is OntimeEvent {
 }
 
 export function isPlayableEvent(event: OntimeEvent): event is PlayableEvent {
-  return !event?.skip;
+  return !event.skip;
 }
 
 export function isOntimeDelay(event: MaybeEvent): event is OntimeDelay {

--- a/packages/utils/src/date-utils/checkIsNextDay.test.ts
+++ b/packages/utils/src/date-utils/checkIsNextDay.test.ts
@@ -57,4 +57,11 @@ describe('checkIsNextDay', () => {
     const timeStart = 2 * MILLIS_PER_HOUR;
     expect(checkIsNextDay(previousStart, timeStart, previousDuration)).toBeTruthy();
   });
+
+  it('should account for normalised start over multiple days', () => {
+    const previousStart = 90000000; // 25:00:00
+    const previousDuration = 1 * MILLIS_PER_HOUR;
+    const timeStart = 0;
+    expect(checkIsNextDay(previousStart, timeStart, previousDuration)).toBeTruthy();
+  });
 });

--- a/packages/utils/src/date-utils/checkIsNextDay.ts
+++ b/packages/utils/src/date-utils/checkIsNextDay.ts
@@ -24,8 +24,9 @@ export function checkIsNextDay(previousStart: number, timeStart: number, previou
     return false;
   }
 
-  if (timeStart <= previousStart) {
-    const normalisedPreviousEnd = previousStart + previousDuration;
+  const cappedStart = previousStart % dayInMs;
+  if (timeStart <= cappedStart) {
+    const normalisedPreviousEnd = cappedStart + previousDuration;
     if (normalisedPreviousEnd === dayInMs) {
       return true;
     }


### PR DESCRIPTION
Still some work to be done here, this PR introduces first batch of improvements to the timeline
- Show correct upcoming events
- Refresh page if options change
- handle timeline with multiple days
- handle filtering events from timeline