### PR TITLE
refactor: handle overflow in menulist

### DIFF
--- a/apps/client/src/common/components/view-params-editor/ParamInput.tsx
+++ b/apps/client/src/common/components/view-params-editor/ParamInput.tsx
@@ -119,7 +119,7 @@ function MultiOption(props: EditFormMultiOptionProps) {
         <MenuButton as={Button} variant='ontime-subtle-white' position='relative' width='fit-content' fontWeight={400}>
           {paramField.title} <IoChevronDown style={{ display: 'inline' }} />
         </MenuButton>
-        <MenuList>
+        <MenuList overflow='auto' maxHeight='200px'>
           <MenuOptionGroup
             type='checkbox'
             value={paramState}

--- a/apps/client/src/features/app-settings/panel-utils/PanelUtils.module.scss
+++ b/apps/client/src/features/app-settings/panel-utils/PanelUtils.module.scss
@@ -38,7 +38,7 @@ $inner-padding: 1rem;
 .section {
   position: relative;
   margin-top: 2rem;
-  max-width: 800px;
+  max-width: 850px;
 }
 
 .indent {

--- a/apps/client/src/features/app-settings/panel/automations-panel/AutomationForm.tsx
+++ b/apps/client/src/features/app-settings/panel/automations-panel/AutomationForm.tsx
@@ -251,7 +251,7 @@ export default function AutomationForm(props: AutomationFormProps) {
                   {...register(`filters.${index}.value`)}
                   variant='ontime-filled'
                   size='sm'
-                  placeholder='<no value>'
+                  placeholder='<empty / no value>'
                   autoComplete='off'
                 />
               </label>


### PR DESCRIPTION
Fixes issue with not being able to scroll the menulist if there are many elements
<img width="425" alt="Screenshot 2025-02-02 at 21 06 32" src="https://github.com/user-attachments/assets/1282b39f-bdd2-4d69-9acf-256a21b4aaf3" />
