### PR TITLE
Cuesheet times

### DIFF
--- a/apps/client/src/common/components/input/text-input/useReactiveTextInput.tsx
+++ b/apps/client/src/common/components/input/text-input/useReactiveTextInput.tsx
@@ -15,6 +15,7 @@ export default function useReactiveTextInput(
   options?: {
     submitOnEnter?: boolean;
     submitOnCtrlEnter?: boolean;
+    onCancelUpdate?: () => void;
   },
 ): UseReactiveTextInputReturn {
   const [text, setText] = useState<string>(initialText);
@@ -47,7 +48,9 @@ export default function useReactiveTextInput(
   const handleSubmit = useCallback(
     (valueToSubmit: string) => {
       // No need to update if it hasn't changed
-      if (valueToSubmit !== initialText) {
+      if (valueToSubmit === initialText) {
+        options?.onCancelUpdate?.();
+      } else {
         const cleanVal = valueToSubmit.trim();
         submitCallback(cleanVal);
         if (cleanVal !== valueToSubmit) {
@@ -56,7 +59,7 @@ export default function useReactiveTextInput(
       }
       setTimeout(() => ref.current?.blur()); // Immediate timeout to ensure text is set before bluring
     },
-    [initialText, ref, submitCallback],
+    [initialText, options, ref, submitCallback],
   );
 
   /**
@@ -66,8 +69,9 @@ export default function useReactiveTextInput(
   const handleEscape = useCallback(() => {
     // No need to update if it hasn't changed
     setText(initialText);
+    options?.onCancelUpdate?.();
     setTimeout(() => ref.current?.blur()); // Immediate timeout to ensure text is set before bluring
-  }, [initialText, ref]);
+  }, [initialText, options, ref]);
 
   const keyHandler = useMemo(() => {
     const hotKeys: HotkeyItem[] = [['Escape', handleEscape, { preventDefault: true }]];

--- a/apps/client/src/common/components/input/time-input/TimeInput.tsx
+++ b/apps/client/src/common/components/input/time-input/TimeInput.tsx
@@ -55,6 +55,7 @@ export default function TimeInput<T extends string>(props: TimeInputProps<T>) {
       // we dont know the values in the rundown, escalate to handler
       if (newValue.startsWith('p') || newValue.startsWith('+')) {
         submitHandler(name, newValue);
+        return true;
       }
 
       const valueInMillis = parseUserTime(newValue);

--- a/apps/client/src/declarations/declaration.d.ts
+++ b/apps/client/src/declarations/declaration.d.ts
@@ -27,6 +27,7 @@ declare module '@tanstack/react-table' {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   interface TableMeta<TData extends RowData> {
     handleUpdate: (rowIndex: number, accessor: string, payload: string, isCustom: boolean) => void;
+    handleUpdateTimer: (eventId: string, field: TimeField, payload: string) => void;
   }
 }
 

--- a/apps/client/src/declarations/declaration.d.ts
+++ b/apps/client/src/declarations/declaration.d.ts
@@ -6,6 +6,9 @@ declare module '*.scss' {
 type ListenerType = (event: 'string', args: unknown[]) => void;
 
 declare global {
+  /**
+   * Register the electron properties
+   */
   interface Window {
     ipcRenderer: {
       send: (channel: string, args?: string | object) => void;
@@ -17,6 +20,19 @@ declare global {
   }
 }
 
+/**
+ * We pass a custom property to the table meta to allow field update
+ */
+declare module '@tanstack/react-table' {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  interface TableMeta<TData extends RowData> {
+    handleUpdate: (rowIndex: number, accessor: string, payload: string, isCustom: boolean) => void;
+  }
+}
+
+/**
+ * Allow passing CSS Properties
+ */
 declare module 'react' {
   interface CSSProperties {
     [key: `--${string}`]: string | number;

--- a/apps/client/src/features/rundown/time-input-flow/TimeInputFlow.tsx
+++ b/apps/client/src/features/rundown/time-input-flow/TimeInputFlow.tsx
@@ -5,7 +5,7 @@ import { IoLink } from '@react-icons/all-files/io5/IoLink';
 import { IoLockClosed } from '@react-icons/all-files/io5/IoLockClosed';
 import { IoLockOpenOutline } from '@react-icons/all-files/io5/IoLockOpenOutline';
 import { IoUnlink } from '@react-icons/all-files/io5/IoUnlink';
-import { MaybeString, TimeStrategy } from 'ontime-types';
+import { MaybeString, TimeField, TimeStrategy } from 'ontime-types';
 
 import TimeInputWithButton from '../../../common/components/input/time-input/TimeInputWithButton';
 import { useEventAction } from '../../../common/hooks/useEventAction';
@@ -25,14 +25,12 @@ interface EventBlockTimerProps {
   delay: number;
 }
 
-type TimeActions = 'timeStart' | 'timeEnd' | 'duration';
-
 function TimeInputFlow(props: EventBlockTimerProps) {
   const { eventId, isTimeToEnd, timeStart, timeEnd, duration, timeStrategy, linkStart, delay } = props;
   const { updateEvent, updateTimer } = useEventAction();
 
   // In sync with EventEditorTimes
-  const handleSubmit = (field: TimeActions, value: string) => {
+  const handleSubmit = (field: TimeField, value: string) => {
     updateTimer(eventId, field, value);
   };
 
@@ -64,7 +62,7 @@ function TimeInputFlow(props: EventBlockTimerProps) {
 
   return (
     <>
-      <TimeInputWithButton<TimeActions>
+      <TimeInputWithButton<TimeField>
         name='timeStart'
         submitHandler={handleSubmit}
         time={timeStart}
@@ -80,7 +78,7 @@ function TimeInputFlow(props: EventBlockTimerProps) {
         </Tooltip>
       </TimeInputWithButton>
 
-      <TimeInputWithButton<TimeActions>
+      <TimeInputWithButton<TimeField>
         name='timeEnd'
         submitHandler={handleSubmit}
         time={timeEnd}
@@ -100,7 +98,7 @@ function TimeInputFlow(props: EventBlockTimerProps) {
         </Tooltip>
       </TimeInputWithButton>
 
-      <TimeInputWithButton<TimeActions>
+      <TimeInputWithButton<TimeField>
         name='duration'
         submitHandler={handleSubmit}
         time={duration}

--- a/apps/client/src/theme/ontimeTextInputs.ts
+++ b/apps/client/src/theme/ontimeTextInputs.ts
@@ -43,7 +43,7 @@ export const ontimeInputTransparent = {
     ...commonStyles,
     backgroundColor: 'transparent',
     _hover: {
-      backgroundColor: 'rgba(255, 255, 255, 0.10)', // $white-10
+      backgroundColor: '#2d2d2d', // $gray-1100
     },
   },
 };
@@ -56,6 +56,6 @@ export const ontimeTextAreaTransparent = {
   ...commonStyles,
   backgroundColor: 'transparent',
   _hover: {
-    backgroundColor: 'rgba(255, 255, 255, 0.10)', // $white-10
+    backgroundColor: '#2d2d2d', // $gray-1100
   },
 };

--- a/apps/client/src/views/cuesheet/CuesheetPage.tsx
+++ b/apps/client/src/views/cuesheet/CuesheetPage.tsx
@@ -25,7 +25,7 @@ import styles from './CuesheetPage.module.scss';
 
 export default function CuesheetPage() {
   // TODO: can we use the normalised rundown for the table?
-  const { data: flatRundown, status: rundownStatus } = useFlatRundown();
+  const { data: flatRundown } = useFlatRundown();
   const { data: customFields } = useCustomFields();
   const [searchParams, setSearchParams] = useSearchParams();
   const { isOpen: isMenuOpen, onOpen, onClose } = useDisclosure();
@@ -118,7 +118,7 @@ export default function CuesheetPage() {
     [onEventEditorClose, onEventEditorOpen],
   );
 
-  if (!customFields || !flatRundown || rundownStatus !== 'success') {
+  if (!customFields || !flatRundown) {
     return <EmptyPage text='Loading...' />;
   }
 

--- a/apps/client/src/views/cuesheet/CuesheetPage.tsx
+++ b/apps/client/src/views/cuesheet/CuesheetPage.tsx
@@ -3,12 +3,10 @@ import { useSearchParams } from 'react-router-dom';
 import { IconButton, Modal, ModalContent, ModalOverlay, useDisclosure } from '@chakra-ui/react';
 import { IoApps } from '@react-icons/all-files/io5/IoApps';
 import { IoSettingsOutline } from '@react-icons/all-files/io5/IoSettingsOutline';
-import { CustomFieldLabel, isOntimeEvent, OntimeEvent } from 'ontime-types';
 
 import ProductionNavigationMenu from '../../common/components/navigation-menu/ProductionNavigationMenu';
 import EmptyPage from '../../common/components/state/EmptyPage';
 import ViewParamsEditor from '../../common/components/view-params-editor/ViewParamsEditor';
-import { useEventAction } from '../../common/hooks/useEventAction';
 import { useWindowTitle } from '../../common/hooks/useWindowTitle';
 import useCustomFields from '../../common/hooks-query/useCustomFields';
 import { useFlatRundown } from '../../common/hooks-query/useRundown';
@@ -32,7 +30,6 @@ export default function CuesheetPage() {
   const { isOpen: isEventEditorOpen, onOpen: onEventEditorOpen, onClose: onEventEditorClose } = useDisclosure();
   const [eventId, setEventId] = useState<string | null>(null);
 
-  const { updateCustomField, updateEvent } = useEventAction();
   const columns = useMemo(() => makeCuesheetColumns(customFields), [customFields]);
 
   useWindowTitle('Cuesheet');
@@ -42,65 +39,6 @@ export default function CuesheetPage() {
     searchParams.set('edit', 'true');
     setSearchParams(searchParams);
   }, [searchParams, setSearchParams]);
-
-  /**
-   * Handles updating a custom field
-   */
-  const handleUpdateCustom = useCallback(
-    async (rowIndex: number, accessor: CustomFieldLabel, payload: string) => {
-      if (!flatRundown || rundownStatus !== 'success') {
-        return;
-      }
-
-      if (rowIndex == null || accessor == null || payload == null) {
-        return;
-      }
-
-      // check if value is the same
-      const event = flatRundown[rowIndex];
-      if (!event || !isOntimeEvent(event)) {
-        return;
-      }
-
-      // skip if there is no value change
-      const previousValue = event.custom[accessor];
-      if (previousValue === payload) {
-        return;
-      }
-      updateCustomField(event.id, accessor, payload);
-    },
-    [flatRundown, rundownStatus, updateCustomField],
-  );
-
-  /**
-   * Handles updating all other string fields
-   */
-  const handleUpdate = useCallback(
-    async (rowIndex: number, accessor: keyof OntimeEvent, payload: string) => {
-      if (!flatRundown || rundownStatus !== 'success') {
-        return;
-      }
-
-      if (rowIndex == null || accessor == null || payload == null) {
-        return;
-      }
-
-      // check if value is the same
-      const event = flatRundown[rowIndex];
-      if (!event || !isOntimeEvent(event)) {
-        return;
-      }
-
-      // skip if there is no value change
-      const previousValue = event[accessor];
-      if (previousValue === payload) {
-        return;
-      }
-
-      updateEvent({ id: event.id, [accessor]: payload });
-    },
-    [flatRundown, rundownStatus, updateEvent],
-  );
 
   /**
    * Handles setting the edit modal target and visibility
@@ -151,13 +89,7 @@ export default function CuesheetPage() {
         </CuesheetOverview>
         <CuesheetProgress />
         <CuesheetDnd columns={columns}>
-          <CuesheetTable
-            data={flatRundown}
-            columns={columns}
-            handleUpdate={handleUpdate}
-            handleUpdateCustom={handleUpdateCustom}
-            showModal={setShowModal}
-          />
+          <CuesheetTable data={flatRundown} columns={columns} showModal={setShowModal} />
         </CuesheetDnd>
       </div>
     </>

--- a/apps/client/src/views/cuesheet/cuesheet-table/CuesheetTable.module.scss
+++ b/apps/client/src/views/cuesheet/cuesheet-table/CuesheetTable.module.scss
@@ -32,23 +32,19 @@ $table-header-font-size: calc(1rem - 2px);
 
 .tableHeader,
 .eventRow {
+  .actionColumn {
+    width: calc(2rem + 0.5rem); // sm button size (--chakra-sizes-8) + 2 * padding
+    background-color: transparent;
+  }
+
   .indexColumn {
     display: flex;
     align-items: center;
     justify-content: end;
-    
-    min-width: 3em; // allow for 3-digit numbers
-    text-align: right;
-    font-weight: 400;
-    font-size: $table-header-font-size;
-    position: sticky;
-    left: 0;
-    z-index: 1;
-    background-color: $gray-1300; // will be overridden inline
-  }
 
-  .actionColumn {
-    width: calc(2rem + 0.5rem); // sm button size (--chakra-sizes-8) + 2 * padding
+    min-width: 3em; // allow for 3-digit numbers
+    font-size: $table-header-font-size;
+    background-color: $gray-1300; // will be overridden inline
   }
 }
 

--- a/apps/client/src/views/cuesheet/cuesheet-table/CuesheetTable.module.scss
+++ b/apps/client/src/views/cuesheet/cuesheet-table/CuesheetTable.module.scss
@@ -48,7 +48,7 @@ $table-header-font-size: calc(1rem - 2px);
   }
 
   .actionColumn {
-    width: calc(1.5rem + 0.5rem); // sm button size (--chakra-sizes-6) + 2 * padding
+    width: calc(2rem + 0.5rem); // sm button size (--chakra-sizes-8) + 2 * padding
   }
 }
 

--- a/apps/client/src/views/cuesheet/cuesheet-table/CuesheetTable.tsx
+++ b/apps/client/src/views/cuesheet/cuesheet-table/CuesheetTable.tsx
@@ -150,10 +150,10 @@ export default function CuesheetTable(props: CuesheetTableProps) {
                       <td>
                         <MenuButton
                           as={IconButton}
-                          size='xs'
+                          size='sm'
                           aria-label='Options'
                           icon={<IoEllipsisHorizontal />}
-                          variant='ontime-ghosted'
+                          variant='ontime-subtle'
                         />
                       </td>
                       {row.getVisibleCells().map((cell) => {

--- a/apps/client/src/views/cuesheet/cuesheet-table/CuesheetTable.tsx
+++ b/apps/client/src/views/cuesheet/cuesheet-table/CuesheetTable.tsx
@@ -1,6 +1,5 @@
 import { useRef } from 'react';
-import { IconButton, Menu, MenuButton } from '@chakra-ui/react';
-import { IoEllipsisHorizontal } from '@react-icons/all-files/io5/IoEllipsisHorizontal';
+import { Menu } from '@chakra-ui/react';
 import { ColumnDef, flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table';
 import Color from 'color';
 import {
@@ -11,6 +10,7 @@ import {
   OntimeEvent,
   OntimeRundown,
   OntimeRundownEntry,
+  TimeField,
 } from 'ontime-types';
 
 import { useEventAction } from '../../../common/hooks/useEventAction';
@@ -38,7 +38,7 @@ interface CuesheetTableProps {
 export default function CuesheetTable(props: CuesheetTableProps) {
   const { data, columns, showModal } = props;
 
-  const { updateEvent } = useEventAction();
+  const { updateEvent, updateTimer } = useEventAction();
   const { selectedEventId } = useSelectedEventId();
   const { followSelected, hideDelays, hidePast, hideIndexColumn } = useCuesheetOptions();
   const { columnVisibility, columnOrder, columnSizing, resetColumnOrder, setColumnVisibility, setColumnSizing } =
@@ -61,7 +61,7 @@ export default function CuesheetTable(props: CuesheetTableProps) {
     onColumnSizingChange: setColumnSizing,
     getCoreRowModel: getCoreRowModel(),
     meta: {
-      handleUpdate: async (rowIndex: number, accessor: string, payload: string, isCustom = false) => {
+      handleUpdate: (rowIndex: number, accessor: string, payload: string, isCustom = false) => {
         // check if value is the same
         const event = data[rowIndex];
         if (!event || !isOntimeEvent(event)) {
@@ -81,6 +81,10 @@ export default function CuesheetTable(props: CuesheetTableProps) {
         }
 
         updateEvent({ id: event.id, [accessor]: payload });
+      },
+      handleUpdateTimer: (eventId: string, field: TimeField, payload) => {
+        // the timer element already contains logic to avoid submitting a unchanged value
+        updateTimer(eventId, field, payload, true);
       },
     },
   });
@@ -166,15 +170,6 @@ export default function CuesheetTable(props: CuesheetTableProps) {
                       colour={entry.colour}
                       showIndexColumn={!hideIndexColumn}
                     >
-                      <td>
-                        <MenuButton
-                          as={IconButton}
-                          size='sm'
-                          aria-label='Options'
-                          icon={<IoEllipsisHorizontal />}
-                          variant='ontime-subtle'
-                        />
-                      </td>
                       {row.getVisibleCells().map((cell) => {
                         return (
                           <td key={cell.id} style={{ width: cell.column.getSize(), backgroundColor: rowBgColour }}>

--- a/apps/client/src/views/cuesheet/cuesheet-table/CuesheetTable.tsx
+++ b/apps/client/src/views/cuesheet/cuesheet-table/CuesheetTable.tsx
@@ -40,7 +40,7 @@ export default function CuesheetTable(props: CuesheetTableProps) {
 
   const { updateEvent, updateTimer } = useEventAction();
   const { selectedEventId } = useSelectedEventId();
-  const { followSelected, hideDelays, hidePast, hideIndexColumn } = useCuesheetOptions();
+  const { followSelected, hideDelays, hidePast } = useCuesheetOptions();
   const { columnVisibility, columnOrder, columnSizing, resetColumnOrder, setColumnVisibility, setColumnSizing } =
     useColumnManager(columns);
 
@@ -115,7 +115,7 @@ export default function CuesheetTable(props: CuesheetTableProps) {
       />
       <div ref={tableContainerRef} className={style.cuesheetContainer}>
         <table className={style.cuesheet} id='cuesheet'>
-          <CuesheetHeader headerGroups={headerGroups} showIndexColumn={!hideIndexColumn} />
+          <CuesheetHeader headerGroups={headerGroups} />
           <tbody>
             {rowModel.rows.map((row, index) => {
               const key = row.original.id;
@@ -168,7 +168,6 @@ export default function CuesheetTable(props: CuesheetTableProps) {
                       selectedRef={isSelected ? selectedRef : undefined}
                       skip={entry.skip}
                       colour={entry.colour}
-                      showIndexColumn={!hideIndexColumn}
                     >
                       {row.getVisibleCells().map((cell) => {
                         return (

--- a/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/CuesheetHeader.tsx
+++ b/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/CuesheetHeader.tsx
@@ -23,8 +23,8 @@ export default function CuesheetHeader(props: CuesheetHeaderProps) {
 
         return (
           <tr key={headerGroup.id}>
-            <th className={style.indexColumn}>{showIndexColumn && '#'}</th>
             <th className={style.actionColumn} />
+            <th className={style.indexColumn}>{showIndexColumn && '#'}</th>
             <SortableContext key={key} items={headerGroup.headers} strategy={horizontalListSortingStrategy}>
               {headerGroup.headers.map((header) => {
                 const width = header.getSize();

--- a/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/CuesheetHeader.tsx
+++ b/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/CuesheetHeader.tsx
@@ -3,6 +3,7 @@ import { flexRender, HeaderGroup } from '@tanstack/react-table';
 import { OntimeRundownEntry } from 'ontime-types';
 
 import { getAccessibleColour } from '../../../../common/utils/styleUtils';
+import { useCuesheetOptions } from '../../cuesheet.options';
 
 import { SortableCell } from './SortableCell';
 
@@ -10,11 +11,11 @@ import style from '../CuesheetTable.module.scss';
 
 interface CuesheetHeaderProps {
   headerGroups: HeaderGroup<OntimeRundownEntry>[];
-  showIndexColumn: boolean;
 }
 
 export default function CuesheetHeader(props: CuesheetHeaderProps) {
-  const { headerGroups, showIndexColumn } = props;
+  const { headerGroups } = props;
+  const { hideIndexColumn, showActionMenu } = useCuesheetOptions();
 
   return (
     <thead className={style.tableHeader}>
@@ -23,8 +24,8 @@ export default function CuesheetHeader(props: CuesheetHeaderProps) {
 
         return (
           <tr key={headerGroup.id}>
-            <th className={style.actionColumn} />
-            <th className={style.indexColumn}>{showIndexColumn && '#'}</th>
+            {showActionMenu && <th className={style.actionColumn} />}
+            {!hideIndexColumn && <th className={style.indexColumn}>#</th>}
             <SortableContext key={key} items={headerGroup.headers} strategy={horizontalListSortingStrategy}>
               {headerGroup.headers.map((header) => {
                 const width = header.getSize();

--- a/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/EventRow.tsx
+++ b/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/EventRow.tsx
@@ -4,12 +4,12 @@ import { IoEllipsisHorizontal } from '@react-icons/all-files/io5/IoEllipsisHoriz
 import Color from 'color';
 
 import { cx, getAccessibleColour } from '../../../../common/utils/styleUtils';
+import { useCuesheetOptions } from '../../cuesheet.options';
 
 import style from '../CuesheetTable.module.scss';
 
 interface EventRowProps {
   eventIndex: number;
-  showIndexColumn: boolean;
   isPast?: boolean;
   selectedRef?: MutableRefObject<HTMLTableRowElement | null>;
   skip?: boolean;
@@ -17,7 +17,8 @@ interface EventRowProps {
 }
 
 function EventRow(props: PropsWithChildren<EventRowProps>) {
-  const { children, eventIndex, isPast, selectedRef, skip, colour, showIndexColumn } = props;
+  const { children, eventIndex, isPast, selectedRef, skip, colour } = props;
+  const { hideIndexColumn, showActionMenu } = useCuesheetOptions();
   const ownRef = useRef<HTMLTableRowElement>(null);
   const [isVisible, setIsVisible] = useState(false);
 
@@ -57,18 +58,22 @@ function EventRow(props: PropsWithChildren<EventRowProps>) {
       style={{ opacity: `${isPast ? '0.2' : '1'}` }}
       ref={selectedRef ?? ownRef}
     >
-      <td className={style.actionColumn}>
-        <MenuButton
-          as={IconButton}
-          size='sm'
-          aria-label='Options'
-          icon={<IoEllipsisHorizontal />}
-          variant='ontime-subtle'
-        />
-      </td>
-      <td className={style.indexColumn} style={{ backgroundColor, color: mutedText }}>
-        {showIndexColumn && eventIndex}
-      </td>
+      {showActionMenu && (
+        <td className={style.actionColumn}>
+          <MenuButton
+            as={IconButton}
+            size='sm'
+            aria-label='Options'
+            icon={<IoEllipsisHorizontal />}
+            variant='ontime-subtle'
+          />
+        </td>
+      )}
+      {!hideIndexColumn && (
+        <td className={style.indexColumn} style={{ backgroundColor, color: mutedText }}>
+          {eventIndex}
+        </td>
+      )}
       {isVisible ? children : null}
     </tr>
   );

--- a/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/EventRow.tsx
+++ b/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/EventRow.tsx
@@ -1,4 +1,6 @@
 import { memo, MutableRefObject, PropsWithChildren, useLayoutEffect, useRef, useState } from 'react';
+import { IconButton, MenuButton } from '@chakra-ui/react';
+import { IoEllipsisHorizontal } from '@react-icons/all-files/io5/IoEllipsisHorizontal';
 import Color from 'color';
 
 import { cx, getAccessibleColour } from '../../../../common/utils/styleUtils';
@@ -55,6 +57,15 @@ function EventRow(props: PropsWithChildren<EventRowProps>) {
       style={{ opacity: `${isPast ? '0.2' : '1'}` }}
       ref={selectedRef ?? ownRef}
     >
+      <td className={style.actionColumn}>
+        <MenuButton
+          as={IconButton}
+          size='sm'
+          aria-label='Options'
+          icon={<IoEllipsisHorizontal />}
+          variant='ontime-subtle'
+        />
+      </td>
       <td className={style.indexColumn} style={{ backgroundColor, color: mutedText }}>
         {showIndexColumn && eventIndex}
       </td>

--- a/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/MultiLineCell.tsx
+++ b/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/MultiLineCell.tsx
@@ -8,7 +8,9 @@ interface MultiLineCellProps {
   handleUpdate: (newValue: string) => void;
 }
 
-const MultiLineCell = (props: MultiLineCellProps) => {
+export default memo(MultiLineCell);
+
+function MultiLineCell(props: MultiLineCellProps) {
   const { initialValue, handleUpdate } = props;
   const ref = useRef<HTMLInputElement | null>(null);
   const submitCallback = useCallback((newValue: string) => handleUpdate(newValue), [handleUpdate]);
@@ -22,8 +24,12 @@ const MultiLineCell = (props: MultiLineCellProps) => {
       inputref={ref}
       rows={1}
       size='sm'
-      padding={0}
-      fontSize='1rem'
+      style={{
+        minHeight: '2rem',
+        padding: '0',
+        paddingTop: '0.25rem',
+        fontSize: '1rem',
+      }}
       transition='none'
       variant='ontime-transparent'
       value={value}
@@ -33,6 +39,4 @@ const MultiLineCell = (props: MultiLineCellProps) => {
       spellCheck={false}
     />
   );
-};
-
-export default memo(MultiLineCell);
+}

--- a/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/SingleLineCell.tsx
+++ b/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/SingleLineCell.tsx
@@ -8,7 +8,9 @@ interface SingleLineCellProps {
   handleUpdate: (newValue: string) => void;
 }
 
-const SingleLineCell = (props: SingleLineCellProps) => {
+export default memo(SingleLineCell);
+
+function SingleLineCell(props: SingleLineCellProps) {
   const { initialValue, handleUpdate } = props;
   const ref = useRef<HTMLInputElement | null>(null);
   const submitCallback = useCallback((newValue: string) => handleUpdate(newValue), [handleUpdate]);
@@ -20,8 +22,10 @@ const SingleLineCell = (props: SingleLineCellProps) => {
   return (
     <Input
       ref={ref}
-      size='sx'
+      size='sm'
       variant='ontime-transparent'
+      padding={0}
+      fontSize='md'
       value={value}
       onChange={onChange}
       onBlur={onBlur}
@@ -30,6 +34,4 @@ const SingleLineCell = (props: SingleLineCellProps) => {
       autoComplete='off'
     />
   );
-};
-
-export default memo(SingleLineCell);
+}

--- a/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/TextLikeInput.module.scss
+++ b/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/TextLikeInput.module.scss
@@ -1,0 +1,16 @@
+/* element attempts matching input styles */
+.textInput {
+  padding-top: 0.25rem;
+  height: 2rem;
+  background-color: transparent;
+  border-radius: 3px;
+
+  &.muted {
+    color: $label-gray;
+  }
+
+  &:hover {
+    background-color: $gray-1100;
+    cursor: text;
+  }
+}

--- a/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/TextLikeInput.tsx
+++ b/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/TextLikeInput.tsx
@@ -1,0 +1,21 @@
+import { HTMLAttributes, memo, PropsWithChildren } from 'react';
+
+import { cx } from '../../../../common/utils/styleUtils';
+
+import style from './TextLikeInput.module.scss';
+
+export default memo(TextLikeInput);
+
+interface TextLikeInputProps extends HTMLAttributes<HTMLSpanElement> {
+  muted?: boolean;
+}
+
+function TextLikeInput(props: PropsWithChildren<TextLikeInputProps>) {
+  const { muted, children, className, ...elementProps } = props;
+  const classes = cx([style.textInput, muted && style.muted, className]);
+  return (
+    <div className={classes} {...elementProps} tabIndex={0}>
+      {children}
+    </div>
+  );
+}

--- a/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/TimeInputDuration.tsx
+++ b/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/TimeInputDuration.tsx
@@ -1,0 +1,87 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { millisToString, parseUserTime } from 'ontime-utils';
+
+import { formatDuration } from '../../../../common/utils/time';
+
+import SingleLineCell from './SingleLineCell';
+import TextLikeInput from './TextLikeInput';
+
+interface TimeInputDurationProps {
+  initialValue: number;
+  lockedValue: boolean;
+  onSubmit: (value: string) => void;
+}
+
+export default function TimeInputDuration(props: TimeInputDurationProps) {
+  const { initialValue, lockedValue, onSubmit } = props;
+
+  const [isEditing, setIsEditing] = useState(false);
+  const [value, setValue] = useState(initialValue);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // when we go into edit mode, set focus to the input
+  useEffect(() => {
+    if (isEditing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [isEditing]);
+
+  // reset value when initialValue changes, avoiding interrupting the user if we are in edit mode
+  useEffect(() => {
+    if (!isEditing) {
+      setValue(initialValue);
+    }
+  }, [initialValue, isEditing]);
+
+  const handleFakeFocus = () => setIsEditing(true);
+  const handleFakeBlur = () => setIsEditing(false);
+
+  const handleUpdate = useCallback(
+    (newValue: string) => {
+      setIsEditing(false);
+
+      // Check if there is anything there
+      if (newValue === '') {
+        return;
+      }
+
+      // TODO: is this valid in the duration input?
+      // we dont know the values in the rundown, escalate to handler
+      if (newValue.startsWith('p') || newValue.startsWith('+')) {
+        onSubmit(newValue);
+      }
+
+      const valueInMillis = parseUserTime(newValue);
+      if (valueInMillis < 0 || isNaN(valueInMillis)) {
+        setValue(initialValue);
+        return;
+      }
+
+      if (valueInMillis === initialValue) {
+        return;
+      }
+
+      onSubmit(newValue);
+      setValue(Number(newValue));
+    },
+    [initialValue, onSubmit],
+  );
+
+  // duration times have a special format
+  const duration = formatDuration(value, false);
+  const timeString = millisToString(value);
+
+  return isEditing ? (
+    <SingleLineCell
+      ref={inputRef}
+      initialValue={timeString}
+      handleUpdate={handleUpdate}
+      handleCancelUpdate={handleFakeBlur}
+    />
+  ) : (
+    <TextLikeInput onClick={handleFakeFocus} onFocus={handleFakeFocus} muted={!lockedValue}>
+      {duration}
+    </TextLikeInput>
+  );
+}

--- a/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/TimeInputDuration.tsx
+++ b/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/TimeInputDuration.tsx
@@ -50,6 +50,7 @@ export default function TimeInputDuration(props: TimeInputDurationProps) {
       // we dont know the values in the rundown, escalate to handler
       if (newValue.startsWith('p') || newValue.startsWith('+')) {
         onSubmit(newValue);
+        return;
       }
 
       const valueInMillis = parseUserTime(newValue);

--- a/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/cuesheetCols.tsx
+++ b/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/cuesheetCols.tsx
@@ -37,8 +37,7 @@ function MakeDuration({ getValue }: CellContext<OntimeRundownEntry, unknown>) {
 function MakeMultiLineField({ row, column, table }: CellContext<OntimeRundownEntry, unknown>) {
   const update = useCallback(
     (newValue: string) => {
-      // @ts-expect-error -- we inject this into react-table
-      table.options.meta?.handleUpdate(row.index, column.id, newValue);
+      table.options.meta?.handleUpdate(row.index, column.id, newValue, false);
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps -- we skip table.options.meta since the reference seems unstable
     [column.id, row.index],
@@ -57,8 +56,7 @@ function MakeMultiLineField({ row, column, table }: CellContext<OntimeRundownEnt
 function MakeSingleLineField({ row, column, table }: CellContext<OntimeRundownEntry, unknown>) {
   const update = useCallback(
     (newValue: string) => {
-      // @ts-expect-error -- we inject this into react-table
-      table.options.meta?.handleUpdate(row.index, column.id, newValue);
+      table.options.meta?.handleUpdate(row.index, column.id, newValue, false);
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps -- we skip table.options.meta since the reference seems unstable
     [column.id, row.index],
@@ -77,8 +75,7 @@ function MakeSingleLineField({ row, column, table }: CellContext<OntimeRundownEn
 function MakeCustomField({ row, column, table }: CellContext<OntimeRundownEntry, unknown>) {
   const update = useCallback(
     (newValue: string) => {
-      // @ts-expect-error -- we inject this into react-table
-      table.options.meta?.handleUpdateCustom(row.index, column.id, newValue);
+      table.options.meta?.handleUpdate(row.index, column.id, newValue, true);
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps -- we skip table.options.meta since the reference seems unstable
     [column.id, row.index],

--- a/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/cuesheetCols.tsx
+++ b/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/cuesheetCols.tsx
@@ -102,6 +102,7 @@ export function makeCuesheetColumns(customFields: CustomFields): ColumnDef<Ontim
     meta: { colour: customFields[key].colour },
     cell: MakeCustomField,
     size: 250,
+    minSize: 75,
   }));
 
   return [
@@ -111,6 +112,7 @@ export function makeCuesheetColumns(customFields: CustomFields): ColumnDef<Ontim
       header: 'Cue',
       cell: MakeSingleLineField,
       size: 75,
+      minSize: 40,
     },
     {
       accessorKey: 'timeStart',
@@ -118,6 +120,7 @@ export function makeCuesheetColumns(customFields: CustomFields): ColumnDef<Ontim
       header: 'Start',
       cell: MakeTimer,
       size: 75,
+      minSize: 75,
     },
     {
       accessorKey: 'timeEnd',
@@ -125,6 +128,7 @@ export function makeCuesheetColumns(customFields: CustomFields): ColumnDef<Ontim
       header: 'End',
       cell: MakeTimer,
       size: 75,
+      minSize: 75,
     },
     {
       accessorKey: 'duration',
@@ -132,6 +136,7 @@ export function makeCuesheetColumns(customFields: CustomFields): ColumnDef<Ontim
       header: 'Duration',
       cell: MakeDuration,
       size: 75,
+      minSize: 75,
     },
     {
       accessorKey: 'title',
@@ -139,6 +144,7 @@ export function makeCuesheetColumns(customFields: CustomFields): ColumnDef<Ontim
       header: 'Title',
       cell: MakeSingleLineField,
       size: 250,
+      minSize: 75,
     },
     {
       accessorKey: 'note',
@@ -146,6 +152,7 @@ export function makeCuesheetColumns(customFields: CustomFields): ColumnDef<Ontim
       header: 'Note',
       cell: MakeMultiLineField,
       size: 250,
+      minSize: 75,
     },
     ...dynamicCustomFields,
   ];

--- a/apps/client/src/views/cuesheet/cuesheet.options.ts
+++ b/apps/client/src/views/cuesheet/cuesheet.options.ts
@@ -11,6 +11,13 @@ import { isStringBoolean } from '../../features/viewers/common/viewUtils';
 export const cuesheetOptions: ViewOption[] = [
   { section: 'Table options' },
   {
+    id: 'showActionMenu',
+    title: 'Show action menu',
+    description: 'Whether to show the action menu for every row in the table',
+    type: 'boolean',
+    defaultValue: false,
+  },
+  {
     id: 'hideTableSeconds',
     title: 'Hide seconds in table',
     description: 'Whether to hide seconds in the time fields displayed in the table',
@@ -56,6 +63,7 @@ export const cuesheetOptions: ViewOption[] = [
 ];
 
 type CuesheetOptions = {
+  showActionMenu: boolean;
   hideTableSeconds: boolean;
   followSelected: boolean;
   hidePast: boolean;
@@ -71,6 +79,7 @@ type CuesheetOptions = {
 export function getOptionsFromParams(searchParams: URLSearchParams): CuesheetOptions {
   // we manually make an object that matches the key above
   return {
+    showActionMenu: isStringBoolean(searchParams.get('showActionMenu')),
     hideTableSeconds: isStringBoolean(searchParams.get('hideTableSeconds')),
     followSelected: isStringBoolean(searchParams.get('followSelected')),
     hidePast: isStringBoolean(searchParams.get('hidePast')),

--- a/packages/types/src/definitions/core/OntimeEvent.type.ts
+++ b/packages/types/src/definitions/core/OntimeEvent.type.ts
@@ -45,3 +45,4 @@ export type OntimeEvent = OntimeBaseEvent & {
 };
 
 export type PlayableEvent = OntimeEvent & { skip: false };
+export type TimeField = 'timeStart' | 'timeEnd' | 'duration';

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -9,6 +9,7 @@ export {
   type OntimeBlock,
   type OntimeEvent,
   type PlayableEvent,
+  type TimeField,
   SupportedEvent,
 } from './definitions/core/OntimeEvent.type.js';
 export type { OntimeEntryCommonKeys, OntimeRundown, OntimeRundownEntry } from './definitions/core/Rundown.type.js';


### PR DESCRIPTION
This PR allows editing duration in the cuesheet.
Once we are happy with the experience of this element, I will create a second PR that applies the same changes to the start and end times

The new implementation introduces a new Element `TextLikeInput` which handles the switch between a piece of text and an input
This will allow us to have different presentation and input elements and simplify things going forward

Also in the same change, we introduce a new flag to the time update function which allows locking the time strategy on update. This is to make the time input in the cuesheet simpler, without needing to use the lock icons and buttons

it also makes a few tweaks to the styles of the cuesheet
most significant:
- extract action button to visually outside the table (the idea is to be able to hide this later without the cuesheet changing)
- durations are shown in the smallest time unit like "10h2m"
