### PR TITLE
refactor: message does not have negative style

### DIFF
--- a/apps/client/src/features/control/message/TimerPreview.tsx
+++ b/apps/client/src/features/control/message/TimerPreview.tsx
@@ -52,7 +52,7 @@ export default function TimerPreview() {
       <div className={contentClasses}>
         <div
           className={style.mainContent}
-          data-phase={phase}
+          data-phase={showColourOverride && phase}
           style={showColourOverride ? { '--override-colour': overrideColour } : {}}
         >
           {main}


### PR DESCRIPTION
When the timer is negative, the message preview was inheriting the overtime styles

This is a one liner to correct the issue