### PR TITLE
Improve cuesheet performance

### DIFF
--- a/apps/client/src/common/components/buttons/IconButton.module.scss
+++ b/apps/client/src/common/components/buttons/IconButton.module.scss
@@ -1,0 +1,26 @@
+.subtle {
+  aspect-ratio: 1;
+  height: 2rem;
+  height: 2rem;
+  display: grid;
+  place-content: center;
+
+  background: $gray-1050;
+  color: $blue-400;
+  border: 1px solid transparent;
+  border-radius: 3px;
+
+  &:hover:not(:disabled):not(:active) {
+    background: $gray-1000;
+    color: $blue-500;
+  }
+
+  &:active {
+    background: $gray-1100;
+    border-color: $gray-1250;
+  }
+
+  &:disabled {
+    background: $gray-1050;
+  }
+}

--- a/apps/client/src/common/components/buttons/IconButton.tsx
+++ b/apps/client/src/common/components/buttons/IconButton.tsx
@@ -1,0 +1,14 @@
+import { ButtonHTMLAttributes } from 'react';
+
+import { cx } from '../../utils/styleUtils';
+
+import style from './IconButton.module.scss';
+
+export default function IconButton(props: ButtonHTMLAttributes<HTMLButtonElement>) {
+  const { className, children, ...buttonProps } = props;
+  return (
+    <button className={cx([style.subtle, className])} {...buttonProps}>
+      {children}
+    </button>
+  );
+}

--- a/apps/client/src/views/cuesheet/cuesheet-table/CuesheetTable.tsx
+++ b/apps/client/src/views/cuesheet/cuesheet-table/CuesheetTable.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useRef } from 'react';
-import { ColumnDef, flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table';
+import { ColumnDef, getCoreRowModel, useReactTable } from '@tanstack/react-table';
 import Color from 'color';
 import {
   isOntimeBlock,
@@ -165,7 +165,8 @@ export default function CuesheetTable(props: CuesheetTableProps) {
 
                 return (
                   <EventRow
-                    key={key}
+                    key={row.id}
+                    rowId={row.id}
                     eventId={entry.id}
                     eventIndex={eventIndex}
                     rowIndex={index}
@@ -173,15 +174,10 @@ export default function CuesheetTable(props: CuesheetTableProps) {
                     selectedRef={isSelected ? selectedRef : undefined}
                     skip={entry.skip}
                     colour={entry.colour}
-                  >
-                    {row.getVisibleCells().map((cell) => {
-                      return (
-                        <td key={cell.id} style={{ width: cell.column.getSize(), backgroundColor: rowBgColour }}>
-                          {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                        </td>
-                      );
-                    })}
-                  </EventRow>
+                    rowBgColour={rowBgColour}
+                    table={table}
+                    columnSizing={columnSizing}
+                  />
                 );
               }
 

--- a/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/EventRow.tsx
+++ b/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/EventRow.tsx
@@ -1,10 +1,10 @@
 import { memo, MutableRefObject, useLayoutEffect, useRef, useState } from 'react';
-import { IconButton } from '@chakra-ui/react';
 import { IoEllipsisHorizontal } from '@react-icons/all-files/io5/IoEllipsisHorizontal';
 import { flexRender, Table } from '@tanstack/react-table';
 import Color from 'color';
 import { OntimeRundownEntry } from 'ontime-types';
 
+import IconButton from '../../../../common/components/buttons/IconButton';
 import { cx, getAccessibleColour } from '../../../../common/utils/styleUtils';
 import { useCuesheetOptions } from '../../cuesheet.options';
 import { useCuesheetTableMenu } from '../cuesheet-table-menu/useCuesheetTableMenu';
@@ -75,16 +75,15 @@ function EventRow(props: EventRowProps) {
       {showActionMenu && (
         <td className={style.actionColumn}>
           <IconButton
-            size='sm'
             aria-label='Options'
-            icon={<IoEllipsisHorizontal />}
-            variant='ontime-subtle'
             onClick={(event) => {
               const rect = event.currentTarget.getBoundingClientRect();
               const yPos = 8 + rect.y + rect.height / 2;
               openMenu({ x: rect.x, y: yPos }, eventId, rowIndex);
             }}
-          />
+          >
+            <IoEllipsisHorizontal />
+          </IconButton>
         </td>
       )}
       {!hideIndexColumn && (

--- a/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/EventRow.tsx
+++ b/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/EventRow.tsx
@@ -34,7 +34,7 @@ function EventRow(props: EventRowProps) {
   const ownRef = useRef<HTMLTableRowElement>(null);
   const [isVisible, setIsVisible] = useState(false);
 
-  const { openMenu } = useCuesheetTableMenu();
+  const openMenu = useCuesheetTableMenu((store) => store.openMenu);
 
   useLayoutEffect(() => {
     const observer = new IntersectionObserver(


### PR DESCRIPTION
Before we continue adding features into the cuesheet, we needed to gain some performance budget

This code changes the mostly the row composition and replaces the chakra button with a native button
The initial render is about 2x faster while sequential updates are like 8x faster
