### PR TITLE
OSC tx and RX shutdown was swapped

### DIFF
--- a/apps/server/src/services/integration-service/OscIntegration.ts
+++ b/apps/server/src/services/integration-service/OscIntegration.ts
@@ -128,18 +128,18 @@ export class OscIntegration implements IIntegration<OscSubscription, OSCSettings
   }
 
   private shutdownTX() {
-    logger.info(LogOrigin.Rx, 'Shutting down OSC integration');
-    if (this.oscServer) {
-      this.oscServer?.shutdown();
-      this.oscServer = null;
+    if (this.oscClient) {
+      logger.info(LogOrigin.Tx, 'Shutting down OSC integration');
+      this.oscClient?.close();
+      this.oscClient = null;
     }
   }
 
   private shutdownRX() {
-    logger.info(LogOrigin.Tx, 'Shutting down OSC integration');
-    if (this.oscClient) {
-      this.oscClient?.close();
-      this.oscClient = null;
+    if (this.oscServer) {
+      logger.info(LogOrigin.Rx, 'Shutting down OSC integration');
+      this.oscServer?.shutdown();
+      this.oscServer = null;
     }
   }
 }


### PR DESCRIPTION
Fix error where the OSC RX and TX when shutdown closed the wrong counterpart
also moved the log statements so it only logs if there is something to close