### PR TITLE
fix: issue where event next was stale

### DIFF
--- a/apps/server/src/services/runtime-service/RuntimeService.ts
+++ b/apps/server/src/services/runtime-service/RuntimeService.ts
@@ -232,7 +232,7 @@ class RuntimeService {
 
     // we need to reload in a few scenarios:
     // 1. we are not confident that changes do not affect running event (eg. all events where changed)
-    const safeOption = typeof affectedIds === 'undefined';
+    const safeOption = affectedIds === undefined;
     // 2. the edited event is in memory (now or next) running
     // behind conditional to avoid doing unnecessary work
     const eventInMemory = safeOption ? false : this.affectsLoaded(affectedIds);

--- a/apps/server/src/stores/runtimeState.ts
+++ b/apps/server/src/stores/runtimeState.ts
@@ -266,6 +266,9 @@ export function loadNext(
     return;
   }
 
+  // temporarily reset this value to simplify loop logic
+  runtimeState.eventNext = null;
+
   for (let i = eventIndex + 1; i < timedEvents.length; i++) {
     const event = timedEvents[i];
     // we dont deal with events that are not playable


### PR DESCRIPTION
Looks like we have a bug where, if we start the timer, and change a property of the next event, The `eventNext` object in the server state does not get updated

this is a one liner to fix it