### PR TITLE
fix: rolling over midnight wrongly classified as skip

### DIFF
--- a/apps/client/src/features/control/playback/playback-timer/PlaybackTimer.tsx
+++ b/apps/client/src/features/control/playback/playback-timer/PlaybackTimer.tsx
@@ -1,9 +1,10 @@
 import { PropsWithChildren } from 'react';
 import { Tooltip } from '@chakra-ui/react';
 import { Playback, TimerPhase } from 'ontime-types';
-import { dayInMs, millisToMinutes, millisToSeconds, millisToString } from 'ontime-utils';
+import { dayInMs, millisToString } from 'ontime-utils';
 
 import { useTimer } from '../../../../common/hooks/useSocket';
+import { formatDuration } from '../../../../common/utils/time';
 import TimerDisplay from '../timer-display/TimerDisplay';
 
 import style from './PlaybackTimer.module.scss';
@@ -13,22 +14,12 @@ interface PlaybackTimerProps {
 }
 
 function resolveAddedTimeLabel(addedTime: number) {
-  function resolveClosestUnit(ms: number) {
-    if (ms < 6000) {
-      return `${millisToSeconds(ms)} seconds`;
-    } else if (ms < 12000) {
-      return '1 minute';
-    } else {
-      return `${millisToMinutes(ms)} minutes`;
-    }
-  }
-
   if (addedTime > 0) {
-    return `Added ${resolveClosestUnit(addedTime)}`;
+    return `Added ${formatDuration(addedTime, false)}`;
   }
 
   if (addedTime < 0) {
-    return `Removed ${resolveClosestUnit(addedTime)}`;
+    return `Removed ${formatDuration(Math.abs(addedTime), false)}`;
   }
 
   return '';

--- a/apps/server/src/config/config.ts
+++ b/apps/server/src/config/config.ts
@@ -1,7 +1,7 @@
 import { MILLIS_PER_MINUTE } from 'ontime-utils';
 
 export const timerConfig = {
-  skipLimit: 1000, // threshold of skip for recalculating
+  skipLimit: 1000, // threshold of skip for recalculating, values lower than updateRate can cause issues with rolling over midnight
   updateRate: 32, // how often do we update the timer
   notificationRate: 1000, // how often do we notify clients and integrations
   triggerAhead: 10, // how far ahead do we trigger the end event

--- a/apps/server/src/services/runtime-service/RuntimeService.ts
+++ b/apps/server/src/services/runtime-service/RuntimeService.ts
@@ -99,10 +99,15 @@ class RuntimeService {
         });
         this.handleLoadNext();
         this.rollLoaded(keepOffset);
-      } else if (skippedOutOfEvent(newState, this.lastIntegrationClockUpdate, timerConfig.skipLimit)) {
+      } else if (
+        // if there is no previous clock, we could not have skipped
+        RuntimeService.previousState?.clock &&
+        skippedOutOfEvent(newState, RuntimeService.previousState.clock, timerConfig.skipLimit)
+      ) {
         // if we have skipped out of the event, we will recall roll
         // to push the playback to the right place
         // this comes with the caveat that we will lose our runtime data
+        logger.warning(LogOrigin.Playback, 'Time skip detected, reloading roll');
         this.roll(true);
       }
     }


### PR DESCRIPTION
it seems that we were passing to the calculation, the time the last integration was fired, rather than the last update
this meant that the skip threshold (1000ms) was potentially higher than the update rate (>1000ms) and could cause issues

This is mostly a patch and maybe not the best fix. However, I couldnt think of a fix here other than guaranteeing that the `skipLimit` must be higher than the clock `updateRate`


Also made a quick change to the time added tooltip to avoid showing like "added 946 seconds"