### PR TITLE
feat: add simple auth to server requests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ COPY --from=builder /app/apps/client/build ./client/
 COPY --from=builder /app/apps/server/dist/ ./server/
 COPY --from=builder /app/apps/server/src/external/ ./external/
 COPY --from=builder /app/apps/server/src/user/ ./user/
+COPY --from=builder /app/apps/server/src/html/ ./html/
 
 # Export default ports
 EXPOSE 4001/tcp 8888/udp 9999/udp

--- a/apps/client/src/common/utils/urlPresets.ts
+++ b/apps/client/src/common/utils/urlPresets.ts
@@ -29,6 +29,13 @@ export const validateUrlPresetPath = (preset: string): { message: string; isVali
 };
 
 /**
+ * Utility removes trailing slash from a string
+ */
+function removeTrailingSlash(text: string): string {
+  return text.replace(/\/$/, '');
+}
+
+/**
  * Gets the URL to send a preset to
  * @param location
  * @param data
@@ -38,7 +45,7 @@ export const getRouteFromPreset = (location: Location, data: URLPreset[], search
   const currentURL = location.pathname.substring(1);
 
   // we need to check if the whole url here is an alias, so we can redirect
-  const foundPreset = data.filter((d) => d.alias === currentURL && d.enabled)[0];
+  const foundPreset = data.find((preset) => preset.alias === removeTrailingSlash(currentURL) && preset.enabled);
   if (foundPreset) {
     return generateUrlFromPreset(foundPreset);
   }

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -6,6 +6,8 @@
   "exports": "./src/index.js",
   "dependencies": {
     "@googleapis/sheets": "^5.0.5",
+    "cookie": "^1.0.2",
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^16.0.1",
     "express": "^4.21.1",

--- a/apps/server/src/adapters/WebsocketAdapter.ts
+++ b/apps/server/src/adapters/WebsocketAdapter.ts
@@ -25,6 +25,7 @@ import { eventStore } from '../stores/EventStore.js';
 import { logger } from '../classes/Logger.js';
 import { dispatchFromAdapter } from '../api-integration/integration.controller.js';
 import { generateId } from 'ontime-utils';
+import { authenticateSocket } from '../middleware/authenticate.js';
 
 let instance: SocketServer | null = null;
 
@@ -51,7 +52,12 @@ export class SocketServer implements IAdapter {
     this.shouldShowWelcome = showWelcome;
     this.wss = new WebSocketServer({ path: `${prefix}/ws`, server, maxPayload: this.MAX_PAYLOAD });
 
-    this.wss.on('connection', (ws) => {
+    this.wss.on('connection', (ws, req) => {
+      authenticateSocket(ws, req, (error) => {
+        if (error) {
+          ws.close(1008, 'Unauthorized');
+        }
+      });
       const clientId = generateId();
 
       this.clients.set(clientId, {

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -84,9 +84,9 @@ app.use(cookieParser());
 const { authenticate, authenticateAndRedirect } = makeAuthenticateMiddleware(prefix);
 
 // Implement route endpoints
+app.use(`${prefix}/login`, loginRouter); // router for login flow
 app.use(`${prefix}/data`, authenticate, appRouter); // router for application data
 app.use(`${prefix}/api`, authenticate, integrationRouter); // router for integrations
-app.use(`${prefix}/login`, loginRouter); // router for login flow
 
 // serve static external files
 app.use(`${prefix}/external`, express.static(publicDir.externalDir));

--- a/apps/server/src/externals.ts
+++ b/apps/server/src/externals.ts
@@ -15,6 +15,8 @@ export const environment = isTest ? 'test' : env;
 export const isDocker = env === 'docker';
 export const isProduction = isDocker || (env === 'production' && !isTest);
 export const isOntimeCloud = Boolean(process.env.IS_CLOUD);
+export const password = process.env.SESSION_PASSWORD;
+
 /**
  * Updates the router prefix in the index.html file
  * This is only needed in the cloud environment where the client is not at the root segment

--- a/apps/server/src/html/login.html
+++ b/apps/server/src/html/login.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex" />
+    <meta http-equiv="X-Content-Type-Options" content="nosniff" />
+    <meta name="description" content="Login page for Ontime application" />
+    <title>Ontime Login</title>
+    <style>
+      body,
+      html {
+        font-family: 'Lucida Sans', 'Lucida Sans Regular', 'Lucida Grande', 'Lucida Sans Unicode', Geneva, Verdana,
+          sans-serif;
+        background: #101010;
+        text-align: center;
+        box-sizing: border-box;
+      }
+
+      h1 {
+        padding-top: 30vh;
+        font-size: 3rem;
+        color: #ff7597;
+        font-weight: 400;
+      }
+
+      input {
+        all: unset;
+        text-align: start;
+        padding-left: 0.5rem;
+        background-color: #fffffa;
+        color: black;
+
+        height: 2rem;
+        border-radius: 2px;
+        margin-right: 0.5rem;
+      }
+      input:focus {
+        outline: 2px solid #779be7;
+        outline-offset: 2px;
+        color: #262626;
+      }
+
+      button {
+        all: unset;
+        color: #779be7;
+        background: #2d2d2d;
+        height: 2rem;
+        padding-inline: 2rem;
+        border-radius: 2px;
+        cursor: pointer;
+      }
+      button:hover {
+        background: #404040;
+      }
+      button:focus {
+        outline: 2px solid #779be7;
+        outline-offset: 2px;
+      }
+    </style>
+  </head>
+
+  <body>
+    <form method="post" class="form" autocomplete="off">
+      <h1>Welcome to Ontime</h1>
+      <input type="hidden" name="redirect" value="" id="redirect" />
+      <input type="password" name="password" placeholder="Password" required autocomplete="current-password" />
+      <button type="submit">Login</button>
+    </form>
+  </body>
+  <script>
+    const params = new URLSearchParams(window.location.search);
+    const redirect = params.get('redirect');
+    if (redirect) {
+      // Validate redirect URL to prevent open redirect attacks
+      const isValidRedirect = redirect.startsWith('/') && !redirect.startsWith('//');
+      if (isValidRedirect) {
+        document.getElementById('redirect').value = redirect;
+      }
+    }
+  </script>
+</html>

--- a/apps/server/src/middleware/authenticate.ts
+++ b/apps/server/src/middleware/authenticate.ts
@@ -1,0 +1,141 @@
+import { LogOrigin } from 'ontime-types';
+
+import express, { type Request, type Response, type NextFunction } from 'express';
+import type { IncomingMessage } from 'node:http';
+import type { WebSocket } from 'ws';
+import { parse as parseCookie } from 'cookie';
+
+import { hashPassword } from '../utils/hash.js';
+import { srcFiles } from '../setup/index.js';
+import { logger } from '../classes/Logger.js';
+// import { password } from '../externals.js';
+const password = 'test';
+import { noopMiddleware } from './noop.js';
+
+export const hasPassword = Boolean(password);
+const hashedPassword = hasPassword ? hashPassword(password) : '';
+
+/**
+ * List of public assets that can be accessed without authentication
+ * should match the files in client/public
+ */
+const publicAssets = ['/favicon.ico', '/manifest.json', '/ontime-logo.png', '/robots.txt', '/site.webmanifest'];
+
+export const loginRouter = express.Router();
+
+// serve static files at root
+loginRouter.use('/', express.static(srcFiles.login));
+
+// verify password and set cookies + redirect appropriately
+loginRouter.post('/', (req, res) => {
+  res.clearCookie('token');
+  const { password: reqPassword, redirect } = req.body;
+
+  if (!hasPassword) {
+    res.redirect(redirect || '/');
+    return;
+  }
+
+  if (!reqPassword) {
+    res.status(401).send('Unauthorized');
+    return;
+  }
+
+  if (hashPassword(reqPassword) === hashedPassword) {
+    res.cookie('token', hashedPassword, {
+      httpOnly: false, // allow websocket to access cookie
+      secure: true,
+      path: '/', // allow cookie to be accessed from any path
+      sameSite: 'strict',
+    });
+    res.redirect(redirect || '/');
+    return;
+  }
+
+  res.status(401).send('Unauthorized');
+});
+
+/**
+ * Express middleware to authenticate requests
+ * @param {string} prefix - Prefix is used for the client hashes in Ontime Cloud
+ */
+export function makeAuthenticateMiddleware(prefix: string) {
+  // we dont need to initialise the authenticate middleware if there is no password
+  if (!hasPassword) {
+    return { authenticate: noopMiddleware, authenticateAndRedirect: noopMiddleware };
+  }
+
+  function authenticate(req: Request, res: Response, next: NextFunction) {
+    const token = req.query.token || req.cookies?.token;
+    if (token && token === hashedPassword) {
+      return next();
+    }
+
+    res.status(401).send('Unauthorized');
+  }
+
+  function authenticateAndRedirect(req: Request, res: Response, next: NextFunction) {
+    // Allow access to specific public assets without authentication
+    if (publicAssets.includes(req.originalUrl)) {
+      return next();
+    }
+
+    if (req.originalUrl.startsWith('/login')) {
+      // cannot authenticate the login route
+      return next();
+    }
+
+    // we expect the token to be in the cookies
+    if (req.cookies?.token === hashedPassword) {
+      return next();
+    }
+
+    // we use query params for generating authenticated URLs and for clients like the companion module
+    // if the user gives is a token in the query params, we set the cookie to be used in further requests
+    if (req.query.token === hashedPassword) {
+      res.cookie('token', hashedPassword, {
+        httpOnly: false, // allow websocket to access cookie
+        secure: true,
+        path: '/', // allow cookie to be accessed from any path
+        sameSite: 'strict',
+      });
+      return next();
+    }
+
+    const redirect = req.originalUrl.startsWith('/login')
+      ? `${prefix}/login`
+      : `${prefix}/login?redirect=${req.originalUrl}`;
+
+    res.redirect(redirect);
+  }
+
+  return { authenticate, authenticateAndRedirect };
+}
+
+/**
+ * Middleware to authenticate a WebSocket connection with a token in the cookie
+ */
+export function authenticateSocket(_ws: WebSocket, req: IncomingMessage, next: (error?: Error) => void) {
+  if (!hasPassword) {
+    return next();
+  }
+
+  // check if the token is in the cookie
+  const cookieString = req.headers.cookie;
+  if (typeof cookieString === 'string') {
+    const cookies = parseCookie(cookieString);
+    if (cookies.token === hashedPassword) {
+      return next();
+    }
+  }
+
+  // check if token is in the params
+  const url = new URL(req.url || '', `http://${req.headers.host}`);
+  const token = url.searchParams.get('token');
+  if (token === hashedPassword) {
+    return next();
+  }
+
+  logger.warning(LogOrigin.Client, 'Unauthorized WebSocket connection attempt');
+  return next(new Error('Unauthorized'));
+}

