### PR TITLE
Stabilize Runtimestate

### DIFF
--- a/apps/client/src/common/utils/socket.ts
+++ b/apps/client/src/common/utils/socket.ts
@@ -145,7 +145,7 @@ export const connectSocket = () => {
           break;
         }
         case 'ontime-timer': {
-          patchRuntime({ timer: payload, clock });
+          patchRuntimeProperty('timer', payload);
           updateDevTools({ timer: payload, clock });
           break;
         }
@@ -160,8 +160,8 @@ export const connectSocket = () => {
           break;
         }
         case 'ontime-runtime': {
-          patchRuntime({ runtime: payload, clock });
-          updateDevTools({ runtime: payload, clock });
+          patchRuntimeProperty('runtime', payload);
+          updateDevTools({ runtime: payload });
           break;
         }
         case 'ontime-eventNow': {

--- a/apps/client/src/common/utils/socket.ts
+++ b/apps/client/src/common/utils/socket.ts
@@ -65,7 +65,7 @@ export const connectSocket = () => {
     try {
       const data = JSON.parse(event.data);
 
-      const { type, payload } = data;
+      const { type, payload, clock } = data;
 
       if (!type) {
         return;
@@ -145,8 +145,8 @@ export const connectSocket = () => {
           break;
         }
         case 'ontime-timer': {
-          patchRuntimeProperty('timer', payload);
-          updateDevTools({ timer: payload });
+          patchRuntime({ timer: payload, clock });
+          updateDevTools({ timer: payload, clock });
           break;
         }
         case 'ontime-onAir': {
@@ -160,8 +160,8 @@ export const connectSocket = () => {
           break;
         }
         case 'ontime-runtime': {
-          patchRuntimeProperty('runtime', payload);
-          updateDevTools({ runtime: payload });
+          patchRuntime({ runtime: payload, clock });
+          updateDevTools({ runtime: payload, clock });
           break;
         }
         case 'ontime-eventNow': {
@@ -170,8 +170,8 @@ export const connectSocket = () => {
           break;
         }
         case 'ontime-currentBlock': {
-          patchRuntimeProperty('currentBlock', payload);
-          updateDevTools({ currentBlock: payload });
+          patchRuntime({ currentBlock: payload, clock });
+          updateDevTools({ currentBlock: payload, clock });
           break;
         }
         case 'ontime-publicEventNow': {

--- a/apps/server/src/stores/EventStore.ts
+++ b/apps/server/src/stores/EventStore.ts
@@ -21,12 +21,11 @@ export const eventStore = {
   get<T extends keyof RuntimeStore>(key: T) {
     return store[key];
   },
-  set<T extends keyof RuntimeStore>(key: T, value: RuntimeStore[T], clock?: number) {
+  set<T extends keyof RuntimeStore>(key: T, value: RuntimeStore[T]) {
     store[key] = value;
     socket.sendAsJson({
       type: `ontime-${key}`,
       payload: value,
-      clock,
     });
   },
   batchSet(values: Partial<RuntimeStore>) {

--- a/apps/server/src/stores/EventStore.ts
+++ b/apps/server/src/stores/EventStore.ts
@@ -33,7 +33,10 @@ export const eventStore = {
     Object.entries(values).forEach(([key, value]) => {
       store[key] = value;
     });
-    this.broadcast();
+    socket.sendAsJson({
+      type: 'ontime',
+      payload: values,
+    });
   },
   poll() {
     return store;

--- a/apps/server/src/stores/EventStore.ts
+++ b/apps/server/src/stores/EventStore.ts
@@ -21,11 +21,12 @@ export const eventStore = {
   get<T extends keyof RuntimeStore>(key: T) {
     return store[key];
   },
-  set<T extends keyof RuntimeStore>(key: T, value: RuntimeStore[T]) {
+  set<T extends keyof RuntimeStore>(key: T, value: RuntimeStore[T], clock?: number) {
     store[key] = value;
     socket.sendAsJson({
       type: `ontime-${key}`,
       payload: value,
+      clock,
     });
   },
   batchSet(values: Partial<RuntimeStore>) {


### PR DESCRIPTION
The goal here is to stabilize runtimestate so that calculations that combine data from `runtime` or `timer` and `clock` don't have incorrect data in the time between receiving the two datasets. Without affecting the mitigations we tried to put in place for #940

