### PR TITLE
Fix: client path with base uri

### DIFF
--- a/apps/client/src/common/hooks/useClientPath.ts
+++ b/apps/client/src/common/hooks/useClientPath.ts
@@ -12,6 +12,7 @@ export const useClientPath = () => {
 
   // notify of client path changes
   useEffect(() => {
+    // pathname from useLocation dose not contain the base element of the URI
     socketSendJson('set-client-path', pathname + search);
   }, [pathname, search]);
 

--- a/apps/client/src/common/utils/socket.ts
+++ b/apps/client/src/common/utils/socket.ts
@@ -1,6 +1,6 @@
 import { Log, RundownCached, RuntimeStore } from 'ontime-types';
 
-import { isProduction, websocketUrl } from '../../externals';
+import { isProduction, resolveFullPathURI, websocketUrl } from '../../externals';
 import { CLIENT_LIST, CUSTOM_FIELDS, RUNDOWN, RUNTIME } from '../api/constants';
 import { invalidateAllCaches } from '../api/utils';
 import { ontimeQueryClient } from '../queryClient';
@@ -40,7 +40,7 @@ export const connectSocket = () => {
 
     socketSendJson('set-client-type', 'ontime');
 
-    socketSendJson('set-client-path', location.pathname + location.search);
+    socketSendJson('set-client-path', resolveFullPathURI());
   };
 
   websocket.onclose = () => {

--- a/apps/client/src/externals.ts
+++ b/apps/client/src/externals.ts
@@ -73,3 +73,15 @@ function resolveBaseURI(): string {
 
   return base;
 }
+
+/**
+ * Resolves a path URI for a client
+ * ie: https://cloud.getontime.com/client-hash/timer?parm=1
+ *                                             ^^^^^
+ */
+export function resolveFullPathURI(): string {
+  const { pathname, search, hash } = window.location;
+  // in ontime cloud, the base tag is set by the server
+  const base = resolveBaseURI();
+  return pathname.replace(base, '') + search + hash;
+}

--- a/apps/server/src/adapters/WebsocketAdapter.ts
+++ b/apps/server/src/adapters/WebsocketAdapter.ts
@@ -133,8 +133,7 @@ export class SocketServer implements IAdapter {
           if (type === 'set-client-path') {
             if (payload && typeof payload == 'string') {
               const previousData = this.clients.get(clientId);
-              previousData.path = payload;
-              this.clients.set(clientId, previousData);
+              this.clients.set(clientId, { ...previousData, path: payload });
 
               if (payload.includes('editor') && this.isFirstEditor) {
                 this.isFirstEditor = false;


### PR DESCRIPTION
the path name form `useLocation` dose not contain the base part
but I can't find documentation on this. Is it intentional or a bug ?