### PR TITLE
refactor: items active by default

### DIFF
--- a/apps/client/src/features/app-settings/panel/feature-settings-panel/UrlPresetsForm.tsx
+++ b/apps/client/src/features/app-settings/panel/feature-settings-panel/UrlPresetsForm.tsx
@@ -78,7 +78,7 @@ export default function UrlPresetsForm() {
 
   const addNew = () => {
     prepend({
-      enabled: false,
+      enabled: true,
       alias: '',
       pathAndParams: '',
     });

--- a/apps/client/src/features/app-settings/panel/integrations-panel/HttpIntegrations.tsx
+++ b/apps/client/src/features/app-settings/panel/integrations-panel/HttpIntegrations.tsx
@@ -60,7 +60,7 @@ export default function HttpIntegrations() {
       id: generateId(),
       cycle: 'onLoad',
       message: '',
-      enabled: false,
+      enabled: true,
     });
   };
 

--- a/apps/client/src/features/app-settings/panel/integrations-panel/OscIntegrations.tsx
+++ b/apps/client/src/features/app-settings/panel/integrations-panel/OscIntegrations.tsx
@@ -75,7 +75,7 @@ export default function OscIntegrations() {
       cycle: 'onLoad',
       address: '',
       payload: '',
-      enabled: false,
+      enabled: true,
     });
   };
 

--- a/e2e/tests/features/206-url-preset.spec.ts
+++ b/e2e/tests/features/206-url-preset.spec.ts
@@ -19,8 +19,6 @@ test('URL preset feature, it should redirect to given URL', async ({ page }) => 
   await page.getByTestId('field__url_0').click();
   await page.getByTestId('field__url_0').fill('countdown');
 
-  await page.getByTestId('field__enable_0').click();
-
   await page.getByTestId('url-preset-form').getByRole('button', { name: 'Save', exact: true }).click();
 
   // make sure preset works


### PR DESCRIPTION
user feedback: when adding new integrations or URL, they forget to activate it and wonder why it doesnt work