### PR TITLE
feat(ui): add warning in view params when styles are overriden

### DIFF
--- a/apps/client/src/common/components/view-params-editor/ViewParamsEditor.module.scss
+++ b/apps/client/src/common/components/view-params-editor/ViewParamsEditor.module.scss
@@ -1,11 +1,26 @@
 .drawerFooter {
   display: flex;
-  justify-content: end;
+  flex-direction: column;
   gap: $section-spacing;
+  width: 100%;
 
   button {
     padding: 0 2em;
   }
+}
+
+.buttonsContainer {
+  display: flex;
+  justify-content: end;
+  gap: $section-spacing;
+}
+
+.warningLabel {
+  display: inherit;
+  align-items: center;
+  gap: $element-spacing;
+  font-size: $inner-section-text-size;
+  color: $warning-orange;
 }
 
 .label {

--- a/apps/client/src/common/components/view-params-editor/ViewParamsEditor.module.scss
+++ b/apps/client/src/common/components/view-params-editor/ViewParamsEditor.module.scss
@@ -1,26 +1,28 @@
 .drawerFooter {
   display: flex;
-  flex-direction: column;
+  justify-content: end;  
   gap: $section-spacing;
-  width: 100%;
 
   button {
     padding: 0 2em;
   }
 }
 
-.buttonsContainer {
+.infoLabel {
   display: flex;
-  justify-content: end;
-  gap: $section-spacing;
-}
-
-.warningLabel {
-  display: inherit;
   align-items: center;
   gap: $element-spacing;
+  padding: 1rem;
+  margin-bottom: 1rem;
+
+  background-color: $gray-1100;
+  border-radius: 2px;
   font-size: $inner-section-text-size;
-  color: $warning-orange;
+
+  svg {
+    font-size: 1.5rem;
+    color: $info-blue;
+  }
 }
 
 .label {

--- a/apps/client/src/common/components/view-params-editor/ViewParamsEditor.tsx
+++ b/apps/client/src/common/components/view-params-editor/ViewParamsEditor.tsx
@@ -11,7 +11,7 @@ import {
   DrawerOverlay,
   useDisclosure,
 } from '@chakra-ui/react';
-import { IoWarning } from '@react-icons/all-files/io5/IoWarning';
+import { IoAlertCircle } from '@react-icons/all-files/io5/IoAlertCircle';
 
 import useViewSettings from '../../../common/hooks-query/useViewSettings';
 
@@ -134,6 +134,12 @@ export default function ViewParamsEditor({ viewOptions }: EditFormDrawerProps) {
         </DrawerHeader>
 
         <DrawerBody>
+          {viewSettings.overrideStyles && (
+            <div className={style.infoLabel}>
+              <IoAlertCircle />
+              This view style is being modified by a custom CSS file. <br />
+            </div>
+          )}
           <form id='edit-params-form' onSubmit={onParamsFormSubmit}>
             {viewOptions.map((option) => {
               if (isSection(option)) {
@@ -161,24 +167,13 @@ export default function ViewParamsEditor({ viewOptions }: EditFormDrawerProps) {
           </form>
         </DrawerBody>
 
-        <DrawerFooter>
-          <div className={style.drawerFooter}>
-            {viewSettings.overrideStyles && (
-              <div className={style.warningLabel}>
-                <IoWarning />
-                <span>Custom CSS styles are active. Saving these changes may disrupt your current settings</span>
-              </div>
-            )}
-
-            <div className={style.buttonsContainer}>
-              <Button variant='ontime-ghosted' onClick={resetParams} type='reset'>
-                Reset to default
-              </Button>
-              <Button variant='ontime-filled' form='edit-params-form' type='submit'>
-                Save
-              </Button>
-            </div>
-          </div>
+        <DrawerFooter className={style.drawerFooter}>
+          <Button variant='ontime-ghosted' onClick={resetParams} type='reset'>
+            Reset to default
+          </Button>
+          <Button variant='ontime-filled' form='edit-params-form' type='submit'>
+            Save
+          </Button>
         </DrawerFooter>
       </DrawerContent>
     </Drawer>

--- a/apps/client/src/common/components/view-params-editor/ViewParamsEditor.tsx
+++ b/apps/client/src/common/components/view-params-editor/ViewParamsEditor.tsx
@@ -11,6 +11,9 @@ import {
   DrawerOverlay,
   useDisclosure,
 } from '@chakra-ui/react';
+import { IoWarning } from '@react-icons/all-files/io5/IoWarning';
+
+import useViewSettings from '../../../common/hooks-query/useViewSettings';
 
 import ParamInput from './ParamInput';
 import { isSection, ViewOption } from './types';
@@ -87,6 +90,8 @@ interface EditFormDrawerProps {
 // TODO: this is a good candidate for memoisation, but needs the paramFields to be stable
 export default function ViewParamsEditor({ viewOptions }: EditFormDrawerProps) {
   const [searchParams, setSearchParams] = useSearchParams();
+  const { data: viewSettings } = useViewSettings();
+
   const { isOpen, onClose, onOpen } = useDisclosure();
 
   useEffect(() => {
@@ -156,13 +161,24 @@ export default function ViewParamsEditor({ viewOptions }: EditFormDrawerProps) {
           </form>
         </DrawerBody>
 
-        <DrawerFooter className={style.drawerFooter}>
-          <Button variant='ontime-ghosted' onClick={resetParams} type='reset'>
-            Reset to default
-          </Button>
-          <Button variant='ontime-filled' form='edit-params-form' type='submit'>
-            Save
-          </Button>
+        <DrawerFooter>
+          <div className={style.drawerFooter}>
+            {viewSettings.overrideStyles && (
+              <div className={style.warningLabel}>
+                <IoWarning />
+                <span>Custom CSS styles are active. Saving these changes may disrupt your current settings</span>
+              </div>
+            )}
+
+            <div className={style.buttonsContainer}>
+              <Button variant='ontime-ghosted' onClick={resetParams} type='reset'>
+                Reset to default
+              </Button>
+              <Button variant='ontime-filled' form='edit-params-form' type='submit'>
+                Save
+              </Button>
+            </div>
+          </div>
         </DrawerFooter>
       </DrawerContent>
     </Drawer>

--- a/apps/client/src/theme/_ontimeStyles.scss
+++ b/apps/client/src/theme/_ontimeStyles.scss
@@ -12,6 +12,7 @@ $action-text-color: $blue-400;
 $ontime-color: #ff7597;
 $error-red: $red-500;
 $warning-orange: $orange-500;
+$info-blue: $blue-500;
 $opacity-disabled: 0.4;
 $active-red: $red-700;
 


### PR DESCRIPTION
Users enable their own custom CSS to style the views. Making any changes to views from the settings will potentially clash with their custom CSS settings. This PR adds a warning before saving their settings. 

<img width="626" alt="Screenshot 2024-12-13 at 12 07 00 PM" src="https://github.com/user-attachments/assets/b977e5c0-1cb6-4577-a336-ad116abf02f7" />
