### PR TITLE
refactor: countToEnd does not cause rundown recalculation

### DIFF
--- a/apps/server/src/services/rundown-service/rundownCacheUtils.ts
+++ b/apps/server/src/services/rundown-service/rundownCacheUtils.ts
@@ -112,6 +112,7 @@ export enum regenerateWhitelist {
   'note',
   'endAction',
   'timerType',
+  'countToEnd',
   'isPublic',
   'colour',
   'timeWarning',


### PR DESCRIPTION
small PR to add `countToEnd` to the whitelist of properties that do not invalidate the rundown
thank you for bringing this up @alex-Arc 