### PR TITLE
refactor: notes as data source

### DIFF
--- a/apps/client/src/features/viewers/lower-thirds/lowerThird.options.ts
+++ b/apps/client/src/features/viewers/lower-thirds/lowerThird.options.ts
@@ -6,10 +6,12 @@ import { ViewOption } from '../../../common/components/view-params-editor/types'
 export const getLowerThirdOptions = (customFields: CustomFields): ViewOption[] => {
   const topSourceOptions = makeOptionsFromCustomFields(customFields, {
     title: 'Title',
+    note: 'Note',
   });
 
   const bottomSourceOptions = makeOptionsFromCustomFields(customFields, {
     title: 'Title',
+    note: 'Note',
     none: 'None',
   });
 

--- a/apps/client/src/features/viewers/public/public.options.ts
+++ b/apps/client/src/features/viewers/public/public.options.ts
@@ -4,7 +4,7 @@ import { getTimeOption, makeOptionsFromCustomFields } from '../../../common/comp
 import { ViewOption } from '../../../common/components/view-params-editor/types';
 
 export const getPublicOptions = (timeFormat: string, customFields: CustomFields): ViewOption[] => {
-  const secondaryOptions = makeOptionsFromCustomFields(customFields);
+  const secondaryOptions = makeOptionsFromCustomFields(customFields, { note: 'Note' });
 
   return [
     { section: 'Clock Options' },

--- a/apps/client/src/features/viewers/timer/timer.options.ts
+++ b/apps/client/src/features/viewers/timer/timer.options.ts
@@ -9,8 +9,9 @@ import {
 import { ViewOption } from '../../../common/components/view-params-editor/types';
 
 export const getTimerOptions = (timeFormat: string, customFields: CustomFields): ViewOption[] => {
-  const mainOptions = makeOptionsFromCustomFields(customFields, { title: 'Title' });
-  const secondaryOptions = makeOptionsFromCustomFields(customFields, { note: 'Note' });
+  const mainOptions = makeOptionsFromCustomFields(customFields, { title: 'Title', note: 'Note' });
+  const secondaryOptions = makeOptionsFromCustomFields(customFields, { title: 'Title', note: 'Note' });
+
   return [
     { section: 'Clock Options' },
     getTimeOption(timeFormat),


### PR DESCRIPTION
Ensuring that notes can be used as a data source in all views
As mentioned in #1251 