### PR TITLE
tweaks to forms

### DIFF
--- a/apps/client/src/features/app-settings/panel/client-control-panel/ClientList.tsx
+++ b/apps/client/src/features/app-settings/panel/client-control-panel/ClientList.tsx
@@ -74,7 +74,7 @@ export default function ClientList() {
                     )}
                     {name}
                   </td>
-                  {isCurrent ? <td /> : <td className={style.pathList}>{path}</td>}
+                  <td className={style.pathList}>{path}</td>
                   <td className={style.actionButtons}>
                     <Button
                       size='xs'

--- a/apps/client/src/features/app-settings/panel/feature-settings-panel/UrlPresetsForm.tsx
+++ b/apps/client/src/features/app-settings/panel/feature-settings-panel/UrlPresetsForm.tsx
@@ -153,6 +153,10 @@ export default function UrlPresetsForm() {
               {fields.map((preset, index) => {
                 const maybeAliasError = errors.data?.[index]?.alias?.message;
                 const maybeUrlError = errors.data?.[index]?.pathAndParams?.message;
+                // only saved and enabled URLs can be tested
+                const canTest =
+                  preset.alias && preset.enabled && preset.pathAndParams && !maybeAliasError && !maybeUrlError;
+
                 return (
                   <tr key={preset.id}>
                     <td className={style.fit}>
@@ -191,6 +195,7 @@ export default function UrlPresetsForm() {
                     <td className={style.flex}>
                       <TooltipActionBtn
                         size='sm'
+                        isDisabled={!canTest}
                         clickHandler={(event) => handleLinks(event, preset.alias)}
                         tooltip='Test preset'
                         aria-label='Test preset'


### PR DESCRIPTION
the client path column can look broken if there is only one client
the easiest fix is to always show the path so the table does not change

<img width="833" alt="Screenshot 2025-01-05 at 10 39 52" src="https://github.com/user-attachments/assets/dfd93bf1-b3f4-4cf3-8ec9-ef053a883b34" />

Also added a small change to prevent users from testing URL presets which havent been saved (and wont work)