### PR TITLE
refactor: wider sheet id length

### DIFF
--- a/apps/server/src/api-data/sheets/sheets.validation.ts
+++ b/apps/server/src/api-data/sheets/sheets.validation.ts
@@ -8,7 +8,7 @@ export const validateRequestConnection = [
     .exists()
     .isString()
     .isLength({
-      min: 40,
+      min: 20,
       max: 100,
     })
     .withMessage('Sheet ID is usually 44 characters long'),

--- a/e2e/tests/000-upload-showfile.spec.ts
+++ b/e2e/tests/000-upload-showfile.spec.ts
@@ -61,8 +61,13 @@ test('project file download', async ({ page }) => {
 
   // Wait for the download process to complete and save the downloaded file somewhere.
   await download.saveAs(fileToDownload);
-  await expect(download.failure()).toMatchObject({});
+  expect(download.failure()).toMatchObject({});
+
   const original = JSON.parse(await readFile(fileToUpload, { encoding: 'utf-8' }));
   const fromServer = JSON.parse(await readFile(fileToDownload, { encoding: 'utf-8' }));
-  await expect(original).toEqual(fromServer);
+
+  // when a file is parsed, the server will write the version number to the project file
+  original.settings.version = 'not-important';
+  fromServer.settings.version = 'not-important';
+  expect(original).toMatchObject(fromServer);
 });


### PR DESCRIPTION
users seems to be getting errors with the validation, in the example we got, the sheetId had 33 characters

This PR makes the validation accept ids between 20 and 100 characters