### PR TITLE
feat: timer preview

### DIFF
--- a/apps/client/src/common/hooks/useSocket.ts
+++ b/apps/client/src/common/hooks/useSocket.ts
@@ -1,4 +1,4 @@
-import { RuntimeStore, SimpleDirection, SimplePlayback } from 'ontime-types';
+import { RuntimeStore, SimpleDirection, SimplePlayback, TimerMessage } from 'ontime-types';
 
 import { useRuntimeStore } from '../stores/runtime';
 import { socketSendJson } from '../utils/socket';
@@ -28,11 +28,43 @@ export const useOperator = () => {
   return useRuntimeStore(featureSelector);
 };
 
-export const useMessageControl = () => {
+export const useTimerViewControl = () => {
   const featureSelector = (state: RuntimeStore) => ({
-    timer: state.message.timer,
-    external: state.message.external,
-    onAir: state.onAir,
+    blackout: state.message.timer.blackout,
+    blink: state.message.timer.blink,
+    secondarySource: state.message.timer.secondarySource,
+  });
+
+  return useRuntimeStore(featureSelector);
+};
+
+export const useTimerMessageInput = () => {
+  const featureSelector = (state: RuntimeStore) => ({
+    text: state.message.timer.text,
+    visible: state.message.timer.visible,
+  });
+
+  return useRuntimeStore(featureSelector);
+};
+
+export const useExternalMessageInput = () => {
+  const featureSelector = (state: RuntimeStore) => ({
+    text: state.message.external,
+    visible: state.message.timer.secondarySource === 'external',
+  });
+
+  return useRuntimeStore(featureSelector);
+};
+
+export const useMessagePreview = () => {
+  const featureSelector = (state: RuntimeStore) => ({
+    blink: state.message.timer.blink,
+    blackout: state.message.timer.blackout,
+    phase: state.timer.phase,
+    showAuxTimer: state.message.timer.secondarySource === 'aux',
+    showExternalMessage: state.message.timer.secondarySource === 'external' && Boolean(state.message.external),
+    showTimerMessage: state.message.timer.visible && Boolean(state.message.timer.text),
+    timerType: state.eventNow?.timerType ?? null,
   });
 
   return useRuntimeStore(featureSelector);
@@ -41,8 +73,11 @@ export const useMessageControl = () => {
 export const setMessage = {
   timerText: (payload: string) => socketSendJson('message', { timer: { text: payload } }),
   timerVisible: (payload: boolean) => socketSendJson('message', { timer: { visible: payload } }),
+  externalText: (payload: string) => socketSendJson('message', { external: payload }),
   timerBlink: (payload: boolean) => socketSendJson('message', { timer: { blink: payload } }),
   timerBlackout: (payload: boolean) => socketSendJson('message', { timer: { blackout: payload } }),
+  timerSecondary: (payload: TimerMessage['secondarySource']) =>
+    socketSendJson('message', { timer: { secondarySource: payload } }),
 };
 
 export const usePlaybackControl = () => {

--- a/apps/client/src/common/stores/runtime.ts
+++ b/apps/client/src/common/stores/runtime.ts
@@ -23,11 +23,9 @@ export const runtimeStorePlaceholder: RuntimeStore = {
       visible: false,
       blink: false,
       blackout: false,
+      secondarySource: null,
     },
-    external: {
-      text: '',
-      visible: false,
-    },
+    external: '',
   },
   runtime: {
     selectedEventIndex: null,

--- a/apps/client/src/features/app-settings/panel/general-panel/ViewSettingsForm.tsx
+++ b/apps/client/src/features/app-settings/panel/general-panel/ViewSettingsForm.tsx
@@ -147,7 +147,7 @@ export default function ViewSettingsForm() {
                 variant='ontime-filled'
                 maxLength={150}
                 width='275px'
-                placeholder='Message shown when timer reaches end'
+                placeholder='Shown when timer reaches end'
                 {...register('endMessage')}
               />
             </Panel.ListItem>

--- a/apps/client/src/features/control/message/InputRow.tsx
+++ b/apps/client/src/features/control/message/InputRow.tsx
@@ -1,10 +1,9 @@
 import { useEffect, useRef } from 'react';
-import { IconButton, Input } from '@chakra-ui/react';
+import { Input } from '@chakra-ui/react';
 import { IoEye } from '@react-icons/all-files/io5/IoEye';
 import { IoEyeOffOutline } from '@react-icons/all-files/io5/IoEyeOffOutline';
 
 import TooltipActionBtn from '../../../common/components/buttons/TooltipActionBtn';
-import { cx } from '../../../common/utils/styleUtils';
 import { tooltipDelayMid } from '../../../ontimeConfig';
 
 import style from './InputRow.module.scss';
@@ -13,15 +12,13 @@ interface InputRowProps {
   label: string;
   placeholder: string;
   text: string;
-  visible?: boolean;
-  readonly?: boolean;
-  actionHandler: (action: string, payload: object) => void;
+  visible: boolean;
+  actionHandler: () => void;
   changeHandler: (newValue: string) => void;
-  className?: string;
 }
 
 export default function InputRow(props: InputRowProps) {
-  const { label, placeholder, text, visible, actionHandler, changeHandler, className, readonly } = props;
+  const { label, placeholder, text, visible, actionHandler, changeHandler } = props;
 
   const inputRef = useRef<HTMLInputElement>(null);
   const cursorPositionRef = useRef(0);
@@ -39,41 +36,27 @@ export default function InputRow(props: InputRowProps) {
     changeHandler(event.target.value);
   };
 
-  const classes = cx([style.inputRow, className]);
-
   return (
-    <div className={classes}>
+    <div className={style.inputRow}>
       <label className={`${style.label} ${visible ? style.active : ''}`}>{label}</label>
       <div className={style.inputItems}>
         <Input
           ref={inputRef}
           size='sm'
           variant='ontime-filled'
-          readOnly={readonly}
-          disabled={readonly}
           value={text}
           onChange={handleInputChange}
           placeholder={placeholder}
         />
-        {readonly ? (
-          <IconButton
-            size='sm'
-            isDisabled
-            icon={visible ? <IoEye size='18px' /> : <IoEyeOffOutline size='18px' />}
-            aria-label={`Toggle ${label}`}
-            variant={visible ? 'ontime-filled' : 'ontime-subtle'}
-          />
-        ) : (
-          <TooltipActionBtn
-            clickHandler={() => actionHandler('update', { field: 'isPublic', value: !visible })}
-            tooltip={visible ? 'Make invisible' : 'Make visible'}
-            aria-label={`Toggle ${label}`}
-            openDelay={tooltipDelayMid}
-            icon={visible ? <IoEye size='18px' /> : <IoEyeOffOutline size='18px' />}
-            variant={visible ? 'ontime-filled' : 'ontime-subtle'}
-            size='sm'
-          />
-        )}
+        <TooltipActionBtn
+          clickHandler={actionHandler}
+          tooltip={visible ? 'Make invisible' : 'Make visible'}
+          aria-label={`Toggle ${label}`}
+          openDelay={tooltipDelayMid}
+          icon={visible ? <IoEye size='18px' /> : <IoEyeOffOutline size='18px' />}
+          variant={visible ? 'ontime-filled' : 'ontime-subtle'}
+          size='sm'
+        />
       </div>
     </div>
   );

--- a/apps/client/src/features/control/message/MessageControl.module.scss
+++ b/apps/client/src/features/control/message/MessageControl.module.scss
@@ -21,6 +21,22 @@
   position: relative;
 }
 
+.corner {
+  transform: rotate(45deg);
+
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  cursor: pointer;
+  color: $ui-white;
+  transition-property: color;
+  transition-duration: $transition-time-action;
+
+  &:hover {
+    color: $ontime-color;
+  }
+}
+
 .options {
   display: flex;
   flex-direction: column;
@@ -29,7 +45,7 @@
 
 .eventStatus {
   position: absolute;
-  right: 0;
+  left: 0;
   margin: 0.5rem 0.25rem;
   display: flex;
   flex-direction: column;

--- a/apps/client/src/features/control/message/MessageControl.module.scss
+++ b/apps/client/src/features/control/message/MessageControl.module.scss
@@ -1,23 +1,3 @@
-.messageContainer {
-  display: flex;
-  flex-direction: column;
-  gap: $section-spacing;
-}
-
-.buttonSection {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: $element-spacing;
-  margin-top: -0.5rem;
-}
-
-.singleAction {
-  display: flex;
-  flex-direction: column;
-  gap: $element-spacing;
-  margin-top: $element-inner-spacing;
-}
-
 .label {
   font-size: $inner-section-text-size;
   color: $label-gray;
@@ -25,4 +5,74 @@
   &.active {
     color: $action-text-color;
   }
+}
+
+.previewContainer {
+  display: grid;
+  gap: $element-spacing;
+  grid-template-columns: 2fr 1fr;
+}
+
+.preview {
+  background-color: $ui-black;
+  display: grid;
+  place-content: center;
+  text-align: center;
+  position: relative;
+}
+
+.options {
+  display: flex;
+  flex-direction: column;
+  gap: $element-spacing;
+}
+
+.eventStatus {
+  position: absolute;
+  right: 0;
+  margin: 0.5rem 0.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.mainContent {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--override-colour, $ui-white);
+
+  &[data-phase='pending'] {
+    color: $ontime-roll;
+  }
+  &[data-phase='overtime'] {
+    color: $playback-negative;
+  }
+  &[data-phase='none'] {
+    opacity: $opacity-disabled;
+  }
+}
+
+.secondaryContent {
+  border-top: 1px solid $white-7;
+}
+
+.blackout {
+  display: none;
+}
+
+.timerIndicators {
+  display: flex;
+  flex-direction: column;
+}
+
+.statusIcon {
+  color: $gray-1000;
+
+  &[data-active='true'] {
+    color: $active-indicator;
+  }
+}
+
+.divider {
+  border-top: 1px solid $gray-1000;
 }

--- a/apps/client/src/features/control/message/MessageControl.tsx
+++ b/apps/client/src/features/control/message/MessageControl.tsx
@@ -1,64 +1,52 @@
-import { Button } from '@chakra-ui/react';
-import { IoEye } from '@react-icons/all-files/io5/IoEye';
-import { IoEyeOffOutline } from '@react-icons/all-files/io5/IoEyeOffOutline';
-import { IoSunny } from '@react-icons/all-files/io5/IoSunny';
-import { IoSunnyOutline } from '@react-icons/all-files/io5/IoSunnyOutline';
-
-import { setMessage, useMessageControl } from '../../../common/hooks/useSocket';
-import { enDash } from '../../../common/utils/styleUtils';
+import { setMessage, useExternalMessageInput, useTimerMessageInput } from '../../../common/hooks/useSocket';
 
 import InputRow from './InputRow';
-
-import style from './MessageControl.module.scss';
-
-const noop = () => undefined;
+import TimerControlsPreview from './TimerViewControl';
 
 export default function MessageControl() {
-  const message = useMessageControl();
-  const blink = message.timer.blink;
-  const blackout = message.timer.blackout;
+  return (
+    <>
+      <TimerControlsPreview />
+      <TimerMessageInput />
+      <ExternalInput />
+    </>
+  );
+}
+
+function TimerMessageInput() {
+  const { text, visible } = useTimerMessageInput();
 
   return (
-    <div className={style.messageContainer}>
-      <InputRow
-        label='Timer'
-        placeholder='Message shown in stage timer'
-        text={message.timer.text}
-        visible={message.timer.visible}
-        changeHandler={(newValue) => setMessage.timerText(newValue)}
-        actionHandler={() => setMessage.timerVisible(!message.timer.visible)}
-      />
-      <div className={style.buttonSection}>
-        <Button
-          size='sm'
-          className={`${blink ? style.blink : ''}`}
-          variant={blink ? 'ontime-filled' : 'ontime-subtle'}
-          leftIcon={blink ? <IoSunny size='1rem' /> : <IoSunnyOutline size='1rem' />}
-          onClick={() => setMessage.timerBlink(!blink)}
-          data-testid='toggle timer blink'
-        >
-          Blink
-        </Button>
-        <Button
-          size='sm'
-          className={style.blackoutButton}
-          variant={blackout ? 'ontime-filled' : 'ontime-subtle'}
-          leftIcon={blackout ? <IoEye size='1rem' /> : <IoEyeOffOutline size='1rem' />}
-          onClick={() => setMessage.timerBlackout(!blackout)}
-          data-testid='toggle timer blackout'
-        >
-          Blackout screen
-        </Button>
-      </div>
-      <InputRow
-        label='External Message (read only)'
-        placeholder={enDash}
-        readonly
-        text={message.external.text}
-        visible={message.external.visible}
-        changeHandler={noop}
-        actionHandler={noop}
-      />
-    </div>
+    <InputRow
+      label='Timer Message'
+      placeholder='Message shown fullscreen in stage timer'
+      text={text}
+      visible={visible}
+      changeHandler={(newValue) => setMessage.timerText(newValue)}
+      actionHandler={() => setMessage.timerVisible(!visible)}
+    />
+  );
+}
+
+function ExternalInput() {
+  const { text, visible } = useExternalMessageInput();
+
+  const toggleExternal = () => {
+    if (visible) {
+      setMessage.timerSecondary(null);
+    } else {
+      setMessage.timerSecondary('external');
+    }
+  };
+
+  return (
+    <InputRow
+      label='External Message'
+      placeholder='Message shown as secondary text in stage timer'
+      text={text}
+      visible={visible}
+      changeHandler={(newValue) => setMessage.externalText(newValue)}
+      actionHandler={toggleExternal}
+    />
   );
 }

--- a/apps/client/src/features/control/message/MessageControlExport.jsx
+++ b/apps/client/src/features/control/message/MessageControlExport.jsx
@@ -3,16 +3,19 @@ import { IoArrowUp } from '@react-icons/all-files/io5/IoArrowUp';
 
 import ErrorBoundary from '../../../common/components/error-boundary/ErrorBoundary';
 import { handleLinks } from '../../../common/utils/linkUtils';
+import { cx } from '../../../common/utils/styleUtils';
 
 import MessageControl from './MessageControl';
 
 import style from '../../editors/Editor.module.scss';
 
 const MessageControlExport = () => {
+  const classes = cx([style.content, style.contentColumnLayout]);
+
   return (
     <div className={style.messages} data-testid='panel-messages-control'>
       <IoArrowUp className={style.corner} onClick={(event) => handleLinks(event, 'messagecontrol')} />
-      <div className={style.content}>
+      <div className={classes}>
         <ErrorBoundary>
           <MessageControl />
         </ErrorBoundary>

--- a/apps/client/src/features/control/message/TimerPreview.tsx
+++ b/apps/client/src/features/control/message/TimerPreview.tsx
@@ -7,6 +7,7 @@ import { TimerPhase, TimerType } from 'ontime-types';
 
 import { useMessagePreview } from '../../../common/hooks/useSocket';
 import useViewSettings from '../../../common/hooks-query/useViewSettings';
+import { handleLinks } from '../../../common/utils/linkUtils';
 import { cx } from '../../../common/utils/styleUtils';
 import { tooltipDelayMid } from '../../../ontimeConfig';
 
@@ -47,6 +48,7 @@ export default function TimerPreview() {
 
   return (
     <div className={style.preview}>
+      <IoArrowUp className={style.corner} onClick={(event) => handleLinks(event, 'timer')} />
       <div className={contentClasses}>
         <div
           className={style.mainContent}

--- a/apps/client/src/features/control/message/TimerPreview.tsx
+++ b/apps/client/src/features/control/message/TimerPreview.tsx
@@ -1,0 +1,76 @@
+import { Tooltip } from '@chakra-ui/react';
+import { IoArrowDown } from '@react-icons/all-files/io5/IoArrowDown';
+import { IoArrowUp } from '@react-icons/all-files/io5/IoArrowUp';
+import { IoFlag } from '@react-icons/all-files/io5/IoFlag';
+import { IoTime } from '@react-icons/all-files/io5/IoTime';
+import { TimerPhase, TimerType } from 'ontime-types';
+
+import { useMessagePreview } from '../../../common/hooks/useSocket';
+import useViewSettings from '../../../common/hooks-query/useViewSettings';
+import { cx } from '../../../common/utils/styleUtils';
+import { tooltipDelayMid } from '../../../ontimeConfig';
+
+import style from './MessageControl.module.scss';
+
+export default function TimerPreview() {
+  const { blink, blackout, phase, showAuxTimer, showExternalMessage, showTimerMessage, timerType } =
+    useMessagePreview();
+  const { data } = useViewSettings();
+
+  const contentClasses = cx([style.previewContent, blink && style.blink, blackout && style.blackout]);
+
+  const main = (() => {
+    if (showTimerMessage) return 'Message';
+    if (phase === TimerPhase.Pending) return 'Standby to start';
+    if (phase === TimerPhase.Overtime && data.endMessage) return 'Custom end message';
+    return 'Timer';
+  })();
+
+  const secondary = (() => {
+    // message is a fullscreen overlay
+    if (showTimerMessage) return null;
+
+    // we need to check aux first since it takes priority
+    if (showAuxTimer) return 'Aux Timer';
+    if (showExternalMessage) return 'External message';
+    return null;
+  })();
+
+  const overrideColour = (() => {
+    // override fallback colours from starter project
+    if (phase === TimerPhase.Warning) return data.warningColor ?? '#FFAB33';
+    if (phase === TimerPhase.Danger) return data.dangerColor ?? '#ED3333';
+    return data.normalColor ?? '#FFFC';
+  })();
+
+  const showColourOverride = main == 'Timer';
+
+  return (
+    <div className={style.preview}>
+      <div className={contentClasses}>
+        <div
+          className={style.mainContent}
+          data-phase={phase}
+          style={showColourOverride ? { '--override-colour': overrideColour } : {}}
+        >
+          {main}
+        </div>
+        {secondary !== null && <div className={style.secondaryContent}>{secondary}</div>}
+      </div>
+      <div className={style.eventStatus}>
+        <Tooltip label='Time type: Count down' openDelay={tooltipDelayMid} shouldWrapChildren>
+          <IoArrowDown className={style.statusIcon} data-active={timerType === TimerType.CountDown} />
+        </Tooltip>
+        <Tooltip label='Time type: Count up' openDelay={tooltipDelayMid} shouldWrapChildren>
+          <IoArrowUp className={style.statusIcon} data-active={timerType === TimerType.CountUp} />
+        </Tooltip>
+        <Tooltip label='Time type: Clock' openDelay={tooltipDelayMid} shouldWrapChildren>
+          <IoTime className={style.statusIcon} data-active={timerType === TimerType.Clock} />
+        </Tooltip>
+        <Tooltip label='Time type: Time to end' openDelay={tooltipDelayMid} shouldWrapChildren>
+          <IoFlag className={style.statusIcon} data-active={timerType === TimerType.TimeToEnd} />
+        </Tooltip>
+      </div>
+    </div>
+  );
+}

--- a/apps/client/src/features/control/message/TimerViewControl.tsx
+++ b/apps/client/src/features/control/message/TimerViewControl.tsx
@@ -1,0 +1,62 @@
+import { Button } from '@chakra-ui/react';
+
+import { setMessage, useTimerViewControl } from '../../../common/hooks/useSocket';
+
+import TimerPreview from './TimerPreview';
+
+import style from './MessageControl.module.scss';
+
+export default function TimerControlsPreview() {
+  const { blackout, blink, secondarySource } = useTimerViewControl();
+
+  const toggleSecondary = (newValue: 'aux' | 'external' | null) => {
+    if (secondarySource === newValue) {
+      setMessage.timerSecondary(null);
+    } else {
+      setMessage.timerSecondary(newValue);
+    }
+  };
+
+  return (
+    <div className={style.previewContainer}>
+      <TimerPreview />
+
+      <div className={style.options}>
+        <Button
+          size='sm'
+          variant={secondarySource === 'aux' ? 'ontime-filled' : 'ontime-subtle'}
+          onClick={() => toggleSecondary('aux')}
+        >
+          Show Aux timer
+        </Button>
+        <Button
+          size='sm'
+          variant={secondarySource === 'external' ? 'ontime-filled' : 'ontime-subtle'}
+          onClick={() => toggleSecondary('external')}
+        >
+          Show external
+        </Button>
+
+        <hr className={style.divider} />
+
+        <Button
+          size='sm'
+          variant={blink ? 'ontime-filled' : 'ontime-subtle'}
+          onClick={() => setMessage.timerBlink(!blink)}
+          data-testid='toggle timer blink'
+        >
+          Blink
+        </Button>
+        <Button
+          size='sm'
+          className={style.blackoutButton}
+          variant={blackout ? 'ontime-filled' : 'ontime-subtle'}
+          onClick={() => setMessage.timerBlackout(!blackout)}
+          data-testid='toggle timer blackout'
+        >
+          Blackout screen
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/client/src/features/control/playback/aux-timer/AuxTimer.tsx
+++ b/apps/client/src/features/control/playback/aux-timer/AuxTimer.tsx
@@ -68,7 +68,7 @@ function AuxTimerInput() {
 
   const handleTimeUpdate = (_field: string, value: string) => {
     const newTime = parseUserTime(value);
-    setDuration(newTime / 1000); //frontend api is seconds based;
+    setDuration(newTime / 1000); // frontend api is seconds based
   };
 
   return (

--- a/apps/client/src/features/editors/Editor.module.scss
+++ b/apps/client/src/features/editors/Editor.module.scss
@@ -40,7 +40,7 @@ $panel-gap: 0.5rem;
   .playback,
   .messages {
     position: relative;
-    border-radius: 8px;
+    border-radius: var(--editor--panel__br);
     background-color: $bg-container-l2;
     padding: 1rem;
   }
@@ -61,4 +61,11 @@ $panel-gap: 0.5rem;
 
 .content {
   padding-top: 1.5rem;
+}
+
+.contentColumnLayout {
+  display: flex;
+  flex-direction: column;
+  gap: $section-spacing;
+  color: $ui-white;
 }

--- a/apps/client/src/features/editors/EditorMixin.scss
+++ b/apps/client/src/features/editors/EditorMixin.scss
@@ -1,10 +1,18 @@
 @use '../../theme/ontimeColours' as *;
 @use '../../theme/ontimeStyles' as *;
 
-@mixin absolute-top-right($distance) {
+// declare editor specific styling constants
+:root {
+  --editor--panel__br: 8px;
+}
+
+@mixin corner() {
+  display: none;
+  transform: rotate(45deg);
+
   position: absolute;
-  top: $distance;
-  right: $distance;
+  top: 0.5rem;
+  right: 0.5rem;
   cursor: pointer;
   color: $ui-white;
   transition-property: color;
@@ -15,17 +23,11 @@
   }
 }
 
-@mixin corner() {
-  display: none;
-  @include absolute-top-right(0.5rem);
-  transform: rotate(45deg);
-}
-
 @mixin panel() {
   display: flex;
 
   position: relative;
-  border-radius: 8px;
+  border-radius: var(--editor--panel__br);
   height: 100%;
   background-color: $bg-container-l2;
   padding: 1rem;

--- a/apps/client/src/features/rundown/event-block/EventBlockInner.tsx
+++ b/apps/client/src/features/rundown/event-block/EventBlockInner.tsx
@@ -21,10 +21,6 @@ import EventBlockProgressBar from './composite/EventBlockProgressBar';
 
 import style from './EventBlock.module.scss';
 
-const tooltipProps = {
-  openDelay: tooltipDelayMid,
-};
-
 interface EventBlockInnerProps {
   timeStart: number;
   timeEnd: number;
@@ -98,11 +94,7 @@ const EventBlockInner = (props: EventBlockInnerProps) => {
       </div>
       <div className={style.titleSection}>
         <EditableBlockTitle title={title} eventId={eventId} placeholder='Event title' className={style.eventTitle} />
-        {isNext && (
-          <Tooltip label='Next event' {...tooltipProps}>
-            <span className={style.nextTag}>UP NEXT</span>
-          </Tooltip>
-        )}
+        {isNext && <span className={style.nextTag}>UP NEXT</span>}
       </div>
       <EventBlockPlayback
         eventId={eventId}
@@ -118,17 +110,17 @@ const EventBlockInner = (props: EventBlockInnerProps) => {
           {loaded && <EventBlockProgressBar />}
         </div>
         <div className={style.eventStatus} tabIndex={-1}>
-          <Tooltip label={`Time type: ${timerType}`} {...tooltipProps}>
+          <Tooltip label={`Time type: ${timerType}`} openDelay={tooltipDelayMid}>
             <span>
               <TimerIcon type={timerType} className={style.statusIcon} />
             </span>
           </Tooltip>
-          <Tooltip label={`End action: ${endAction}`} {...tooltipProps}>
+          <Tooltip label={`End action: ${endAction}`} openDelay={tooltipDelayMid}>
             <span>
               <EndActionIcon action={endAction} className={style.statusIcon} />
             </span>
           </Tooltip>
-          <Tooltip label={`${isPublic ? 'Event is public' : 'Event is private'}`} {...tooltipProps}>
+          <Tooltip label={`${isPublic ? 'Event is public' : 'Event is private'}`} openDelay={tooltipDelayMid}>
             <span>
               <IoPeople className={`${style.statusIcon} ${isPublic ? style.active : style.disabled}`} />
             </span>

--- a/apps/client/src/features/viewers/ViewWrapper.tsx
+++ b/apps/client/src/features/viewers/ViewWrapper.tsx
@@ -2,13 +2,13 @@ import { ComponentType, useMemo } from 'react';
 import { ViewExtendedTimer } from 'common/models/TimeManager.type';
 import {
   CustomFields,
-  Message,
+  MessageState,
   OntimeEvent,
   ProjectData,
   Runtime,
   Settings,
+  SimpleTimerState,
   SupportedEvent,
-  TimerMessage,
   ViewSettings,
 } from 'ontime-types';
 import { useStore } from 'zustand';
@@ -23,17 +23,17 @@ import { runtimeStore } from '../../common/stores/runtime';
 import { useViewOptionsStore } from '../../common/stores/viewOptions';
 
 type WithDataProps = {
+  auxTimer: SimpleTimerState;
   backstageEvents: OntimeEvent[];
   customFields: CustomFields;
   eventNext: OntimeEvent | null;
   eventNow: OntimeEvent | null;
   events: OntimeEvent[];
-  external: Message;
   general: ProjectData;
   isMirrored: boolean;
+  message: MessageState;
   nextId: string | null;
   onAir: boolean;
-  pres: TimerMessage;
   publicEventNext: OntimeEvent | null;
   publicEventNow: OntimeEvent | null;
   publicSelectedId: string | null;
@@ -68,7 +68,7 @@ const withData = <P extends WithDataProps>(Component: ComponentType<P>) => {
     }, [rundownData]);
 
     // websocket data
-    const { clock, timer, message, onAir, eventNext, publicEventNext, publicEventNow, eventNow, runtime } =
+    const { clock, timer, message, onAir, eventNext, publicEventNext, publicEventNow, eventNow, runtime, auxtimer1 } =
       useStore(runtimeStore);
     const publicSelectedId = publicEventNow?.id ?? null;
     const selectedId = eventNow?.id ?? null;
@@ -96,17 +96,17 @@ const withData = <P extends WithDataProps>(Component: ComponentType<P>) => {
         <ViewNavigationMenu />
         <Component
           {...props}
+          auxTimer={auxtimer1}
           backstageEvents={rundownData}
           customFields={customFields}
           eventNext={eventNext}
           eventNow={eventNow}
           events={publicEvents}
-          external={message.external}
           general={project}
           isMirrored={isMirrored}
+          message={message}
           nextId={nextId}
           onAir={onAir}
-          pres={message.timer}
           publicEventNext={publicEventNext}
           publicEventNow={publicEventNow}
           publicSelectedId={publicSelectedId}

--- a/apps/client/src/features/viewers/timer/Timer.scss
+++ b/apps/client/src/features/viewers/timer/Timer.scss
@@ -129,20 +129,22 @@
     }
   }
 
-  .external {
+  .secondary {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+
+    margin-top: 0.25em;
+    padding-block: 0.25em;
 
     font-weight: 600;
     text-align: center;
     color: var(--external-color-override, $external-color);
     letter-spacing: 0.5px;
     line-height: 0.9em;
-    padding-bottom: 0.2em;
     transition-property: opacity, height;
     transition-duration: $viewer-transition-time;
-    border-top: 1px solid rgba(white, 0.1);
+    border-top: 1px solid color-mix(in srgb, var(--external-color-override, $external-color) 10%, transparent);
 
     &--hidden {
       opacity: 0;

--- a/apps/client/src/features/viewers/timer/Timer.tsx
+++ b/apps/client/src/features/viewers/timer/Timer.tsx
@@ -203,7 +203,7 @@ export default function Timer(props: TimerProps) {
           </div>
         )}
         <div
-          className={`external${secondaryContent ? '' : ' external--hidden'}`}
+          className={`secondary${secondaryContent ? '' : ' secondary--hidden'}`}
           style={{ fontSize: `${externalFontSize}vw` }}
         >
           {secondaryContent}

--- a/apps/client/src/theme/_viewerDefs.scss
+++ b/apps/client/src/theme/_viewerDefs.scss
@@ -26,7 +26,7 @@ $timer-color: rgba(white, 80%); // --timer-color-override
 $timer-finished-color: $playback-negative;
 $timer-bold-font-family: 'Arial Black', sans-serif; // --card-background-color-override
 
-$external-color: rgba(white, 70%); // --external-color-override
+$external-color: rgba(white, 85%); // --external-color-override
 
 // properties of other timers (clock and countdown)
 $timer-label-size: clamp(16px, 1.5vw, 24px);

--- a/apps/server/src/api-integration/__tests__/integration.legacy.test.ts
+++ b/apps/server/src/api-integration/__tests__/integration.legacy.test.ts
@@ -1,0 +1,36 @@
+import { handleLegacyMessageConversion } from '../integration.legacy.js';
+
+describe('handleLegacyConversion', () => {
+  it('should return the payload as is if it is not a legacy message', () => {
+    expect(handleLegacyMessageConversion({})).toEqual({});
+    const newPayload = {
+      timer: {
+        text: 'text',
+        visible: true,
+        blink: true,
+        blackout: true,
+      },
+      external: 'text',
+    };
+    expect(handleLegacyMessageConversion(newPayload)).toEqual(newPayload);
+  });
+
+  it('should convert a legacy payload with external message', () => {
+    expect(handleLegacyMessageConversion({ external: { text: 'text', visible: true } })).toEqual({
+      external: 'text',
+      timer: {
+        secondarySource: 'external',
+      },
+    });
+
+    expect(handleLegacyMessageConversion({ external: { visible: true } })).toEqual({
+      timer: {
+        secondarySource: 'external',
+      },
+    });
+
+    expect(handleLegacyMessageConversion({ external: { text: 'text' } })).toEqual({
+      external: 'text',
+    });
+  });
+});

--- a/apps/server/src/api-integration/integration.controller.ts
+++ b/apps/server/src/api-integration/integration.controller.ts
@@ -1,9 +1,11 @@
-import { DeepPartial, MessageState, OntimeEvent, SimpleDirection, SimplePlayback } from 'ontime-types';
+import { MessageState, OntimeEvent, SimpleDirection, SimplePlayback } from 'ontime-types';
 import { MILLIS_PER_HOUR, MILLIS_PER_SECOND } from 'ontime-utils';
+
+import { DeepPartial } from 'ts-essentials';
 
 import { ONTIME_VERSION } from '../ONTIME_VERSION.js';
 import { auxTimerService } from '../services/aux-timer-service/AuxTimerService.js';
-import { messageService } from '../services/message-service/MessageService.js';
+import * as messageService from '../services/message-service/MessageService.js';
 import { validateMessage, validateTimerMessage } from '../services/message-service/messageUtils.js';
 import { runtimeService } from '../services/runtime-service/RuntimeService.js';
 import { eventStore } from '../stores/EventStore.js';
@@ -13,6 +15,8 @@ import { parseProperty, updateEvent } from './integration.utils.js';
 import { socket } from '../adapters/WebsocketAdapter.js';
 import { throttle } from '../utils/throttle.js';
 import { willCauseRegeneration } from '../services/rundown-service/rundownCacheUtils.js';
+
+import { handleLegacyMessageConversion } from './integration.legacy.js';
 
 const throttledUpdateEvent = throttle(updateEvent, 20);
 
@@ -78,9 +82,12 @@ const actionHandlers: Record<string, ActionHandler> = {
   message: (payload) => {
     assert.isObject(payload);
 
+    // TODO: remove this once we feel its been enough time, ontime 3.6.0, 20/09/2024
+    const migratedPayload = handleLegacyMessageConversion(payload);
+
     const patch: DeepPartial<MessageState> = {
-      timer: 'timer' in payload ? validateTimerMessage(payload.timer) : undefined,
-      external: 'external' in payload ? validateMessage(payload.external) : undefined,
+      timer: 'timer' in migratedPayload ? validateTimerMessage(migratedPayload.timer) : undefined,
+      external: 'external' in migratedPayload ? validateMessage(migratedPayload.external) : undefined,
     };
 
     const newMessage = messageService.patch(patch);

--- a/apps/server/src/api-integration/integration.legacy.ts
+++ b/apps/server/src/api-integration/integration.legacy.ts
@@ -1,0 +1,67 @@
+import { MessageState } from 'ontime-types';
+import { DeepPartial } from 'ts-essentials';
+
+export type LegacyMessageState = DeepPartial<{
+  timer: {
+    text: string;
+    visible: boolean;
+    blink: boolean;
+    blackout: boolean;
+  };
+  external: {
+    text: string;
+    visible: boolean;
+  };
+}>;
+
+function isLegacyMessageState(value: object): value is LegacyMessageState {
+  // @ts-expect-error -- good enough here
+  return value?.external?.text !== undefined || value?.external?.visible !== undefined;
+}
+
+/**
+ * This function is used to maintain support for legacy data in the /message endpoint
+ * The previous message endpoint expected a patch of the message state
+ * @example {
+ *  timer: { blink: boolean, blackout: boolean, text: string, visible: boolean },
+ *  external: { visible: boolean, text: string }
+ * }
+ *
+ * This change is introduced in version 3.6.0
+ */
+export function handleLegacyMessageConversion(payload: object): object | Partial<MessageState> {
+  // if it is not a legacy message, we pass it as is
+  if (!isLegacyMessageState(payload)) {
+    return payload;
+  }
+
+  /**
+   * The current migration only needs to handle the cases
+   * for the deprecated external message controls
+   */
+
+  // Migrate external message
+  // 2.1 the user gives us the text and a visible flag
+  if (payload?.external?.text !== undefined && payload.external.visible !== undefined) {
+    return {
+      timer: { secondarySource: payload.external.visible ? 'external' : null },
+      external: payload.external.text,
+    } as Partial<MessageState>;
+  }
+  // 2.2 the user gives us the text
+  else if (payload?.external?.text !== undefined) {
+    return {
+      external: payload.external.text,
+    } as Partial<MessageState>;
+  }
+  // 2.3 the user gives us the visible flag
+  else if (payload?.external?.visible !== undefined) {
+    return {
+      timer: { secondarySource: payload.external.visible ? 'external' : null },
+    } as Partial<MessageState>;
+  }
+
+  // there should be no case for us to reach this since
+  // the type guard would have ensured one of the above states
+  return payload;
+}

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -210,7 +210,7 @@ export const startServer = async (
   runtimeService.init(maybeRestorePoint);
 
   // eventStore set is a dependency of the services that publish to it
-  messageService.init(eventStore.set);
+  messageService.init((key, value) => eventStore.set(key, value));
 
   expressServer.listen(serverPort, '0.0.0.0', () => {
     const nif = getNetworkInterfaces();

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -38,7 +38,7 @@ import { populateStyles } from './setup/loadStyles.js';
 import { eventStore } from './stores/EventStore.js';
 import { runtimeService } from './services/runtime-service/RuntimeService.js';
 import { restoreService } from './services/RestoreService.js';
-import { messageService } from './services/message-service/MessageService.js';
+import * as messageService from './services/message-service/MessageService.js';
 import { populateDemo } from './setup/loadDemo.js';
 import { getState } from './stores/runtimeState.js';
 import { initRundown } from './services/rundown-service/RundownService.js';
@@ -198,7 +198,7 @@ export const startServer = async (
   // initialise logging service, escalateErrorFn is only exists in electron
   logger.init(escalateErrorFn);
 
-  // initialise rundown service
+  // initialise rundown service 
   const persistedRundown = getDataProvider().getRundown();
   const persistedCustomFields = getDataProvider().getCustomFields();
   initRundown(persistedRundown, persistedCustomFields);
@@ -210,7 +210,7 @@ export const startServer = async (
   runtimeService.init(maybeRestorePoint);
 
   // eventStore set is a dependency of the services that publish to it
-  messageService.init(eventStore.set.bind(eventStore));
+  messageService.init(eventStore.set);
 
   expressServer.listen(serverPort, '0.0.0.0', () => {
     const nif = getNetworkInterfaces();

--- a/apps/server/src/services/message-service/__tests__/MessageService.test.ts
+++ b/apps/server/src/services/message-service/__tests__/MessageService.test.ts
@@ -1,4 +1,4 @@
-import { messageService } from '../MessageService.js';
+import * as messageService from '../MessageService.js';
 
 describe('MessageService', () => {
   const publishFunction = () => {};
@@ -14,17 +14,14 @@ describe('MessageService', () => {
   it('should patch the message state', () => {
     const message = {
       timer: { text: 'new text', visible: true },
-      external: { visible: true },
+      external: 'external',
     };
 
     const newState = messageService.patch(message);
 
     expect(newState).toEqual({
-      timer: { text: 'new text', visible: true, blackout: false, blink: false },
-      external: {
-        text: '',
-        visible: true,
-      },
+      timer: { text: 'new text', visible: true, blackout: false, blink: false, secondarySource: null },
+      external: 'external',
     });
   });
 
@@ -36,11 +33,8 @@ describe('MessageService', () => {
     const newState = messageService.patch(initialMessage);
 
     expect(newState).toEqual({
-      timer: { text: 'initial text', visible: true, blackout: false, blink: false },
-      external: {
-        text: '',
-        visible: false,
-      },
+      timer: { text: 'initial text', visible: true, blackout: false, blink: false, secondarySource: null },
+      external: '',
     });
   });
 });

--- a/apps/server/src/services/message-service/__tests__/messageUtils.test.ts
+++ b/apps/server/src/services/message-service/__tests__/messageUtils.test.ts
@@ -2,26 +2,7 @@ import { validateMessage, validateTimerMessage } from '../messageUtils.js';
 
 describe('validateMessage()', () => {
   it('returns a valid Message object', () => {
-    const payload = {
-      text: '12312',
-      visible: 'true',
-    };
-    const expected = {
-      text: '12312',
-      visible: true,
-    };
-
-    expect(validateMessage(payload)).toEqual(expected);
-  });
-  it('skips keys not given', () => {
-    const payload = {
-      visible: 'true',
-    };
-    const expected = {
-      visible: true,
-    };
-
-    expect(validateMessage(payload)).toStrictEqual(expected);
+    expect(validateMessage('test')).toEqual('test');
   });
 });
 

--- a/apps/server/src/services/message-service/messageUtils.ts
+++ b/apps/server/src/services/message-service/messageUtils.ts
@@ -1,4 +1,4 @@
-import { Message, TimerMessage } from 'ontime-types';
+import { TimerMessage } from 'ontime-types';
 
 import * as assert from '../../utils/assert.js';
 import { coerceBoolean, coerceString } from '../../utils/coerceType.js';
@@ -7,14 +7,8 @@ import { coerceBoolean, coerceString } from '../../utils/coerceType.js';
  * Creates a valid Message object from a payload
  * @throws if the payload is not an object
  */
-export function validateMessage(message: unknown): Partial<Message> {
-  assert.isObject(message);
-
-  const result: Partial<Message> = {};
-  if ('text' in message) result.text = coerceString(message.text);
-  if ('visible' in message) result.visible = coerceBoolean(message.visible);
-
-  return result;
+export function validateMessage(message: unknown): string {
+  return decodeURI(coerceString(message));
 }
 
 /**
@@ -26,10 +20,28 @@ export function validateTimerMessage(message: unknown): Partial<TimerMessage> {
 
   const result: Partial<TimerMessage> = {};
 
-  if ('text' in message) result.text = coerceString(message.text);
+  if ('text' in message) result.text = decodeURI(coerceString(message.text));
   if ('visible' in message) result.visible = coerceBoolean(message.visible);
   if ('blink' in message) result.blink = coerceBoolean(message.blink);
   if ('blackout' in message) result.blackout = coerceBoolean(message.blackout);
+  if ('secondarySource' in message) result.secondarySource = coerceSecondary(message.secondarySource);
 
   return result;
+}
+
+/**
+ * Asserts that the secondary value is one of the permitted values
+ */
+function assertSecondary(source: unknown): source is TimerMessage['secondarySource'] {
+  return source === 'aux' || source === 'external' || source === null;
+}
+
+/**
+ * Ensures that the secondary value is one of the permitted values
+ */
+function coerceSecondary(source: unknown): TimerMessage['secondarySource'] {
+  if (!assertSecondary(source)) {
+    return null;
+  }
+  return source;
 }

--- a/e2e/tests/features/201-message-control.spec.ts
+++ b/e2e/tests/features/201-message-control.spec.ts
@@ -7,9 +7,9 @@ test('message control sends messages to screens', async ({ context }) => {
   await editorPage.goto('http://localhost:4001/messagecontrol');
 
   // stage timer message
-  await editorPage.getByPlaceholder('Timer').click();
-  await editorPage.getByPlaceholder('Timer').fill('testing stage');
-  await editorPage.getByRole('button', { name: /toggle timer/i }).click({ timeout: 5000 });
+  await editorPage.getByPlaceholder('Message shown fullscreen in stage timer').click();
+  await editorPage.getByPlaceholder('Message shown fullscreen in stage timer').fill('testing stage');
+  await editorPage.getByRole('button', { name: /toggle timer message/i }).click({ timeout: 5000 });
 
   await featurePage.goto('http://localhost:4001/timer');
   await featurePage.waitForLoadState('load', { timeout: 5000 });

--- a/packages/types/src/definitions/runtime/MessageControl.type.ts
+++ b/packages/types/src/definitions/runtime/MessageControl.type.ts
@@ -1,14 +1,12 @@
-export type Message = {
+export type TimerMessage = {
   text: string;
   visible: boolean;
-};
-
-export type TimerMessage = Message & {
   blink: boolean;
   blackout: boolean;
+  secondarySource: 'aux' | 'external' | null;
 };
 
 export type MessageState = {
   timer: TimerMessage;
-  external: Message;
+  external: string;
 };

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -58,7 +58,7 @@ export type { RundownCached, NormalisedRundown } from './api/rundown-controller/
 export { type Log, LogLevel, type LogMessage, LogOrigin } from './definitions/runtime/Logger.type.js';
 export { Playback } from './definitions/runtime/Playback.type.js';
 export { TimerLifeCycle } from './definitions/core/TimerLifecycle.type.js';
-export type { Message, TimerMessage, MessageState } from './definitions/runtime/MessageControl.type.js';
+export type { TimerMessage, MessageState } from './definitions/runtime/MessageControl.type.js';
 
 export type { Runtime } from './definitions/runtime/Runtime.type.js';
 export type { RuntimeStore } from './definitions/runtime/RuntimeStore.type.js';
@@ -80,4 +80,4 @@ export {
   isOntimeCycle,
   isKeyOfType,
 } from './utils/guards.js';
-export type { DeepPartial, MaybeNumber, MaybeString } from './utils/utils.type.js';
+export type { MaybeNumber, MaybeString } from './utils/utils.type.js';

--- a/packages/types/src/utils/utils.type.ts
+++ b/packages/types/src/utils/utils.type.ts
@@ -1,6 +1,2 @@
 export type MaybeNumber = number | null;
 export type MaybeString = string | null;
-
-export type DeepPartial<T> = {
-  [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
-};


### PR DESCRIPTION
WIP

The idea is to help users manage the timer view and make things friendlier
https://www.figma.com/design/TOjSQ4e8q4dhNDNN5DElD3/ontime?node-id=1722-6&t=9OAa5afIUFi2Ule1-1

This also helps resolve #1024 

![Screenshot 2024-09-20 at 22 34 11](https://github.com/user-attachments/assets/c4737c06-8c80-4628-9cd9-dadbfdaf5842)

- expose button to show auxiliary as secondary
- expose button to show external as secondary (previously disabled)
- create preview of timer
- show timer type with tooltips in preview
- show timer phase (warning / danger) in preview

Questions:

The button for external visibility is duplicated, I experimented without it but it felt strange to have two different inputs for External Message and Timer Message. I am not sure what the best way is here

I opted for not showing the real message and time to be conservative of performance. While this is a nice feature, I didnt feel it was worth the performance investment. However we could do better at showing the current formatting from settings (eg: HH:MM), any ideas for this?
