### PR TITLE
fix: update time in block

### DIFF
--- a/apps/server/src/stores/__tests__/runtimeState.test.ts
+++ b/apps/server/src/stores/__tests__/runtimeState.test.ts
@@ -340,7 +340,7 @@ describe('roll mode', () => {
   });
 });
 
-describe.only('loadBlock', () => {
+describe('loadBlock', () => {
   test('from no-block to a block will clear startedAt', () => {
     const rundown = [
       { id: '0', type: SupportedEvent.Event },

--- a/apps/server/src/stores/runtimeState.ts
+++ b/apps/server/src/stores/runtimeState.ts
@@ -664,6 +664,11 @@ export function roll(rundown: OntimeRundown, offset = 0): { eventId: MaybeString
 
   // there is something to run, load event
 
+  // update runtime
+  if (runtimeState.currentBlock.startedAt === null) {
+    runtimeState.currentBlock.startedAt = runtimeState.clock;
+  }
+
   // event will finish on time
   // account for event that finishes the day after
   const endTime =
@@ -696,13 +701,13 @@ function loadBlock(rundown: OntimeRundown) {
 
   const newCurrentBlock = getPreviousBlock(rundown, runtimeState.eventNow.id);
 
-  // test all block change posibiletys
-  const formNoBlockToBlock = runtimeState.currentBlock.block === null && newCurrentBlock !== null;
-  const formBlockToNoBlock = runtimeState.currentBlock.block !== null && newCurrentBlock === null;
-  const formBlockToNewBlock = runtimeState.currentBlock.block?.id !== newCurrentBlock?.id;
+  // test all block change possibilities
+  const loadedBlock = runtimeState.currentBlock.block === null && newCurrentBlock !== null;
+  const unloadedBlock = runtimeState.currentBlock.block !== null && newCurrentBlock === null;
+  const changedBlock = runtimeState.currentBlock.block?.id !== newCurrentBlock?.id;
 
   // update time only if the block has changed
-  if (formNoBlockToBlock || formBlockToNoBlock || formBlockToNewBlock) {
+  if (loadedBlock || unloadedBlock || changedBlock) {
     runtimeState.currentBlock.startedAt = null;
   }
 

--- a/apps/server/src/stores/runtimeState.ts
+++ b/apps/server/src/stores/runtimeState.ts
@@ -705,13 +705,8 @@ export function loadBlock(rundown: OntimeRundown, state = runtimeState) {
 
   const newCurrentBlock = getPreviousBlock(rundown, state.eventNow.id);
 
-  // test all block change possibilities
-  const loadedBlock = state.currentBlock.block === null && newCurrentBlock !== null;
-  const unloadedBlock = state.currentBlock.block !== null && newCurrentBlock === null;
-  const changedBlock = state.currentBlock.block?.id !== newCurrentBlock?.id;
-
   // update time only if the block has changed
-  if (loadedBlock || unloadedBlock || changedBlock) {
+  if (state.currentBlock.block?.id !== newCurrentBlock?.id) {
     state.currentBlock.startedAt = null;
   }
 

--- a/apps/server/src/stores/runtimeState.ts
+++ b/apps/server/src/stores/runtimeState.ts
@@ -691,26 +691,30 @@ export function roll(rundown: OntimeRundown, offset = 0): { eventId: MaybeString
   return { eventId: runtimeState.eventNow.id, didStart: true };
 }
 
-function loadBlock(rundown: OntimeRundown) {
-  if (runtimeState.eventNow === null) {
+/**
+ * handle block loading, not for use outside of runtimeState
+ * @param rundown
+ */
+export function loadBlock(rundown: OntimeRundown, state = runtimeState) {
+  if (state.eventNow === null) {
     // we need a loaded event to have a block
-    runtimeState.currentBlock.block = null;
-    runtimeState.currentBlock.startedAt = null;
+    state.currentBlock.block = null;
+    state.currentBlock.startedAt = null;
     return;
   }
 
-  const newCurrentBlock = getPreviousBlock(rundown, runtimeState.eventNow.id);
+  const newCurrentBlock = getPreviousBlock(rundown, state.eventNow.id);
 
   // test all block change possibilities
-  const loadedBlock = runtimeState.currentBlock.block === null && newCurrentBlock !== null;
-  const unloadedBlock = runtimeState.currentBlock.block !== null && newCurrentBlock === null;
-  const changedBlock = runtimeState.currentBlock.block?.id !== newCurrentBlock?.id;
+  const loadedBlock = state.currentBlock.block === null && newCurrentBlock !== null;
+  const unloadedBlock = state.currentBlock.block !== null && newCurrentBlock === null;
+  const changedBlock = state.currentBlock.block?.id !== newCurrentBlock?.id;
 
   // update time only if the block has changed
   if (loadedBlock || unloadedBlock || changedBlock) {
-    runtimeState.currentBlock.startedAt = null;
+    state.currentBlock.startedAt = null;
   }
 
   // update the block anyway
-  runtimeState.currentBlock.block = newCurrentBlock === null ? null : { ...newCurrentBlock };
+  state.currentBlock.block = newCurrentBlock === null ? null : { ...newCurrentBlock };
 }


### PR DESCRIPTION
I was looking into an issue where roll mode would not set the time in block

It seems to me that our existing logic is incorrect, and that we wanted to be setting the time when our conditions matched (blocked changed)

@alex-Arc , can you please sanity check this?
I may have missed something