### PR TITLE
bump version to 3.15.0

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@getontime/cli",
-    "version": "3.14.5",
+    "version": "3.15.0",
     "author": "Carlos Valente",
     "description": "Time keeping for live events",
     "repository": "https://github.com/cpvalente/ontime",

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ontime-ui",
-  "version": "3.14.5",
+  "version": "3.15.0",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ontime-electron",
-  "version": "3.14.5",
+  "version": "3.15.0",
   "author": "Carlos Valente",
   "description": "Time keeping for live events",
   "repository": "https://github.com/cpvalente/ontime",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -2,7 +2,7 @@
   "name": "ontime-server",
   "type": "module",
   "main": "src/index.ts",
-  "version": "3.14.5",
+  "version": "3.15.0",
   "exports": "./src/index.js",
   "dependencies": {
     "@googleapis/sheets": "^5.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ontime",
-  "version": "3.14.5",
+  "version": "3.15.0",
   "description": "Time keeping for live events",
   "keywords": [
     "ontime",


### PR DESCRIPTION
Release notes:

This release introduces two major features to Ontime
- Relative offset mode: allows modifying the offset calculations depending on whether the rundown start time is significant
- Event automation: allows adding automations at the event level

There are also some smaller features and fixes worth noting:
- Allow editing CSS override in the settings
- Improve usability of lower thirds with addition of separate in, out and hold timings 
- fix issue with studio clock timer size
- fix issue with delays disappearing when editing an event