### PR TITLE
Cuesheet times

### DIFF
--- a/apps/client/src/common/components/delay-indicator/DelayIndicator.tsx
+++ b/apps/client/src/common/components/delay-indicator/DelayIndicator.tsx
@@ -9,32 +9,23 @@ import style from './DelayIndicator.module.scss';
 
 interface DelayIndicatorProps {
   delayValue?: number;
+  tooltipPrefix?: string;
 }
 
 export default function DelayIndicator(props: DelayIndicatorProps) {
-  const { delayValue } = props;
+  const { delayValue, tooltipPrefix } = props;
 
-  if (typeof delayValue === 'number') {
-    if (delayValue < 0) {
-      return (
-        <Tooltip openDelay={tooltipDelayFast} label={millisToDelayString(delayValue)}>
-          <span className={style.delaySymbol}>
-            <IoChevronDown />
-          </span>
-        </Tooltip>
-      );
-    }
-
-    if (delayValue > 0) {
-      return (
-        <Tooltip openDelay={tooltipDelayFast} label={millisToDelayString(delayValue)}>
-          <span className={style.delaySymbol}>
-            <IoChevronUp />
-          </span>
-        </Tooltip>
-      );
-    }
+  if (typeof delayValue !== 'number' || delayValue === 0) {
+    return null;
   }
 
-  return null;
+  const delayString = tooltipPrefix
+    ? `${tooltipPrefix} ${millisToDelayString(delayValue)}`
+    : millisToDelayString(delayValue);
+
+  return (
+    <Tooltip openDelay={tooltipDelayFast} label={delayString}>
+      <span className={style.delaySymbol}>{delayValue < 0 ? <IoChevronDown /> : <IoChevronUp />}</span>
+    </Tooltip>
+  );
 }

--- a/apps/client/src/common/components/input/text-input/useReactiveTextInput.tsx
+++ b/apps/client/src/common/components/input/text-input/useReactiveTextInput.tsx
@@ -16,6 +16,7 @@ export default function useReactiveTextInput(
     submitOnEnter?: boolean;
     submitOnCtrlEnter?: boolean;
     onCancelUpdate?: () => void;
+    allowSubmitSameValue?: boolean;
   },
 ): UseReactiveTextInputReturn {
   const [text, setText] = useState<string>(initialText);
@@ -48,7 +49,7 @@ export default function useReactiveTextInput(
   const handleSubmit = useCallback(
     (valueToSubmit: string) => {
       // No need to update if it hasn't changed
-      if (valueToSubmit === initialText) {
+      if (valueToSubmit === initialText && !options?.allowSubmitSameValue) {
         options?.onCancelUpdate?.();
       } else {
         const cleanVal = valueToSubmit.trim();

--- a/apps/client/src/common/utils/dateConfig.ts
+++ b/apps/client/src/common/utils/dateConfig.ts
@@ -3,8 +3,8 @@ import { formatFromMillis, MILLIS_PER_HOUR, MILLIS_PER_MINUTE } from 'ontime-uti
 
 /**
  * Parses a value in millis to a string which encodes a delay
- * @param millis 
- * @param format 
+ * @param millis
+ * @param format
  */
 export function millisToDelayString(millis: MaybeNumber, format: 'compact' | 'expanded' = 'compact'): string {
   if (millis == null || millis === 0) {

--- a/apps/client/src/declarations/declaration.d.ts
+++ b/apps/client/src/declarations/declaration.d.ts
@@ -28,6 +28,10 @@ declare module '@tanstack/react-table' {
   interface TableMeta<TData extends RowData> {
     handleUpdate: (rowIndex: number, accessor: string, payload: string, isCustom: boolean) => void;
     handleUpdateTimer: (eventId: string, field: TimeField, payload: string) => void;
+    options: {
+      showDelayedTimes: boolean;
+      hideTableSeconds: boolean;
+    };
   }
 }
 

--- a/apps/client/src/views/cuesheet/cuesheet-table/CuesheetTable.module.scss
+++ b/apps/client/src/views/cuesheet/cuesheet-table/CuesheetTable.module.scss
@@ -121,16 +121,6 @@ th {
   margin: 0 auto;
 }
 
-.time {
-  display: flex;
-  gap: 0.5rem;
-  align-items: center;
-
-  > * {
-    @include ellipsis-overflow;
-  }
-}
-
 .delayedTime {
   color: $ontime-delay-text;
   font-size: calc(1rem - 2px);

--- a/apps/client/src/views/cuesheet/cuesheet-table/CuesheetTable.tsx
+++ b/apps/client/src/views/cuesheet/cuesheet-table/CuesheetTable.tsx
@@ -40,7 +40,7 @@ export default function CuesheetTable(props: CuesheetTableProps) {
 
   const { updateEvent, updateTimer } = useEventAction();
   const { selectedEventId } = useSelectedEventId();
-  const { followSelected, hideDelays, hidePast } = useCuesheetOptions();
+  const { followSelected, hideDelays, hidePast, showDelayedTimes, hideTableSeconds } = useCuesheetOptions();
   const { columnVisibility, columnOrder, columnSizing, resetColumnOrder, setColumnVisibility, setColumnSizing } =
     useColumnManager(columns);
 
@@ -85,6 +85,10 @@ export default function CuesheetTable(props: CuesheetTableProps) {
       handleUpdateTimer: (eventId: string, field: TimeField, payload) => {
         // the timer element already contains logic to avoid submitting a unchanged value
         updateTimer(eventId, field, payload, true);
+      },
+      options: {
+        showDelayedTimes,
+        hideTableSeconds,
       },
     },
   });

--- a/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/SingleLineCell.tsx
+++ b/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/SingleLineCell.tsx
@@ -5,16 +5,18 @@ import useReactiveTextInput from '../../../../common/components/input/text-input
 
 interface SingleLineCellProps {
   initialValue: string;
+  allowSubmitSameValue?: boolean;
   handleUpdate: (newValue: string) => void;
   handleCancelUpdate?: () => void;
 }
 
 const SingleLineCell = forwardRef((props: SingleLineCellProps, inputRef) => {
-  const { initialValue, handleUpdate, handleCancelUpdate } = props;
+  const { initialValue, allowSubmitSameValue, handleUpdate, handleCancelUpdate } = props;
   const ref = useRef<HTMLInputElement | null>(null);
   const submitCallback = useCallback((newValue: string) => handleUpdate(newValue), [handleUpdate]);
 
   const { value, onChange, onBlur, onKeyDown } = useReactiveTextInput(initialValue, submitCallback, ref, {
+    allowSubmitSameValue,
     submitOnEnter: true, // single line should submit on enter
     submitOnCtrlEnter: true,
     onCancelUpdate: handleCancelUpdate,

--- a/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/TextLikeInput.module.scss
+++ b/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/TextLikeInput.module.scss
@@ -8,8 +8,13 @@
   align-items: center;
   gap: 0.25rem;
 
+  &.delayed {
+    color: $ontime-delay-text;
+  }
+
   &.muted {
-    color: $muted-gray;
+    // we use opacity instead of colour to handle delayed values
+    opacity: 0.4;
   }
 
   &:hover {

--- a/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/TextLikeInput.module.scss
+++ b/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/TextLikeInput.module.scss
@@ -1,12 +1,15 @@
 /* element attempts matching input styles */
 .textInput {
-  padding-top: 0.25rem;
   height: 2rem;
   background-color: transparent;
   border-radius: 3px;
 
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+
   &.muted {
-    color: $label-gray;
+    color: $muted-gray;
   }
 
   &:hover {

--- a/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/TextLikeInput.tsx
+++ b/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/TextLikeInput.tsx
@@ -7,12 +7,13 @@ import style from './TextLikeInput.module.scss';
 export default memo(TextLikeInput);
 
 interface TextLikeInputProps extends HTMLAttributes<HTMLSpanElement> {
+  delayed?: boolean;
   muted?: boolean;
 }
 
 function TextLikeInput(props: PropsWithChildren<TextLikeInputProps>) {
-  const { muted, children, className, ...elementProps } = props;
-  const classes = cx([style.textInput, muted && style.muted, className]);
+  const { delayed, muted, children, className, ...elementProps } = props;
+  const classes = cx([style.textInput, delayed && style.delayed, muted && style.muted, className]);
   return (
     <div className={classes} {...elementProps} tabIndex={0}>
       {children}

--- a/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/TimeInput.tsx
+++ b/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/TimeInput.tsx
@@ -1,7 +1,5 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { memo, PropsWithChildren, useCallback, useEffect, useRef, useState } from 'react';
 import { millisToString, parseUserTime } from 'ontime-utils';
-
-import { formatDuration } from '../../../../common/utils/time';
 
 import SingleLineCell from './SingleLineCell';
 import TextLikeInput from './TextLikeInput';
@@ -12,8 +10,10 @@ interface TimeInputDurationProps {
   onSubmit: (value: string) => void;
 }
 
-export default function TimeInputDuration(props: TimeInputDurationProps) {
-  const { initialValue, lockedValue, onSubmit } = props;
+export default memo(TimeInputDuration);
+
+function TimeInputDuration(props: PropsWithChildren<TimeInputDurationProps>) {
+  const { initialValue, lockedValue, onSubmit, children } = props;
 
   const [isEditing, setIsEditing] = useState(false);
   const [value, setValue] = useState(initialValue);
@@ -47,7 +47,6 @@ export default function TimeInputDuration(props: TimeInputDurationProps) {
         return;
       }
 
-      // TODO: is this valid in the duration input?
       // we dont know the values in the rundown, escalate to handler
       if (newValue.startsWith('p') || newValue.startsWith('+')) {
         onSubmit(newValue);
@@ -71,8 +70,6 @@ export default function TimeInputDuration(props: TimeInputDurationProps) {
     [initialValue, lockedValue, onSubmit],
   );
 
-  // duration times have a special format
-  const duration = formatDuration(value, false);
   const timeString = millisToString(value);
 
   return isEditing ? (
@@ -85,7 +82,7 @@ export default function TimeInputDuration(props: TimeInputDurationProps) {
     />
   ) : (
     <TextLikeInput onClick={handleFakeFocus} onFocus={handleFakeFocus} muted={!lockedValue}>
-      {duration}
+      {children}
     </TextLikeInput>
   );
 }

--- a/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/TimeInput.tsx
+++ b/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/TimeInput.tsx
@@ -7,13 +7,14 @@ import TextLikeInput from './TextLikeInput';
 interface TimeInputDurationProps {
   initialValue: number;
   lockedValue: boolean;
+  delayed?: boolean;
   onSubmit: (value: string) => void;
 }
 
 export default memo(TimeInputDuration);
 
 function TimeInputDuration(props: PropsWithChildren<TimeInputDurationProps>) {
-  const { initialValue, lockedValue, onSubmit, children } = props;
+  const { initialValue, lockedValue, delayed, onSubmit, children } = props;
 
   const [isEditing, setIsEditing] = useState(false);
   const [value, setValue] = useState(initialValue);
@@ -81,7 +82,7 @@ function TimeInputDuration(props: PropsWithChildren<TimeInputDurationProps>) {
       handleCancelUpdate={handleFakeBlur}
     />
   ) : (
-    <TextLikeInput onClick={handleFakeFocus} onFocus={handleFakeFocus} muted={!lockedValue}>
+    <TextLikeInput onClick={handleFakeFocus} onFocus={handleFakeFocus} muted={!lockedValue} delayed={delayed}>
       {children}
     </TextLikeInput>
   );

--- a/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/TimeInputDuration.tsx
+++ b/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/TimeInputDuration.tsx
@@ -41,8 +41,9 @@ export default function TimeInputDuration(props: TimeInputDurationProps) {
     (newValue: string) => {
       setIsEditing(false);
 
-      // Check if there is anything there
+      // if the user sends an empty string, we want to clear the value
       if (newValue === '') {
+        onSubmit(newValue);
         return;
       }
 
@@ -59,14 +60,15 @@ export default function TimeInputDuration(props: TimeInputDurationProps) {
         return;
       }
 
-      if (valueInMillis === initialValue) {
+      // if the value is the same, we may still want to push the lock change
+      if (valueInMillis === initialValue && lockedValue) {
         return;
       }
 
       onSubmit(newValue);
       setValue(Number(newValue));
     },
-    [initialValue, onSubmit],
+    [initialValue, lockedValue, onSubmit],
   );
 
   // duration times have a special format
@@ -77,6 +79,7 @@ export default function TimeInputDuration(props: TimeInputDurationProps) {
     <SingleLineCell
       ref={inputRef}
       initialValue={timeString}
+      allowSubmitSameValue={!lockedValue} // if the value is not locked, submitting will lock the value
       handleUpdate={handleUpdate}
       handleCancelUpdate={handleFakeBlur}
     />

--- a/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/cuesheetCols.tsx
+++ b/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/cuesheetCols.tsx
@@ -24,15 +24,16 @@ function MakeStart({ getValue, row, table }: CellContext<OntimeRundownEntry, unk
   const isStartLocked = (row.original as OntimeEvent).linkStart === null;
   const delayValue = (row.original as OntimeEvent)?.delay ?? 0;
 
-  let formattedTime = millisToString(startTime);
+  const displayTime = showDelayedTimes ? startTime + delayValue : startTime;
+  let formattedTime = millisToString(displayTime);
   if (hideTableSeconds) {
     formattedTime = removeSeconds(formattedTime);
   }
 
   return (
-    <TimeInput initialValue={startTime} onSubmit={update} lockedValue={isStartLocked}>
+    <TimeInput initialValue={startTime} onSubmit={update} lockedValue={isStartLocked} delayed={delayValue !== 0}>
       {formattedTime}
-      {delayValue !== 0 && showDelayedTimes && <DelayIndicator delayValue={delayValue} />}
+      <DelayIndicator delayValue={delayValue} tooltipPrefix={millisToString(startTime)} />
     </TimeInput>
   );
 }
@@ -43,21 +44,24 @@ function MakeEnd({ getValue, row, table }: CellContext<OntimeRundownEntry, unkno
   }
 
   const { handleUpdateTimer } = table.options.meta;
-  const { hideTableSeconds } = table.options.meta.options;
+  const { showDelayedTimes, hideTableSeconds } = table.options.meta.options;
 
   const update = (newValue: string) => handleUpdateTimer(row.original.id, 'timeEnd', newValue);
 
   const endTime = getValue() as number;
   const isEndLocked = (row.original as OntimeEvent).timeStrategy === TimeStrategy.LockEnd;
+  const delayValue = (row.original as OntimeEvent)?.delay ?? 0;
 
-  let formattedTime = millisToString(endTime);
+  const displayTime = showDelayedTimes ? endTime + delayValue : endTime;
+  let formattedTime = millisToString(displayTime);
   if (hideTableSeconds) {
     formattedTime = removeSeconds(formattedTime);
   }
 
   return (
-    <TimeInput initialValue={endTime} onSubmit={update} lockedValue={isEndLocked}>
+    <TimeInput initialValue={endTime} onSubmit={update} lockedValue={isEndLocked} delayed={delayValue !== 0}>
       {formattedTime}
+      <DelayIndicator delayValue={delayValue} tooltipPrefix={millisToString(endTime)} />
     </TimeInput>
   );
 }


### PR DESCRIPTION
This is a continuation PR that allows the user to edit event start and end times in the `cuesheet`
With this PR the `cuesheet` is fully editable

There is some code duplication, but I think it is best to leave things detached for now

Also includes a few decisions: 
- simplify the timer strategy properties by assuming the user will input the times that are relevant
- show delay indicator only on start time