### PR TITLE
refactor: allow messages not starting with http

### DIFF
--- a/apps/client/src/common/utils/__tests__/regex.test.ts
+++ b/apps/client/src/common/utils/__tests__/regex.test.ts
@@ -1,4 +1,4 @@
-import { isAlphanumeric, isIPAddress, isNotEmpty, isOnlyNumbers, startsWithHttp, startsWithSlash } from '../regex';
+import { isAlphanumeric, isIPAddress, isNotEmpty, isOnlyNumbers, startsWithSlash } from '../regex';
 
 describe('simple tests for regex', () => {
   test('isOnlyNumbers', () => {
@@ -22,18 +22,6 @@ describe('simple tests for regex', () => {
     });
     wrong.forEach((t) => {
       expect(isIPAddress.test(t)).toBe(false);
-    });
-  });
-
-  test('startsWithHttp', () => {
-    const right = ['http://test'];
-    const wrong = ['https://test', 'testing', '123.0.1'];
-
-    right.forEach((t) => {
-      expect(startsWithHttp.test(t)).toBe(true);
-    });
-    wrong.forEach((t) => {
-      expect(startsWithHttp.test(t)).toBe(false);
     });
   });
 

--- a/apps/client/src/common/utils/regex.ts
+++ b/apps/client/src/common/utils/regex.ts
@@ -5,7 +5,6 @@
 
 export const isOnlyNumbers = /^\d+$/;
 export const isIPAddress = /^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}$/;
-export const startsWithHttp = /^http:\/\//;
 export const startsWithSlash = /^\//;
 export const isAlphanumeric = /^[a-z0-9]+$/i;
 export const isASCII = /^[ -~]+$/; //https://catonmat.net/my-favorite-regex

--- a/apps/client/src/features/app-settings/panel/integrations-panel/HttpIntegrations.tsx
+++ b/apps/client/src/features/app-settings/panel/integrations-panel/HttpIntegrations.tsx
@@ -158,10 +158,6 @@ export default function HttpIntegrations() {
                           placeholder='http://third-party/vt1/{{timer.current}}'
                           {...register(`subscriptions.${index}.message`, {
                             required: { value: true, message: 'Required field' },
-                            pattern: {
-                              value: startsWithHttp,
-                              message: 'HTTP messages should start with http://',
-                            },
                           })}
                         />
                         {maybeError && <Panel.Error>{maybeError}</Panel.Error>}

--- a/apps/client/src/features/app-settings/panel/integrations-panel/HttpIntegrations.tsx
+++ b/apps/client/src/features/app-settings/panel/integrations-panel/HttpIntegrations.tsx
@@ -8,7 +8,6 @@ import { generateId } from 'ontime-utils';
 import { maybeAxiosError } from '../../../../common/api/utils';
 import { useHttpSettings, usePostHttpSettings } from '../../../../common/hooks-query/useHttpSettings';
 import { isKeyEscape } from '../../../../common/utils/keyEvent';
-import { startsWithHttp } from '../../../../common/utils/regex';
 import * as Panel from '../PanelUtils';
 
 import { cycles } from './integrationUtils';

--- a/apps/server/src/utils/__tests__/parserFunctions.test.ts
+++ b/apps/server/src/utils/__tests__/parserFunctions.test.ts
@@ -128,7 +128,6 @@ describe('parseHttp()', () => {
         { id: '1', cycle: 'onLoad', message: 'http://', enabled: true }, // OK
         {}, // no data
         { id: '2', cycle: 'onStart', enabled: true }, // no message
-        { id: '3', cycle: 'onLoad', message: '/test', enabled: true }, // doesnt start with http
       ],
     } as HttpSettings;
     const result = parseHttp({ http }, errorEmitter);

--- a/apps/server/src/utils/parserFunctions.ts
+++ b/apps/server/src/utils/parserFunctions.ts
@@ -222,11 +222,7 @@ export function sanitiseHttpSubscriptions(subscriptions?: HttpSubscription[]): H
 
   return subscriptions.filter(
     ({ id, cycle, message, enabled }) =>
-      typeof id === 'string' &&
-      isOntimeCycle(cycle) &&
-      typeof message === 'string' &&
-      message.startsWith('http://') &&
-      typeof enabled === 'boolean',
+      typeof id === 'string' && isOntimeCycle(cycle) && typeof message === 'string' && typeof enabled === 'boolean',
   );
 }
 


### PR DESCRIPTION
We have got a user report that they need the HTTP integration to allow a target that who is not behind an HTTP protocol
In the user example, we would like to have `kmtrigger://macro=...`

Our development policy is often to not interfere with users setup as long as we can make it safe in Ontime.
In this case, I am unsure if we can get into trouble by being too permissive with the HTTP target

I couldn't find any reason for issues other than https requests will be rejected, https://httpwg.org/specs/rfc9110.html#field.host
Any ideas @alex-Arc or @jwetzell? Is there maybe another type of validation we should be doing?