### PR TITLE
Shutdown

### DIFF
--- a/apps/client/src/common/api/constants.ts
+++ b/apps/client/src/common/api/constants.ts
@@ -18,6 +18,7 @@ const location = window.location;
 const socketProtocol = location.protocol === 'https:' ? 'wss' : 'ws';
 export const isProduction = import.meta.env.MODE === 'production';
 export const isDev = !isProduction;
+export const isLocalhost = location.hostname === 'localhost' || location.hostname === '127.0.0.1';
 
 // resolve port
 const STATIC_PORT = 4001;

--- a/apps/client/src/features/app-settings/panel/shutdown-panel/ShutdownPanel.tsx
+++ b/apps/client/src/features/app-settings/panel/shutdown-panel/ShutdownPanel.tsx
@@ -10,6 +10,7 @@ import {
   useDisclosure,
 } from '@chakra-ui/react';
 
+import { isLocalhost } from '../../../../common/api/constants';
 import useElectronEvent from '../../../../common/hooks/useElectronEvent';
 import * as Panel from '../PanelUtils';
 
@@ -31,7 +32,7 @@ export default function ShutdownPanel() {
           This will shutdown the Ontime server. <br />
           The runtime state will be lost, but your project is kept for next time.
         </Panel.Paragraph>
-        <Button colorScheme='red' onClick={onOpen} maxWidth='350px' isDisabled={!isElectron}>
+        <Button colorScheme='red' onClick={onOpen} maxWidth='350px' isDisabled={!(isElectron || isLocalhost)}>
           Shutdown ontime
         </Button>
         <Panel.Description>Note: Ontime can only be shutdown from the machine it is running in.</Panel.Description>

--- a/apps/client/src/features/app-settings/panel/shutdown-panel/ShutdownPanel.tsx
+++ b/apps/client/src/features/app-settings/panel/shutdown-panel/ShutdownPanel.tsx
@@ -34,6 +34,7 @@ export default function ShutdownPanel() {
         <Button colorScheme='red' onClick={onOpen} maxWidth='350px' isDisabled={!isElectron}>
           Shutdown ontime
         </Button>
+        <Panel.Description>Note: Ontime can only be shutdown from the machine it is running in.</Panel.Description>
         <AlertDialog variant='ontime' isOpen={isOpen} leastDestructiveRef={cancelRef} onClose={onClose}>
           <AlertDialogOverlay>
             <AlertDialogContent>


### PR DESCRIPTION
small change to allow shutting down from localhost outside electron as discussed in #1215

This will also impact the users in node and docker environments.
As far as I can see, there are no downsides here, but thought of double checking @alex-Arc @jwetzell. Am I maybe missing something? In those environments, is there a reason for us not to want users to shutdown the process from the interface?
