### PR TITLE
feat: custom data for projects

### DIFF
--- a/apps/client/src/common/models/ProjectData.ts
+++ b/apps/client/src/common/models/ProjectData.ts
@@ -8,4 +8,5 @@ export const projectDataPlaceholder: ProjectData = {
   backstageUrl: '',
   backstageInfo: '',
   projectLogo: null,
+  custom: [],
 };

--- a/apps/client/src/features/app-settings/panel/project-panel/ProjectCreateForm.tsx
+++ b/apps/client/src/features/app-settings/panel/project-panel/ProjectCreateForm.tsx
@@ -11,6 +11,7 @@ import { documentationUrl, websiteUrl } from '../../../../externals';
 import * as Panel from '../../panel-utils/PanelUtils';
 
 import style from './ProjectPanel.module.scss';
+import { IoTrash } from 'react-icons/io5';
 
 interface ProjectCreateFromProps {
   onClose: () => void;
@@ -171,7 +172,8 @@ export default function ProjectCreateForm(props: ProjectCreateFromProps) {
             </Button>
           </Panel.ListItem>
           {fields.map((field, idx) => (
-            <Panel.InlineElements key={field.id}>
+            <div key={field.id} className={style.customDataItem}>
+              <Panel.Paragraph>{idx + 1}.</Panel.Paragraph>
               <label>
                 Title
                 <Input
@@ -192,10 +194,10 @@ export default function ProjectCreateForm(props: ProjectCreateFromProps) {
                   {...register(`custom.${idx}.value` as const)}
                 />
               </label>
-              <Button variant='ontime-ghost' onClick={() => remove(idx)}>
-                X
+              <Button variant='ontime-ghosted' onClick={() => remove(idx)}>
+                <IoTrash />
               </Button>
-            </Panel.InlineElements>
+            </div>
           ))}
         </Panel.Section>
       </Panel.Section>

--- a/apps/client/src/features/app-settings/panel/project-panel/ProjectCreateForm.tsx
+++ b/apps/client/src/features/app-settings/panel/project-panel/ProjectCreateForm.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useFieldArray, useForm } from 'react-hook-form';
+import { IoTrash } from 'react-icons/io5';
 import { Button, Input, Textarea } from '@chakra-ui/react';
 import { useQueryClient } from '@tanstack/react-query';
 
@@ -11,7 +12,6 @@ import { documentationUrl, websiteUrl } from '../../../../externals';
 import * as Panel from '../../panel-utils/PanelUtils';
 
 import style from './ProjectPanel.module.scss';
-import { IoTrash } from 'react-icons/io5';
 
 interface ProjectCreateFromProps {
   onClose: () => void;

--- a/apps/client/src/features/app-settings/panel/project-panel/ProjectData.tsx
+++ b/apps/client/src/features/app-settings/panel/project-panel/ProjectData.tsx
@@ -1,5 +1,5 @@
-import { ChangeEvent, useEffect, useRef } from 'react';
-import { useForm } from 'react-hook-form';
+import { ChangeEvent, Fragment, useEffect, useRef } from 'react';
+import { useFieldArray, useForm } from 'react-hook-form';
 import { IoDownloadOutline, IoTrash } from 'react-icons/io5';
 import { Button, Input, Textarea } from '@chakra-ui/react';
 import { type ProjectData } from 'ontime-types';
@@ -25,6 +25,7 @@ export default function ProjectData() {
     formState: { isSubmitting, isValid, isDirty, errors },
     setError,
     watch,
+    control,
     setValue,
   } = useForm({
     defaultValues: data,
@@ -32,6 +33,11 @@ export default function ProjectData() {
     resetOptions: {
       keepDirtyValues: true,
     },
+  });
+
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: 'custom',
   });
 
   // reset form values if data changes
@@ -75,6 +81,10 @@ export default function ProjectData() {
     setValue('projectLogo', null, {
       shouldDirty: true,
     });
+  };
+
+  const handleAddCustom = () => {
+    append({ title: '', value: '' });
   };
 
   const onSubmit = async (formData: ProjectData) => {
@@ -231,6 +241,42 @@ export default function ProjectData() {
               {...register('backstageUrl')}
             />
           </label>
+          <Panel.ListItem>
+            <Panel.Field title='Custom data' description='' />
+            <Button variant='ontime-subtle' onClick={handleAddCustom}>
+              +
+            </Button>
+          </Panel.ListItem>
+          {fields.length === 0 && <p>Project has no metadata currently</p>}
+          {fields.length > 0 &&
+            fields.map((field, idx) => (
+              <Panel.InlineElements key={field.id}>
+                <Panel.Paragraph>{idx + 1}.</Panel.Paragraph>
+                <label>
+                  Title
+                  <Input
+                    variant='ontime-filled'
+                    size='sm'
+                    placeholder={field.title}
+                    autoComplete='off'
+                    {...register(`custom.${idx}.title`)}
+                  />
+                </label>
+                <label>
+                  Value
+                  <Input
+                    variant='ontime-filled'
+                    size='sm'
+                    placeholder={field.value}
+                    autoComplete='off'
+                    {...register(`custom.${idx}.value`)}
+                  />
+                </label>
+                <Button variant='ontime-ghosted' onClick={() => remove(idx)}>
+                  X
+                </Button>
+              </Panel.InlineElements>
+            ))}
         </Panel.Section>
       </Panel.Card>
     </Panel.Section>

--- a/apps/client/src/features/app-settings/panel/project-panel/ProjectData.tsx
+++ b/apps/client/src/features/app-settings/panel/project-panel/ProjectData.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, Fragment, useEffect, useRef } from 'react';
+import { ChangeEvent, useEffect, useRef } from 'react';
 import { useFieldArray, useForm } from 'react-hook-form';
 import { IoDownloadOutline, IoTrash } from 'react-icons/io5';
 import { Button, Input, Textarea } from '@chakra-ui/react';
@@ -241,42 +241,44 @@ export default function ProjectData() {
               {...register('backstageUrl')}
             />
           </label>
-          <Panel.ListItem>
-            <Panel.Field title='Custom data' description='' />
-            <Button variant='ontime-subtle' onClick={handleAddCustom}>
-              +
-            </Button>
-          </Panel.ListItem>
-          {fields.length === 0 && <p>Project has no metadata currently</p>}
-          {fields.length > 0 &&
-            fields.map((field, idx) => (
-              <Panel.InlineElements key={field.id}>
-                <Panel.Paragraph>{idx + 1}.</Panel.Paragraph>
-                <label>
-                  Title
-                  <Input
-                    variant='ontime-filled'
-                    size='sm'
-                    placeholder={field.title}
-                    autoComplete='off'
-                    {...register(`custom.${idx}.title`)}
-                  />
-                </label>
-                <label>
-                  Value
-                  <Input
-                    variant='ontime-filled'
-                    size='sm'
-                    placeholder={field.value}
-                    autoComplete='off'
-                    {...register(`custom.${idx}.value`)}
-                  />
-                </label>
-                <Button variant='ontime-ghosted' onClick={() => remove(idx)}>
-                  X
-                </Button>
-              </Panel.InlineElements>
-            ))}
+          <Panel.Section style={{ marginTop: 0 }}>
+            <Panel.ListItem>
+              <Panel.Field title='Custom data' description='' />
+              <Button variant='ontime-subtle' onClick={handleAddCustom}>
+                +
+              </Button>
+            </Panel.ListItem>
+            {fields.length === 0 && !isDirty && <p>Project has no metadata currently</p>}
+            {fields.length > 0 &&
+              fields.map((field, idx) => (
+                <div key={field.id} className={style.customDataItem}>
+                  <Panel.Paragraph>{idx + 1}.</Panel.Paragraph>
+                  <label>
+                    Title
+                    <Input
+                      variant='ontime-filled'
+                      size='sm'
+                      value={field.title}
+                      autoComplete='off'
+                      {...register(`custom.${idx}.title`)}
+                    />
+                  </label>
+                  <label>
+                    Value
+                    <Input
+                      variant='ontime-filled'
+                      size='sm'
+                      value={field.value}
+                      autoComplete='off'
+                      {...register(`custom.${idx}.value`)}
+                    />
+                  </label>
+                  <Button variant='ontime-ghosted' onClick={() => remove(idx)}>
+                    <IoTrash />
+                  </Button>
+                </div>
+              ))}
+          </Panel.Section>
         </Panel.Section>
       </Panel.Card>
     </Panel.Section>

--- a/apps/client/src/features/app-settings/panel/project-panel/ProjectData.tsx
+++ b/apps/client/src/features/app-settings/panel/project-panel/ProjectData.tsx
@@ -258,7 +258,7 @@ export default function ProjectData() {
                     <Input
                       variant='ontime-filled'
                       size='sm'
-                      value={field.title}
+                      defaultValue={field.title}
                       autoComplete='off'
                       {...register(`custom.${idx}.title`)}
                     />
@@ -268,7 +268,7 @@ export default function ProjectData() {
                     <Input
                       variant='ontime-filled'
                       size='sm'
-                      value={field.value}
+                      defaultValue={field.value}
                       autoComplete='off'
                       {...register(`custom.${idx}.value`)}
                     />

--- a/apps/client/src/features/app-settings/panel/project-panel/ProjectPanel.module.scss
+++ b/apps/client/src/features/app-settings/panel/project-panel/ProjectPanel.module.scss
@@ -57,3 +57,11 @@
     height: auto;
   }
 }
+
+.customDataItem {
+  display: grid;
+  grid-template-columns: auto 1fr 1fr auto;
+  gap: 1rem;
+  align-items: end;
+  justify-content: center;
+}

--- a/apps/client/src/translation/languages/de.ts
+++ b/apps/client/src/translation/languages/de.ts
@@ -30,4 +30,5 @@ export const langDe: TranslationObject = {
   'project.backstage_url': 'Backstage-URL',
   'project.public_info': 'Öffentliche Informationen',
   'project.public_url': 'Öffentliche URL',
+  'project.custom': 'Benutzerdefinierte Daten',
 };

--- a/apps/client/src/translation/languages/en.ts
+++ b/apps/client/src/translation/languages/en.ts
@@ -28,6 +28,7 @@ export const langEn = {
   'project.backstage_url': 'Backstage URL',
   'project.public_info': 'Public Info',
   'project.public_url': 'Public URL',
+  'project.custom': 'Custom Data',
 };
 
 export type TranslationObject = Record<keyof typeof langEn, string>;

--- a/apps/client/src/translation/languages/es.ts
+++ b/apps/client/src/translation/languages/es.ts
@@ -30,4 +30,5 @@ export const langEs: TranslationObject = {
   'project.backstage_url': 'URL de backstage',
   'project.public_info': 'Información pública',
   'project.public_url': 'URL pública',
+  'project.custom': 'Datos personalizados',
 };

--- a/apps/client/src/translation/languages/fr.ts
+++ b/apps/client/src/translation/languages/fr.ts
@@ -30,4 +30,5 @@ export const langFr: TranslationObject = {
   'project.backstage_url': 'URL des coulisses',
   'project.public_info': 'Informations publiques',
   'project.public_url': 'URL publique',
+  'project.custom': 'Données personnalisées',
 };

--- a/apps/client/src/translation/languages/hu.ts
+++ b/apps/client/src/translation/languages/hu.ts
@@ -30,4 +30,5 @@ export const langHu: TranslationObject = {
   'project.backstage_url': 'Kulisszák mögötti URL',
   'project.public_info': 'Nyilvános információ',
   'project.public_url': 'Nyilvános URL',
+  'project.custom': 'Egyéni adatok',
 };

--- a/apps/client/src/translation/languages/it.ts
+++ b/apps/client/src/translation/languages/it.ts
@@ -30,4 +30,5 @@ export const langIt: TranslationObject = {
   'project.backstage_url': 'URL di backstage',
   'project.public_info': 'Informazioni pubbliche',
   'project.public_url': 'URL pubblico',
+  'project.custom': 'Dati personalizzati',
 };

--- a/apps/client/src/translation/languages/no.ts
+++ b/apps/client/src/translation/languages/no.ts
@@ -30,4 +30,5 @@ export const langNo: TranslationObject = {
   'project.backstage_url': 'Backstage-URL',
   'project.public_info': 'Offentlig informasjon',
   'project.public_url': 'Offentlig URL',
+  'project.custom': 'Egendefinerte data',
 };

--- a/apps/client/src/translation/languages/pl.ts
+++ b/apps/client/src/translation/languages/pl.ts
@@ -30,4 +30,5 @@ export const langPl: TranslationObject = {
   'project.backstage_url': 'URL zaplecza',
   'project.public_info': 'Informacje publiczne',
   'project.public_url': 'URL publiczny',
+  'project.custom': 'Dane niestandardowe',
 };

--- a/apps/client/src/translation/languages/pt.ts
+++ b/apps/client/src/translation/languages/pt.ts
@@ -30,4 +30,5 @@ export const langPt: TranslationObject = {
   'project.backstage_url': 'URL de bastidores',
   'project.public_info': 'Informações públicas',
   'project.public_url': 'URL pública',
+  'project.custom': 'Dados personalizados',
 };

--- a/apps/client/src/translation/languages/sv.ts
+++ b/apps/client/src/translation/languages/sv.ts
@@ -30,4 +30,5 @@ export const langSv: TranslationObject = {
   'project.backstage_url': 'Backstage-URL',
   'project.public_info': 'Offentlig information',
   'project.public_url': 'Offentlig URL',
+  'project.custom': 'Anpassade data',
 };

--- a/apps/client/src/translation/languages/zh.ts
+++ b/apps/client/src/translation/languages/zh.ts
@@ -30,4 +30,5 @@ export const langZhCn: TranslationObject = {
   'project.backstage_url': '后台网址',
   'project.public_info': '公开信息',
   'project.public_url': '公开网址',
+  'project.custom': '自定义数据',
 };

--- a/apps/client/src/views/project-info/ProjectInfo.scss
+++ b/apps/client/src/views/project-info/ProjectInfo.scss
@@ -42,6 +42,12 @@
       color: $ontime-color;
     }
   }
+
+  .custom_data {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+  }
 }
 
 /* =================== MOBILE ===================*/

--- a/apps/client/src/views/project-info/ProjectInfo.tsx
+++ b/apps/client/src/views/project-info/ProjectInfo.tsx
@@ -8,11 +8,11 @@ import { useWindowTitle } from '../../common/hooks/useWindowTitle';
 import { useTranslation } from '../../translation/TranslationProvider';
 
 import BackstageInfo from './backstage-info/BackstageInfo';
-import PublicInfo from './public-info/PublicInfo';
 import CustomInfo from './custom-info/CustomInfo';
+import PublicInfo from './public-info/PublicInfo';
+import { projectInfoOptions } from './projectInfo.options';
 
 import './ProjectInfo.scss';
-import { projectInfoOptions } from './projectInfo.options';
 
 interface ProjectInfoProps {
   general: ProjectData;

--- a/apps/client/src/views/project-info/ProjectInfo.tsx
+++ b/apps/client/src/views/project-info/ProjectInfo.tsx
@@ -9,9 +9,10 @@ import { useTranslation } from '../../translation/TranslationProvider';
 
 import BackstageInfo from './backstage-info/BackstageInfo';
 import PublicInfo from './public-info/PublicInfo';
-import { projectInfoOptions } from './projectInfo.options';
+import CustomInfo from './custom-info/CustomInfo';
 
 import './ProjectInfo.scss';
+import { projectInfoOptions } from './projectInfo.options';
 
 interface ProjectInfoProps {
   general: ProjectData;
@@ -66,6 +67,7 @@ export default function ProjectInfo(props: ProjectInfoProps) {
         )}
         <BackstageInfo general={general} />
         <PublicInfo general={general} />
+        <CustomInfo general={general} />
       </div>
     </div>
   );

--- a/apps/client/src/views/project-info/custom-info/CustomInfo.tsx
+++ b/apps/client/src/views/project-info/custom-info/CustomInfo.tsx
@@ -1,0 +1,38 @@
+import { ProjectData } from 'ontime-types';
+import { useSearchParams } from 'react-router-dom';
+
+import { isStringBoolean } from '../../../features/viewers/common/viewUtils';
+import { useTranslation } from '../../../translation/TranslationProvider';
+
+interface CustomInfoProps {
+  general: ProjectData;
+}
+
+export default function CustomInfo(props: CustomInfoProps) {
+  const { general } = props;
+  const [searchParams] = useSearchParams();
+  const { getLocalizedString } = useTranslation();
+
+  const showCustom = isStringBoolean(searchParams.get('showCustom'));
+
+  if (!showCustom) {
+    return null;
+  }
+
+  return (
+    <>
+      {general.custom && general.custom.length > 0 && (
+        <>
+          <div className='info__label'>{getLocalizedString('project.custom')}</div>
+          {general.custom &&
+            general.custom.map((info) => (
+              <div className='custom_data'>
+                <p>{info.title}:</p>
+                <p>{info.value}</p>
+              </div>
+            ))}
+        </>
+      )}
+    </>
+  );
+}

--- a/apps/client/src/views/project-info/custom-info/CustomInfo.tsx
+++ b/apps/client/src/views/project-info/custom-info/CustomInfo.tsx
@@ -1,5 +1,5 @@
-import { ProjectData } from 'ontime-types';
 import { useSearchParams } from 'react-router-dom';
+import { ProjectData } from 'ontime-types';
 
 import { isStringBoolean } from '../../../features/viewers/common/viewUtils';
 import { useTranslation } from '../../../translation/TranslationProvider';
@@ -25,8 +25,8 @@ export default function CustomInfo(props: CustomInfoProps) {
         <>
           <div className='info__label'>{getLocalizedString('project.custom')}</div>
           {general.custom &&
-            general.custom.map((info) => (
-              <div className='custom_data'>
+            general.custom.map((info, idx) => (
+              <div className='custom_data' key={idx}>
                 <p>{info.title}:</p>
                 <p>{info.value}</p>
               </div>

--- a/apps/client/src/views/project-info/projectInfo.options.ts
+++ b/apps/client/src/views/project-info/projectInfo.options.ts
@@ -20,6 +20,13 @@ export const projectInfoOptions: ViewOption[] = [
         type: 'boolean',
         defaultValue: false,
       },
+      {
+        id: 'showCustom',
+        title: 'Show Custom Data',
+        description: 'Weather to show fields related to the custom data',
+        type: 'boolean',
+        defaultValue: false,
+      },
     ],
   },
 ];

--- a/apps/server/src/api-data/db/db.controller.ts
+++ b/apps/server/src/api-data/db/db.controller.ts
@@ -58,6 +58,7 @@ export async function createProjectFile(req: Request, res: Response<{ filename: 
         backstageUrl: req.body?.backstageUrl ?? '',
         backstageInfo: req.body?.backstageInfo ?? '',
         projectLogo: req.body?.projectLogo ?? null,
+        custom: req.body?.custom ?? [],
       },
     });
 

--- a/apps/server/src/api-data/db/db.validation.ts
+++ b/apps/server/src/api-data/db/db.validation.ts
@@ -16,6 +16,7 @@ export const validateNewProject = [
   body('backstageInfo').optional().isString().trim(),
   body('projectLogo').optional().isString().trim(),
   body('endMessage').optional().isString().trim(),
+  body('custom').optional().isArray(),
 
   (req: Request, res: Response, next: NextFunction) => {
     const errors = validationResult(req);

--- a/apps/server/src/api-data/project/project.controller.ts
+++ b/apps/server/src/api-data/project/project.controller.ts
@@ -27,6 +27,7 @@ export async function postProjectData(req: Request, res: Response<ProjectData | 
       backstageInfo: req.body?.backstageInfo,
       endMessage: req.body?.endMessage,
       projectLogo: req.body?.projectLogo,
+      custom: req.body?.custom,
     });
 
     const updatedData = await editCurrentProjectData(newData);

--- a/apps/server/src/api-data/project/project.validation.ts
+++ b/apps/server/src/api-data/project/project.validation.ts
@@ -10,6 +10,7 @@ export const projectSanitiser = [
   body('backstageInfo').optional().isString().trim(),
   body('endMessage').optional().isString().trim(),
   body('projectLogo').optional({ nullable: true }).isString().trim(),
+  body('custom').optional().isArray(),
 
   (req: Request, res: Response, next: NextFunction) => {
     const errors = validationResult(req);

--- a/packages/types/src/definitions/core/ProjectData.type.ts
+++ b/packages/types/src/definitions/core/ProjectData.type.ts
@@ -6,4 +6,5 @@ export type ProjectData = {
   backstageUrl: string;
   backstageInfo: string;
   projectLogo: string | null;
+  custom: { title: string; value: string }[];
 };


### PR DESCRIPTION
Hey, opening a PR for adding custom data on projects. Here's a summary of changes done:

- added custom field's type on `ProjectData.type.ts`
- added custom field under translations
- refactored controllers and validation on server to account for the custom data
- added form fields for custom data (used `useFieldArray` from react-hook-form)
- added css for custom data under `ProjectPanel.,module.scss` and `ProjectInfo.scss`
- added `showCustom` field under `projectInfo.options.ts` to be able to view custom data from the view params settings

Note: Was going back and forth between calling this as custom data or meta data for the project

Attaching a video to show the working:

https://github.com/user-attachments/assets/5186f9f6-304d-4ea1-9366-035d4b6c27bc

Let me know if there's any changes required