### PR TITLE
feat(ui): disable menu buttons with `locked` param

### DIFF
--- a/apps/client/src/common/components/navigation-menu/FloatingNavigation.tsx
+++ b/apps/client/src/common/components/navigation-menu/FloatingNavigation.tsx
@@ -1,8 +1,7 @@
-import { useEffect, useState } from 'react';
 import { IoApps } from '@react-icons/all-files/io5/IoApps';
 import { IoSettingsOutline } from '@react-icons/all-files/io5/IoSettingsOutline';
 
-import { debounce } from '../../utils/debounce';
+import { useFadeOutOnInactivity } from '../../../common/hooks/useFadeOutOnInactivity';
 
 import style from './NavigationMenu.module.scss';
 
@@ -13,32 +12,10 @@ interface FloatingNavigationProps {
 
 export default function FloatingNavigation(props: FloatingNavigationProps) {
   const { toggleMenu, toggleSettings } = props;
-  const [showButton, setShowButton] = useState(false);
-
-  // show on mouse move
-  useEffect(() => {
-    let fadeOut: NodeJS.Timeout | null = null;
-    const setShowMenuTrue = () => {
-      setShowButton(true);
-      if (fadeOut) {
-        clearTimeout(fadeOut);
-      }
-      fadeOut = setTimeout(() => setShowButton(false), 3000);
-    };
-
-    const debouncedShowMenu = debounce(setShowMenuTrue, 1000);
-
-    document.addEventListener('mousemove', debouncedShowMenu);
-    return () => {
-      document.removeEventListener('mousemove', debouncedShowMenu);
-      if (fadeOut) {
-        clearTimeout(fadeOut);
-      }
-    };
-  }, []);
+  const isButtonShown = useFadeOutOnInactivity();
 
   return (
-    <div className={`${style.buttonContainer} ${!showButton ? style.hidden : ''}`}>
+    <div className={`${style.buttonContainer} ${!isButtonShown ? style.hidden : ''}`}>
       <button
         onClick={toggleMenu}
         aria-label='toggle menu'

--- a/apps/client/src/common/components/navigation-menu/FloatingNavigation.tsx
+++ b/apps/client/src/common/components/navigation-menu/FloatingNavigation.tsx
@@ -1,7 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
 import { IoApps } from '@react-icons/all-files/io5/IoApps';
-import { IoLockClosedOutline } from '@react-icons/all-files/io5/IoLockClosedOutline';
 import { IoSettingsOutline } from '@react-icons/all-files/io5/IoSettingsOutline';
 
 import { debounce } from '../../utils/debounce';
@@ -16,9 +14,6 @@ interface FloatingNavigationProps {
 export default function FloatingNavigation(props: FloatingNavigationProps) {
   const { toggleMenu, toggleSettings } = props;
   const [showButton, setShowButton] = useState(false);
-  const [searchParams] = useSearchParams();
-
-  const isViewLocked = searchParams.get('locked') ? true : false;
 
   // show on mouse move
   useEffect(() => {
@@ -44,30 +39,22 @@ export default function FloatingNavigation(props: FloatingNavigationProps) {
 
   return (
     <div className={`${style.buttonContainer} ${!showButton ? style.hidden : ''}`}>
-      {isViewLocked ? (
-        <div className={style.lockIcon}>
-          <IoLockClosedOutline />
-        </div>
-      ) : (
-        <>
-          <button
-            onClick={toggleMenu}
-            aria-label='toggle menu'
-            className={style.navButton}
-            data-testid='navigation__toggle-menu'
-          >
-            <IoApps />
-          </button>
-          <button
-            className={style.button}
-            onClick={toggleSettings}
-            aria-label='toggle settings'
-            data-testid='navigation__toggle-settings'
-          >
-            <IoSettingsOutline />
-          </button>
-        </>
-      )}
+      <button
+        onClick={toggleMenu}
+        aria-label='toggle menu'
+        className={style.navButton}
+        data-testid='navigation__toggle-menu'
+      >
+        <IoApps />
+      </button>
+      <button
+        className={style.button}
+        onClick={toggleSettings}
+        aria-label='toggle settings'
+        data-testid='navigation__toggle-settings'
+      >
+        <IoSettingsOutline />
+      </button>
     </div>
   );
 }

--- a/apps/client/src/common/components/navigation-menu/FloatingNavigation.tsx
+++ b/apps/client/src/common/components/navigation-menu/FloatingNavigation.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { IoApps } from '@react-icons/all-files/io5/IoApps';
+import { IoLockClosedOutline } from '@react-icons/all-files/io5/IoLockClosedOutline';
 import { IoSettingsOutline } from '@react-icons/all-files/io5/IoSettingsOutline';
 
 import { debounce } from '../../utils/debounce';
@@ -14,6 +16,9 @@ interface FloatingNavigationProps {
 export default function FloatingNavigation(props: FloatingNavigationProps) {
   const { toggleMenu, toggleSettings } = props;
   const [showButton, setShowButton] = useState(false);
+  const [searchParams] = useSearchParams();
+
+  const isViewLocked = searchParams.get('locked') ? true : false;
 
   // show on mouse move
   useEffect(() => {
@@ -39,22 +44,30 @@ export default function FloatingNavigation(props: FloatingNavigationProps) {
 
   return (
     <div className={`${style.buttonContainer} ${!showButton ? style.hidden : ''}`}>
-      <button
-        onClick={toggleMenu}
-        aria-label='toggle menu'
-        className={style.navButton}
-        data-testid='navigation__toggle-menu'
-      >
-        <IoApps />
-      </button>
-      <button
-        className={style.button}
-        onClick={toggleSettings}
-        aria-label='toggle settings'
-        data-testid='navigation__toggle-settings'
-      >
-        <IoSettingsOutline />
-      </button>
+      {isViewLocked ? (
+        <div className={style.lockIcon}>
+          <IoLockClosedOutline />
+        </div>
+      ) : (
+        <>
+          <button
+            onClick={toggleMenu}
+            aria-label='toggle menu'
+            className={style.navButton}
+            data-testid='navigation__toggle-menu'
+          >
+            <IoApps />
+          </button>
+          <button
+            className={style.button}
+            onClick={toggleSettings}
+            aria-label='toggle settings'
+            data-testid='navigation__toggle-settings'
+          >
+            <IoSettingsOutline />
+          </button>
+        </>
+      )}
     </div>
   );
 }

--- a/apps/client/src/common/components/navigation-menu/NavigationMenu.module.scss
+++ b/apps/client/src/common/components/navigation-menu/NavigationMenu.module.scss
@@ -39,7 +39,10 @@ $button-size: 3rem;
 }
 
 .lockIcon {
-  @extend .button;
+  font-size: 1.5rem;
+  display: grid;
+  place-content: center;
+  border-radius: 3px;
   background-color: transparent;
   color: $active-indicator;
   cursor: default;

--- a/apps/client/src/common/components/navigation-menu/NavigationMenu.module.scss
+++ b/apps/client/src/common/components/navigation-menu/NavigationMenu.module.scss
@@ -38,6 +38,13 @@ $button-size: 3rem;
   border-radius: 3px;
 }
 
+.lockIcon {
+  @extend .button;
+  background-color: transparent;
+  color: $active-indicator;
+  cursor: default;
+}
+
 .navButton {
   @extend .button;
   z-index: 3;

--- a/apps/client/src/common/components/navigation-menu/ViewLockedIcon.tsx
+++ b/apps/client/src/common/components/navigation-menu/ViewLockedIcon.tsx
@@ -1,0 +1,15 @@
+import { IoLockClosedOutline } from '@react-icons/all-files/io5/IoLockClosedOutline';
+
+import { useFadeOutOnInactivity } from '../../../common/hooks/useFadeOutOnInactivity';
+
+import style from './NavigationMenu.module.scss';
+
+export default function ViewLockedIcon() {
+  const isLockIconShown = useFadeOutOnInactivity();
+
+  return (
+    <div className={`${style.buttonContainer} ${!isLockIconShown ? style.hidden : ''}`}>
+      <IoLockClosedOutline className={style.lockIcon} />
+    </div>
+  );
+}

--- a/apps/client/src/common/components/navigation-menu/ViewNavigationMenu.tsx
+++ b/apps/client/src/common/components/navigation-menu/ViewNavigationMenu.tsx
@@ -26,9 +26,7 @@ function ViewNavigationMenu() {
   if (isViewLocked) {
     return (
       <div className={style.buttonContainer}>
-        <div className={style.lockIcon}>
-          <IoLockClosedOutline />
-        </div>
+        <IoLockClosedOutline className={style.lockIcon} />
       </div>
     );
   }

--- a/apps/client/src/common/components/navigation-menu/ViewNavigationMenu.tsx
+++ b/apps/client/src/common/components/navigation-menu/ViewNavigationMenu.tsx
@@ -1,14 +1,12 @@
 import { memo, useCallback } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { useDisclosure } from '@chakra-ui/react';
-import { IoLockClosedOutline } from '@react-icons/all-files/io5/IoLockClosedOutline';
 
 import { isStringBoolean } from '../../../features/viewers/common/viewUtils';
 
 import FloatingNavigation from './FloatingNavigation';
 import NavigationMenu from './NavigationMenu';
-
-import style from './NavigationMenu.module.scss';
+import ViewLockedIcon from './ViewLockedIcon';
 
 function ViewNavigationMenu() {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -24,11 +22,7 @@ function ViewNavigationMenu() {
   const toggleMenu = () => (isMenuOpen ? onMenuClose() : onMenuOpen());
 
   if (isViewLocked) {
-    return (
-      <div className={style.buttonContainer}>
-        <IoLockClosedOutline className={style.lockIcon} />
-      </div>
-    );
+    return <ViewLockedIcon />;
   }
 
   return (

--- a/apps/client/src/common/components/navigation-menu/ViewNavigationMenu.tsx
+++ b/apps/client/src/common/components/navigation-menu/ViewNavigationMenu.tsx
@@ -1,13 +1,20 @@
 import { memo, useCallback } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { useDisclosure } from '@chakra-ui/react';
+import { IoLockClosedOutline } from '@react-icons/all-files/io5/IoLockClosedOutline';
+
+import { isStringBoolean } from '../../../features/viewers/common/viewUtils';
 
 import FloatingNavigation from './FloatingNavigation';
 import NavigationMenu from './NavigationMenu';
 
+import style from './NavigationMenu.module.scss';
+
 function ViewNavigationMenu() {
   const [searchParams, setSearchParams] = useSearchParams();
   const { isOpen: isMenuOpen, onOpen: onMenuOpen, onClose: onMenuClose } = useDisclosure();
+
+  const isViewLocked = isStringBoolean(searchParams.get('locked'));
 
   const showEditFormDrawer = useCallback(() => {
     searchParams.set('edit', 'true');
@@ -15,6 +22,16 @@ function ViewNavigationMenu() {
   }, [searchParams, setSearchParams]);
 
   const toggleMenu = () => (isMenuOpen ? onMenuClose() : onMenuOpen());
+
+  if (isViewLocked) {
+    return (
+      <div className={style.buttonContainer}>
+        <div className={style.lockIcon}>
+          <IoLockClosedOutline />
+        </div>
+      </div>
+    );
+  }
 
   return (
     <>

--- a/apps/client/src/common/hooks/useFadeOutOnInactivity.tsx
+++ b/apps/client/src/common/hooks/useFadeOutOnInactivity.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+
+import { debounce } from '../../common/utils/debounce';
+
+export const useFadeOutOnInactivity = () => {
+  const [showButton, setShowButton] = useState(false);
+
+  // show on mouse move
+  useEffect(() => {
+    let fadeOut: NodeJS.Timeout | null = null;
+    const setShowMenuTrue = () => {
+      setShowButton(true);
+      if (fadeOut) {
+        clearTimeout(fadeOut);
+      }
+      fadeOut = setTimeout(() => setShowButton(false), 3000);
+    };
+
+    const debouncedShowMenu = debounce(setShowMenuTrue, 1000);
+
+    document.addEventListener('mousemove', debouncedShowMenu);
+    return () => {
+      document.removeEventListener('mousemove', debouncedShowMenu);
+      if (fadeOut) {
+        clearTimeout(fadeOut);
+      }
+    };
+  }, []);
+
+  return showButton;
+};

--- a/apps/client/src/common/hooks/useFadeOutOnInactivity.tsx
+++ b/apps/client/src/common/hooks/useFadeOutOnInactivity.tsx
@@ -3,17 +3,17 @@ import { useEffect, useState } from 'react';
 import { debounce } from '../../common/utils/debounce';
 
 export const useFadeOutOnInactivity = () => {
-  const [showButton, setShowButton] = useState(false);
+  const [isMouseMoved, setIsMouseMoved] = useState(false);
 
   // show on mouse move
   useEffect(() => {
     let fadeOut: NodeJS.Timeout | null = null;
     const setShowMenuTrue = () => {
-      setShowButton(true);
+      setIsMouseMoved(true);
       if (fadeOut) {
         clearTimeout(fadeOut);
       }
-      fadeOut = setTimeout(() => setShowButton(false), 3000);
+      fadeOut = setTimeout(() => setIsMouseMoved(false), 3000);
     };
 
     const debouncedShowMenu = debounce(setShowMenuTrue, 1000);
@@ -27,5 +27,5 @@ export const useFadeOutOnInactivity = () => {
     };
   }, []);
 
-  return showButton;
+  return isMouseMoved;
 };


### PR DESCRIPTION
<img width="1458" alt="Screenshot 2024-11-17 at 6 48 58 PM" src="https://github.com/user-attachments/assets/b49868ce-4b45-45ce-9977-5c28ce3929bf">

I attempted to lock navigation with `useBlocker`, but there are two roadblocks to implement this feature:

- the `react-router-dom` package needs an upgrade. I was able to do so without any problems, FYI
- the hook is a data hook and thus only works with the `RouterProvider` configuration, which means re-doing `AppRouter.tsx` to use `createBrowserRouter`