### PR TITLE
fix: issue with roll evaluating multiple days

### DIFF
--- a/apps/server/src/services/__tests__/rollUtils.test.ts
+++ b/apps/server/src/services/__tests__/rollUtils.test.ts
@@ -246,6 +246,43 @@ describe('loadRoll() handle edge cases with midnight', () => {
   });
 });
 
+describe('loadRoll() handle rundowns with several days', () => {
+  it('should find the correct event, when we have many days', () => {
+    const now = 11 * MILLIS_PER_HOUR + 30 * MILLIS_PER_MINUTE;
+    const timedEvents = [
+      {
+        id: '0',
+        timeStart: 10 * MILLIS_PER_HOUR,
+        timeEnd: 11 * MILLIS_PER_HOUR,
+      },
+      {
+        id: '2',
+        timeStart: 11 * MILLIS_PER_HOUR,
+        timeEnd: 12 * MILLIS_PER_HOUR,
+      },
+      {
+        id: '3',
+        timeStart: 12 * MILLIS_PER_HOUR,
+        timeEnd: 13 * MILLIS_PER_HOUR,
+      },
+      {
+        id: '4',
+        timeStart: 11 * MILLIS_PER_HOUR,
+        timeEnd: 12 * MILLIS_PER_HOUR,
+      },
+    ];
+
+    const state = loadRoll(prepareTimedEvents(timedEvents), now);
+    const expected = {
+      event: timedEvents[1],
+      index: 1,
+    };
+    expect(state).toMatchObject(expected);
+  });
+
+  });
+});
+
 describe('loadRoll() handle edge cases with before and after start', () => {
   it('should prepare first event, if we are not yet in the rundown start', () => {
     const now = 7 * MILLIS_PER_HOUR;
@@ -302,7 +339,7 @@ describe('loadRoll() handle edge cases with before and after start', () => {
       index: 0,
     };
     const state = loadRoll(singleEventList, now);
-    expect(state.isPending).toBeUndefined();
+    expect(state.isPending).toBeUndefined(); // we are playing the event
     expect(state).toStrictEqual(expected);
   });
 
@@ -443,6 +480,7 @@ describe('loadRoll() test that roll behaviour multi day event edge cases', () =>
     };
 
     const state = loadRoll(eventlist, now);
+    expect(state.isPending).toBeUndefined(); // we are playing the event
     expect(state).toStrictEqual(expected);
   });
 });

--- a/apps/server/src/services/__tests__/rollUtils.test.ts
+++ b/apps/server/src/services/__tests__/rollUtils.test.ts
@@ -280,6 +280,42 @@ describe('loadRoll() handle rundowns with several days', () => {
     expect(state).toMatchObject(expected);
   });
 
+  it('should find the correct event, when we have events of zero duration', () => {
+    const now = 20 * MILLIS_PER_HOUR + 37 * MILLIS_PER_MINUTE;
+    const timedEvents = [
+      {
+        id: '0',
+        timeStart: 18 * MILLIS_PER_HOUR,
+        timeEnd: 19 * MILLIS_PER_HOUR,
+      },
+      {
+        id: '1 no duration',
+        timeStart: 0,
+        timeEnd: 0,
+      },
+      {
+        id: '2',
+        timeStart: 19 * MILLIS_PER_HOUR,
+        timeEnd: 20 * MILLIS_PER_HOUR,
+      },
+      {
+        id: '3 no duration',
+        timeStart: 0,
+        timeEnd: 0,
+      },
+      {
+        id: '4',
+        timeStart: 20 * MILLIS_PER_HOUR,
+        timeEnd: 21 * MILLIS_PER_HOUR,
+      },
+    ];
+
+    const state = loadRoll(prepareTimedEvents(timedEvents), now);
+    const expected = {
+      event: timedEvents[4],
+      index: 4,
+    };
+    expect(state).toMatchObject(expected);
   });
 });
 

--- a/apps/server/src/services/rollUtils.ts
+++ b/apps/server/src/services/rollUtils.ts
@@ -31,6 +31,10 @@ export function loadRoll(
       continue;
     }
 
+    if (event.duration === 0) {
+      continue;
+    }
+
     // we check if event crosses midnight
     if (event.timeStart > event.timeEnd) {
       daySpan++;

--- a/apps/server/src/services/rollUtils.ts
+++ b/apps/server/src/services/rollUtils.ts
@@ -1,4 +1,4 @@
-import { dayInMs, getFirstEvent, getLastEvent } from 'ontime-utils';
+import { dayInMs, getFirstEvent } from 'ontime-utils';
 import { OntimeEvent, MaybeNumber, PlayableEvent, isPlayableEvent } from 'ontime-types';
 
 import { normaliseEndTime } from './timerUtils.js';
@@ -15,24 +15,9 @@ export function loadRoll(
   isPending?: boolean;
 } {
   const { firstEvent } = getFirstEvent(timedEvents);
-  const { lastEvent } = getLastEvent(timedEvents);
 
-  if (!firstEvent || !lastEvent) {
+  if (!firstEvent) {
     return { event: null, index: null };
-  }
-
-  // check that the rundown wraps around midnight
-  const wrapsAroundMidnight = firstEvent.timeStart > lastEvent.timeEnd;
-
-  if (!wrapsAroundMidnight) {
-    // check whether we are before or after the rundown
-    const lastNormalEnd = normaliseEndTime(lastEvent.timeStart, lastEvent.timeEnd);
-    const isAfterRundown = timeNow > lastNormalEnd;
-    const isBeforeRundown = timeNow < firstEvent.timeStart && !isAfterRundown;
-
-    if (isAfterRundown || isBeforeRundown) {
-      return { event: firstEvent, index: 0, isPending: true };
-    }
   }
 
   // we know we are in the middle of the rundown and we need to find the current event

--- a/apps/server/src/stores/runtimeState.ts
+++ b/apps/server/src/stores/runtimeState.ts
@@ -120,8 +120,10 @@ export function clear() {
   runtimeState.clock = clock.timeNow();
   runtimeState.timer = { ...initialTimer };
 
-  // we maintain the total delay
+  // when clearing, we maintain the total delay from the rundown
+  runtimeState._timer.forceFinish = null;
   runtimeState._timer.pausedAt = null;
+  runtimeState._timer.secondaryTarget = null;
 }
 
 /**


### PR DESCRIPTION
Fixes an issue where we would fail to recognise if a rundown had multiple days

This was because of the naive evaluation of `wrapsAroundMidnight = firstEvent.timeStart > lastEvent.timeEnd`

I believe the best (ie: easiest and safest) fix is to try and be less clever, and force the loader to always iterate through the dataset. This at cost of performance and some complexity