### PR TITLE
add more shortcuts for zooming in

### DIFF
--- a/apps/electron/src/menu/applicationMenu.js
+++ b/apps/electron/src/menu/applicationMenu.js
@@ -140,7 +140,10 @@ function makeViewMenu(clientUrl) {
       { role: 'forceReload' },
       { type: 'separator' },
       { role: 'resetZoom' },
-      { role: 'zoomIn' },
+      // NOTE: I still contend this zoomin mess is an electron bug
+      { role: 'zoomIn', accelerator: 'CmdOrCtrl+Plus' },
+      { role: 'zoomIn', accelerator: 'CmdOrCtrl+=', visible: false },
+      { role: 'zoomIn', accelerator: 'CmdOrCtrl+numadd', visible: false },
       { role: 'zoomOut' },
       { type: 'separator' },
       { role: 'togglefullscreen' },


### PR DESCRIPTION
As noted I still contend this is a bug with electron. I still haven't found a single app where pressing`ctrl` plus the key that `+` is on does not zoom in. 

Closes #1256 