### PR TITLE
refactor: refetch on change

### DIFF
--- a/apps/client/src/common/hooks-query/useCustomFields.ts
+++ b/apps/client/src/common/hooks-query/useCustomFields.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { CustomFields } from 'ontime-types';
 
-import { queryRefetchInterval } from '../../ontimeConfig';
+import { queryRefetchIntervalSlow } from '../../ontimeConfig';
 import { CUSTOM_FIELDS } from '../api/constants';
 import { getCustomFields } from '../api/customFields';
 
@@ -14,7 +14,7 @@ export default function useCustomFields() {
     placeholderData: (previousData, _previousQuery) => previousData,
     retry: 5,
     retryDelay: (attempt) => attempt * 2500,
-    refetchInterval: queryRefetchInterval,
+    refetchInterval: queryRefetchIntervalSlow,
     networkMode: 'always',
   });
 

--- a/apps/client/src/common/hooks-query/useRundown.ts
+++ b/apps/client/src/common/hooks-query/useRundown.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { NormalisedRundown, OntimeRundown, RundownCached } from 'ontime-types';
 
-import { queryRefetchInterval } from '../../ontimeConfig';
+import { queryRefetchIntervalSlow } from '../../ontimeConfig';
 import { RUNDOWN } from '../api/constants';
 import { fetchNormalisedRundown } from '../api/rundown';
 
@@ -16,7 +16,7 @@ export default function useRundown() {
     placeholderData: (previousData, _previousQuery) => previousData,
     retry: 5,
     retryDelay: (attempt) => attempt * 2500,
-    refetchInterval: queryRefetchInterval,
+    refetchInterval: queryRefetchIntervalSlow,
     networkMode: 'always',
   });
   return { data: data ?? cachedRundownPlaceholder, status, isError, refetch, isFetching };

--- a/apps/client/src/ontimeConfig.ts
+++ b/apps/client/src/ontimeConfig.ts
@@ -2,5 +2,5 @@ export const tooltipDelaySlow = 1000;
 export const tooltipDelayMid = 500;
 export const tooltipDelayFast = 300;
 
-export const queryRefetchInterval = 10000;
-export const queryRefetchIntervalSlow = 30000;
+export const queryRefetchInterval = 10000; // 10 seconds
+export const queryRefetchIntervalSlow = 30000; // 30 seconds

--- a/apps/server/src/services/rundown-service/RundownService.ts
+++ b/apps/server/src/services/rundown-service/RundownService.ts
@@ -247,7 +247,11 @@ function notifyChanges(options: { timer?: boolean | string[]; external?: boolean
 
   if (options.external) {
     // advice socket subscribers of change
-    sendRefetch(Array.isArray(options.timer) ? options.timer : undefined);
+    const payload = {
+      changes: Array.isArray(options.timer) ? options.timer : undefined,
+      revision: cache.getMetadata().revision,
+    };
+    sendRefetch(payload);
   }
 }
 

--- a/apps/server/src/services/rundown-service/rundownCache.ts
+++ b/apps/server/src/services/rundown-service/rundownCache.ts
@@ -215,6 +215,7 @@ export function getMetadata() {
     lastEnd,
     totalDelay,
     totalDuration,
+    revision,
   };
 }
 
@@ -242,6 +243,12 @@ export function mutateCache<T extends object>(mutation: MutatingFn<T>) {
     isStale = true;
 
     const { newEvent, newRundown, didMutate } = mutation({ ...params, persistedRundown });
+
+    // early return without calling side effects
+    if (!didMutate) {
+      isStale = false;
+      return { newEvent, newRundown, didMutate };
+    }
 
     revision = revision + 1;
     persistedRundown = newRundown;


### PR DESCRIPTION
this implements refetching in the client when we get a refetch message

It also adds a revision field to the refetch payload so the client can decide whether the refetch is essential