--- a/apps/server/src/middleware/authenticate.ts
+++ b/apps/server/src/middleware/authenticate.ts
@@ -8,8 +8,7 @@ import { parse as parseCookie } from 'cookie';
 import { hashPassword } from '../utils/hash.js';
 import { srcFiles } from '../setup/index.js';
 import { logger } from '../classes/Logger.js';
-// import { password } from '../externals.js';
-const password = 'test';
+import { password } from '../externals.js';
 import { noopMiddleware } from './noop.js';
 
 export const hasPassword = Boolean(password);
@@ -19,7 +18,13 @@ const hashedPassword = hasPassword ? hashPassword(password) : '';
  * List of public assets that can be accessed without authentication
  * should match the files in client/public
  */
-const publicAssets = ['/favicon.ico', '/manifest.json', '/ontime-logo.png', '/robots.txt', '/site.webmanifest'];
+const publicAssets = new Set([
+  '/favicon.ico',
+  '/manifest.json',
+  '/ontime-logo.png',
+  '/robots.txt',
+  '/site.webmanifest',
+]);
 
 export const loginRouter = express.Router();
 
@@ -31,23 +36,8 @@ loginRouter.post('/', (req, res) => {
   res.clearCookie('token');
   const { password: reqPassword, redirect } = req.body;
 
-  if (!hasPassword) {
-    res.redirect(redirect || '/');
-    return;
-  }
-
-  if (!reqPassword) {
-    res.status(401).send('Unauthorized');
-    return;
-  }
-
   if (hashPassword(reqPassword) === hashedPassword) {
-    res.cookie('token', hashedPassword, {
-      httpOnly: false, // allow websocket to access cookie
-      secure: true,
-      path: '/', // allow cookie to be accessed from any path
-      sameSite: 'strict',
-    });
+    setSessionCookie(res, hashedPassword);
     res.redirect(redirect || '/');
     return;
   }
@@ -76,12 +66,12 @@ export function makeAuthenticateMiddleware(prefix: string) {
 
   function authenticateAndRedirect(req: Request, res: Response, next: NextFunction) {
     // Allow access to specific public assets without authentication
-    if (publicAssets.includes(req.originalUrl)) {
+    if (publicAssets.has(req.originalUrl)) {
       return next();
     }
 
+    // we shouldnt be here in the login route
     if (req.originalUrl.startsWith('/login')) {
-      // cannot authenticate the login route
       return next();
     }
 
@@ -93,20 +83,11 @@ export function makeAuthenticateMiddleware(prefix: string) {
     // we use query params for generating authenticated URLs and for clients like the companion module
     // if the user gives is a token in the query params, we set the cookie to be used in further requests
     if (req.query.token === hashedPassword) {
-      res.cookie('token', hashedPassword, {
-        httpOnly: false, // allow websocket to access cookie
-        secure: true,
-        path: '/', // allow cookie to be accessed from any path
-        sameSite: 'strict',
-      });
+      setSessionCookie(res, hashedPassword);
       return next();
     }
 
-    const redirect = req.originalUrl.startsWith('/login')
-      ? `${prefix}/login`
-      : `${prefix}/login?redirect=${req.originalUrl}`;
-
-    res.redirect(redirect);
+    res.redirect(`${prefix}/login?redirect=${req.originalUrl}`);
   }
 
   return { authenticate, authenticateAndRedirect };
@@ -138,4 +119,13 @@ export function authenticateSocket(_ws: WebSocket, req: IncomingMessage, next: (
 
   logger.warning(LogOrigin.Client, 'Unauthorized WebSocket connection attempt');
   return next(new Error('Unauthorized'));
+}
+
+function setSessionCookie(res: Response, token: string) {
+  res.cookie('token', token, {
+    httpOnly: false, // allow websocket to access cookie
+    secure: true,
+    path: '/', // allow cookie to be accessed from any path
+    sameSite: 'strict',
+  });
 }

--- a/apps/server/src/middleware/noop.ts
+++ b/apps/server/src/middleware/noop.ts
@@ -1,0 +1,5 @@
+import type { Request, Response, NextFunction } from 'express';
+
+export function noopMiddleware(_req: Request, _res: Response, next: NextFunction) {
+  next();
+}

--- a/apps/server/src/setup/index.ts
+++ b/apps/server/src/setup/index.ts
@@ -87,6 +87,8 @@ export const srcFiles = {
   userReadme: join(srcDir.root, config.user, 'README.md'),
   /** Path to bundled CSS readme */
   cssReadme: join(srcDir.root, config.user, config.styles.directory, 'README.md'),
+  /** Path to login */
+  login: join(srcDir.root, 'html/login.html'),
 };
 
 /**

--- a/apps/server/src/utils/hash.ts
+++ b/apps/server/src/utils/hash.ts
@@ -1,0 +1,9 @@
+import { createHash } from 'node:crypto';
+
+/**
+ * Creates a hash of the password that is URL safe
+ * @link https://stackoverflow.com/questions/17639645/websafe-encoding-of-hashed-string-in-nodejs
+ */
+export function hashPassword(password: string) {
+  return createHash('sha256').update(password).digest('base64url');
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -288,6 +288,12 @@ importers:
       '@googleapis/sheets':
         specifier: ^5.0.5
         version: 5.0.5
+      cookie:
+        specifier: ^1.0.2
+        version: 1.0.2
+      cookie-parser:
+        specifier: ^1.4.7
+        version: 1.4.7
       cors:
         specifier: ^2.8.5
         version: 2.8.5
@@ -2717,12 +2723,24 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie-parser@1.4.7:
+    resolution: {integrity: sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==}
+    engines: {node: '>= 0.8.0'}
+
   cookie-signature@1.0.6:
     resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
 
   cookie@0.7.1:
     resolution: {integrity: sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==}
     engines: {node: '>= 0.6'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cookie@1.0.2:
+    resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
+    engines: {node: '>=18'}
 
   copy-to-clipboard@3.3.3:
     resolution: {integrity: sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==}
@@ -7799,9 +7817,18 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cookie-parser@1.4.7:
+    dependencies:
+      cookie: 0.7.2
+      cookie-signature: 1.0.6
+
   cookie-signature@1.0.6: {}
 
   cookie@0.7.1: {}
+
+  cookie@0.7.2: {}
+
+  cookie@1.0.2: {}
 
   copy-to-clipboard@3.3.3:
     dependencies:


### PR DESCRIPTION
This is a proposal for protecting the HTTP connections with a password

Strategy
- requests go through authentication middleware
- if the password is active and the user has not provided a password in the cookie or params
- a) for the client assets, we serve a login page instead
- b) for the data endpoints, we refuse the request
- when the user sets the correct password in the login form, we set the cookie that will be with all requests

Notes:
- had to do some cheating to allow the client to access public files, which are requested before the connection is made
- need to test the token in query params solution, do we want UI to generate this? or pass the password in the websocket request? The token in query params will be important for generating an authenticated URL and for the companion module


Whis is a viable solution for ontime-cloud, but not for Ontime