### PR TITLE
refactor: add options to hide schedule

### DIFF
--- a/apps/client/src/features/viewers/studio/StudioClock.scss
+++ b/apps/client/src/features/viewers/studio/StudioClock.scss
@@ -42,6 +42,11 @@ $orange-active: #f60;
   grid-template-areas: 'clock schedule';
   text-transform: uppercase;
 
+  &.hide-right {
+    grid-template-columns: 1fr;
+    grid-template-areas: 'clock';
+  }
+
   .clock-container {
     grid-area: clock;
     display: grid;

--- a/apps/client/src/features/viewers/studio/StudioClockSchedule.tsx
+++ b/apps/client/src/features/viewers/studio/StudioClockSchedule.tsx
@@ -1,0 +1,50 @@
+import { isOntimeEvent, MaybeString, OntimeEvent, OntimeRundown } from 'ontime-types';
+
+import { formatTime } from '../../../common/utils/time';
+import SuperscriptTime from '../common/superscript-time/SuperscriptTime';
+
+import { trimRundown } from './studioClock.utils';
+
+import './StudioClock.scss';
+
+interface StudioClockScheduleProps {
+  rundown: OntimeRundown;
+  selectedId: MaybeString;
+  nextId: MaybeString;
+  onAir: boolean;
+}
+
+// TODO: fit titles on screen
+const MAX_TITLES = 11;
+
+export default function StudioClockSchedule(props: StudioClockScheduleProps) {
+  const { rundown, selectedId, nextId, onAir } = props;
+
+  const delayed = rundown.filter((event) => isOntimeEvent(event)) as OntimeEvent[];
+  const trimmedRundown = trimRundown(delayed, selectedId, MAX_TITLES);
+
+  return (
+    <div className='schedule-container'>
+      <div className={onAir ? 'onAir' : 'onAir onAir--idle'} data-testid={onAir ? 'on-air-enabled' : 'on-air-disabled'}>
+        ON AIR
+      </div>
+      <ul className='schedule'>
+        {trimmedRundown.map((event) => {
+          const start = formatTime(event.timeStart + (event?.delay ?? 0), { format12: 'h:mm a', format24: 'HH:mm' });
+          const isSelected = event.id === selectedId;
+          const isNext = event.id === nextId;
+          const classes = `schedule__item schedule__item${isSelected ? '--now' : isNext ? '--next' : '--future'}`;
+          return (
+            <li key={event.id} className={classes}>
+              <span className='event'>
+                <span className='event__colour' style={{ backgroundColor: `${event.colour}` }} />
+                <SuperscriptTime time={start} />
+              </span>
+              <span>{event.title}</span>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/apps/client/src/features/viewers/studio/__tests__/studioClock.utils.test.ts
+++ b/apps/client/src/features/viewers/studio/__tests__/studioClock.utils.test.ts
@@ -1,6 +1,6 @@
 import { OntimeEvent } from 'ontime-types';
 
-import { secondsInMillis, trimRundown } from '../studioClock.utils';
+import { trimRundown } from '../studioClock.utils';
 
 describe('test trimEventlist function', () => {
   const limit = 8;
@@ -116,16 +116,5 @@ describe('test trimEventlist function', () => {
     const l = trimRundown(testData as OntimeEvent[], selectedId, limit);
     expect(l.length).toBe(limit);
     expect(l).toStrictEqual(expected);
-  });
-});
-
-describe('secondsInMillis()', () => {
-  it('return 0 if value is null', () => {
-    expect(secondsInMillis(null)).toBe(0);
-  });
-  it('returns the seconds value of a millis date', () => {
-    const date = 1686255053619; // Thu Jun 08 2023 20:10:53
-    const seconds = secondsInMillis(date);
-    expect(seconds).toBe(53);
   });
 });

--- a/apps/client/src/features/viewers/studio/studioClock.options.ts
+++ b/apps/client/src/features/viewers/studio/studioClock.options.ts
@@ -6,4 +6,12 @@ export const getStudioClockOptions = (timeFormat: string): ViewOption[] => [
   getTimeOption(timeFormat),
   { section: 'Timer Options' },
   hideTimerSeconds,
+  { section: 'Element visibility' },
+  {
+    id: 'hideRight',
+    title: 'Hide right section',
+    description: 'Hides the right section with On Air indicator and the schedule',
+    type: 'boolean',
+    defaultValue: false,
+  },
 ];

--- a/apps/client/src/features/viewers/studio/studioClock.utils.ts
+++ b/apps/client/src/features/viewers/studio/studioClock.utils.ts
@@ -1,5 +1,4 @@
-import { MaybeNumber, OntimeEvent } from 'ontime-types';
-import { MILLIS_PER_MINUTE, MILLIS_PER_SECOND } from 'ontime-utils';
+import { OntimeEvent } from 'ontime-types';
 
 /**
  * @description Returns trimmed event list array
@@ -19,16 +18,4 @@ export function trimRundown(rundown: OntimeEvent[], selectedId: string | null, l
   const endIndex = Math.min(startIndex + limit, rundown.length);
   const trimmedRundown = rundown.slice(startIndex, endIndex);
   return trimmedRundown;
-}
-
-/**
- * @description Returns amount of seconds in a date given in milliseconds. For studio clock second indicator
- * @param {MaybeNumber} millis time to format
- * @returns amount of elapsed seconds
- */
-export function secondsInMillis(millis: MaybeNumber): number {
-  if (!millis) {
-    return 0;
-  }
-  return Math.floor((millis % MILLIS_PER_MINUTE) / MILLIS_PER_SECOND);
 }

--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -42,6 +42,7 @@ export {
   millisToHours,
   millisToMinutes,
   millisToSeconds,
+  secondsInMillis,
 } from './src/date-utils/conversionUtils.js';
 export { isTimeString } from './src/date-utils/isTimeString.js';
 export {

--- a/packages/utils/src/date-utils/conversionUtils.test.ts
+++ b/packages/utils/src/date-utils/conversionUtils.test.ts
@@ -1,4 +1,4 @@
-import { millisToHours, millisToMinutes, millisToSeconds } from "./conversionUtils";
+import { millisToHours, millisToMinutes, millisToSeconds, secondsInMillis } from './conversionUtils';
 
 describe('millisToSecond()', () => {
   test('null values', () => {
@@ -110,5 +110,16 @@ describe('millisToHours()', () => {
     // negative numbers are rounded up
     const t = { val: -86401000, result: -25 };
     expect(millisToHours(t.val)).toBe(t.result);
+  });
+});
+
+describe('secondsInMillis()', () => {
+  it('return 0 if value is null', () => {
+    expect(secondsInMillis(null)).toBe(0);
+  });
+  it('returns the seconds value of a millis date', () => {
+    const date = 1686255053619; // Thu Jun 08 2023 20:10:53
+    const seconds = secondsInMillis(date);
+    expect(seconds).toBe(53);
   });
 });

--- a/packages/utils/src/date-utils/conversionUtils.ts
+++ b/packages/utils/src/date-utils/conversionUtils.ts
@@ -64,3 +64,15 @@ export function secondsToMinutes(seconds: number): number {
 export function secondsToHours(seconds: number): number {
   return Math.floor(seconds / 3600);
 }
+
+/**
+ * @description Returns amount of seconds in a date given in milliseconds. For studio clock second indicator
+ * @param {MaybeNumber} millis time to format
+ * @returns amount of elapsed seconds
+ */
+export function secondsInMillis(millis: MaybeNumber): number {
+  if (!millis) {
+    return 0;
+  }
+  return Math.floor((millis % MILLIS_PER_MINUTE) / MILLIS_PER_SECOND);
+}


### PR DESCRIPTION
Adds option to disable right section in studio clock so we only get the clock view in the center
As described in #1168 