### PR TITLE
Fix project renumber

### DIFF
--- a/apps/server/src/services/project-service/ProjectService.ts
+++ b/apps/server/src/services/project-service/ProjectService.ts
@@ -80,6 +80,7 @@ export async function getCurrentProject(): Promise<{ filename: string; pathToFil
 
 /**
  * Private function loads a project file and handles necessary side effects
+ * @param projectData
  * @param fileName file name of the project including the extension
  */
 async function loadProject(projectData: DatabaseModel, fileName: string) {
@@ -125,8 +126,8 @@ async function loadNewProject(): Promise<string> {
 /**
  * Private function handles side effects on corrupted files
  * Corrupted files in this context contain data that failed domain validation
- * @param filePath file name of the project including the extension
- * @param filename file name of the project including the extension
+ * @param filePath path to the project type include the fileName and extension
+ * @param fileName as extracted from filePath, includes extension
  */
 async function handleCorruptedFile(filePath: string, fileName: string): Promise<string> {
   // copy file to corrupted folder
@@ -258,6 +259,7 @@ export async function renameProjectFile(originalFile: string, newFilename: strin
 /**
  * Creates a new project file and applies its result
  * @param fileName file name of the project including the extension
+ * @param initialData db to initialize the project with
  */
 export async function createProject(fileName: string, initialData: Partial<DatabaseModel>): Promise<string> {
   const data = safeMerge(dbModel, initialData);

--- a/apps/server/src/services/project-service/ProjectService.ts
+++ b/apps/server/src/services/project-service/ProjectService.ts
@@ -80,7 +80,7 @@ export async function getCurrentProject(): Promise<{ filename: string; pathToFil
 
 /**
  * Private function loads a project file and handles necessary side effects
- * @param fileName file name of the project including the extention
+ * @param fileName file name of the project including the extension
  */
 async function loadProject(projectData: DatabaseModel, fileName: string) {
   // change LowDB to point to new file
@@ -125,8 +125,8 @@ async function loadNewProject(): Promise<string> {
 /**
  * Private function handles side effects on corrupted files
  * Corrupted files in this context contain data that failed domain validation
- * @param filePath file name of the project including the extention
- * @param filename file name of the project including the extention
+ * @param filePath file name of the project including the extension
+ * @param filename file name of the project including the extension
  */
 async function handleCorruptedFile(filePath: string, fileName: string): Promise<string> {
   // copy file to corrupted folder
@@ -173,7 +173,7 @@ export async function initialiseProject(): Promise<string> {
 
 /**
  * Loads a data from a file into the runtime
- * @param fileName file name of the project including the extention
+ * @param fileName file name of the project including the extension
  */
 export async function loadProjectFile(fileName: string): Promise<string> {
   const filePath = doesProjectExist(fileName);
@@ -257,7 +257,7 @@ export async function renameProjectFile(originalFile: string, newFilename: strin
 
 /**
  * Creates a new project file and applies its result
- * @param fileName file name of the project including the extention
+ * @param fileName file name of the project including the extension
  */
 export async function createProject(fileName: string, initialData: Partial<DatabaseModel>): Promise<string> {
   const data = safeMerge(dbModel, initialData);

--- a/apps/server/src/services/project-service/ProjectService.ts
+++ b/apps/server/src/services/project-service/ProjectService.ts
@@ -96,16 +96,15 @@ async function loadProject(projectData: DatabaseModel, fileName: string) {
   await initRundown(firstRundown, projectData.customFields);
 
   // persist the project selection
-  const newName = getFileNameFromPath(fileName);
   await setLastLoadedProject(fileName);
 
   // update the service state
   currentProjectState = {
     status: 'INITIALIZED',
-    currentProjectName: newName,
+    currentProjectName: fileName,
   };
 
-  return newName;
+  return fileName;
 }
 
 /**

--- a/apps/server/src/utils/__tests__/fileManagement.test.ts
+++ b/apps/server/src/utils/__tests__/fileManagement.test.ts
@@ -105,11 +105,11 @@ describe('file index', () => {
     expect(incrementProjectNumber('test file (1).json')).toBe('test file (2).json');
   });
 
-  it('dose not count number not warped in parenthesise', () => {
+  it('does not count number not wrapped in parenthesis', () => {
     expect(incrementProjectNumber('test file 1.json')).toBe('test file 1 (1).json');
   });
 
-  it('dose not count number if there is not a space', () => {
+  it('does not count number if there is not a space', () => {
     expect(incrementProjectNumber('test file(1).json')).toBe('test file(1) (1).json');
   });
 

--- a/apps/server/src/utils/__tests__/fileManagement.test.ts
+++ b/apps/server/src/utils/__tests__/fileManagement.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, Mock } from 'vitest';
 import * as fs from 'fs';
 
-import { appendToName, ensureJsonExtension, generateUniqueFileName } from '../fileManagement.js';
+import { appendToName, ensureJsonExtension, generateUniqueFileName, getProjectNumber } from '../fileManagement.js';
 
 // Mock fs.existsSync to control the test environment
 vi.mock('fs', () => ({
@@ -88,5 +88,27 @@ describe('generateUniqueFileName', () => {
     const expectedFilename = `${baseName} (2)${extension}`;
     const uniqueFilename = generateUniqueFileName(directory, filename);
     expect(uniqueFilename).toBe(expectedFilename);
+  });
+});
+
+describe('file index', () => {
+  it('returns 0 when there is no index', () => {
+    expect(getProjectNumber('test file')).toBe(0);
+  });
+
+  it('returns 1 when index is 1', () => {
+    expect(getProjectNumber('test file (1)')).toBe(1);
+  });
+
+  it('dont count number not warpd in parentecies', () => {
+    expect(getProjectNumber('test file 1')).toBe(0);
+  });
+
+  it('dont count number if there is not a space', () => {
+    expect(getProjectNumber('test file(1)')).toBe(0);
+  });
+
+  it('counts multi digit numbers', () => {
+    expect(getProjectNumber('test file (890)')).toBe(890);
   });
 });

--- a/apps/server/src/utils/__tests__/fileManagement.test.ts
+++ b/apps/server/src/utils/__tests__/fileManagement.test.ts
@@ -100,11 +100,11 @@ describe('file index', () => {
     expect(getProjectNumber('test file (1)')).toBe(1);
   });
 
-  it('dont count number not warpd in parentecies', () => {
+  it('dose not count number not warped in parenthesise', () => {
     expect(getProjectNumber('test file 1')).toBe(0);
   });
 
-  it('dont count number if there is not a space', () => {
+  it('dose not count number if there is not a space', () => {
     expect(getProjectNumber('test file(1)')).toBe(0);
   });
 

--- a/apps/server/src/utils/__tests__/fileManagement.test.ts
+++ b/apps/server/src/utils/__tests__/fileManagement.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, Mock } from 'vitest';
 import * as fs from 'fs';
 
-import { appendToName, ensureJsonExtension, generateUniqueFileName, getProjectNumber } from '../fileManagement.js';
+import {
+  appendToName,
+  ensureJsonExtension,
+  generateUniqueFileName,
+  incrementProjectNumber,
+} from '../fileManagement.js';
 
 // Mock fs.existsSync to control the test environment
 vi.mock('fs', () => ({
@@ -92,23 +97,23 @@ describe('generateUniqueFileName', () => {
 });
 
 describe('file index', () => {
-  it('returns 0 when there is no index', () => {
-    expect(getProjectNumber('test file')).toBe(0);
+  it('sets index to 1 when there is no index', () => {
+    expect(incrementProjectNumber('test file.json')).toBe('test file (1).json');
   });
 
-  it('returns 1 when index is 1', () => {
-    expect(getProjectNumber('test file (1)')).toBe(1);
+  it('increments to 2 when index is 1', () => {
+    expect(incrementProjectNumber('test file (1).json')).toBe('test file (2).json');
   });
 
   it('dose not count number not warped in parenthesise', () => {
-    expect(getProjectNumber('test file 1')).toBe(0);
+    expect(incrementProjectNumber('test file 1.json')).toBe('test file 1 (1).json');
   });
 
   it('dose not count number if there is not a space', () => {
-    expect(getProjectNumber('test file(1)')).toBe(0);
+    expect(incrementProjectNumber('test file(1).json')).toBe('test file(1) (1).json');
   });
 
   it('counts multi digit numbers', () => {
-    expect(getProjectNumber('test file (890)')).toBe(890);
+    expect(incrementProjectNumber('test file (890).json')).toBe('test file (891).json');
   });
 });

--- a/apps/server/src/utils/fileManagement.ts
+++ b/apps/server/src/utils/fileManagement.ts
@@ -112,6 +112,9 @@ export async function dockerSafeRename(oldPath: PathLike, newPath: PathLike) {
 
 /**
  * finds potential file index number in our (*) format and increments
+ * the number section (*) must be separated from the name by a space
+ * @example incrementProjectNumber('test(1).json') -> 'test(1).json'
+  * @example incrementProjectNumber('test (1).json') -> 'test(2).json'
  */
 export function incrementProjectNumber(path: string): string {
   const { dir, name, ext } = parse(path);

--- a/apps/server/src/utils/fileManagement.ts
+++ b/apps/server/src/utils/fileManagement.ts
@@ -56,7 +56,7 @@ export function generateUniqueFileName(directory: string, filename: string): str
   const extension = extname(filename);
   const baseName = basename(filename, extension);
 
-  let counter = 0;
+  let counter = Number(baseName.match(/\((\d)\)$/)?.at(1) ?? 0);
   let uniqueFilename = filename;
 
   while (fileExists(uniqueFilename)) {

--- a/apps/server/src/utils/fileManagement.ts
+++ b/apps/server/src/utils/fileManagement.ts
@@ -117,7 +117,7 @@ export async function dockerSafeRename(oldPath: PathLike, newPath: PathLike) {
 
 /**
  * finds potential file index number in our (*) format
- * @param baseName the base name of the project file, without extention af path
+ * @param baseName the base name of the project file, without extension af path
  */
 export function getProjectNumber(baseName: string): number {
   return Number(baseName.match(/ \((\d+)\)$/)?.at(1) ?? 0);

--- a/apps/server/src/utils/fileManagement.ts
+++ b/apps/server/src/utils/fileManagement.ts
@@ -114,3 +114,11 @@ export async function dockerSafeRename(oldPath: PathLike, newPath: PathLike) {
   await copyFile(oldPath, newPath);
   await unlink(oldPath);
 }
+
+/**
+ * finds potential file index number in our (*) format
+ * @param baseName the base name of the project file, without extention af path
+ */
+export function getProjectNumber(baseName: string): number {
+  return Number(baseName.match(/ \((\d+)\)$/)?.at(1) ?? 0);
+}

--- a/apps/server/src/utils/fileManagement.ts
+++ b/apps/server/src/utils/fileManagement.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, PathLike } from 'fs';
 import { readdir, copyFile, unlink } from 'fs/promises';
-import { basename, extname, join, parse } from 'path';
+import { basename, join, parse } from 'path';
 
 /**
  * @description Creates a directory if it doesn't exist
@@ -53,16 +53,11 @@ export function appendToName(filePath: string, append: string): string {
  * If a file with the same name already exists, appends a counter to the filename.
  */
 export function generateUniqueFileName(directory: string, filename: string): string {
-  const extension = extname(filename);
-  const baseName = basename(filename, extension);
-
-  let counter = getProjectNumber(baseName);
   let uniqueFilename = filename;
 
   while (fileExists(uniqueFilename)) {
-    counter++;
     // Append counter to filename if the file exists.
-    uniqueFilename = `${baseName} (${counter})${extension}`;
+    uniqueFilename = incrementProjectNumber(uniqueFilename);
   }
 
   return uniqueFilename;
@@ -116,9 +111,18 @@ export async function dockerSafeRename(oldPath: PathLike, newPath: PathLike) {
 }
 
 /**
- * finds potential file index number in our (*) format
- * @param baseName the base name of the project file, without extension af path
+ * finds potential file index number in our (*) format and increments
  */
-export function getProjectNumber(baseName: string): number {
-  return Number(baseName.match(/ \((\d+)\)$/)?.at(1) ?? 0);
+export function incrementProjectNumber(path: string): string {
+  const { dir, name, ext } = parse(path);
+
+  if (!name.endsWith(')')) return join(dir, `${name} (1)${ext}`);
+
+  const openingParenIndex = name.lastIndexOf(' (');
+  if (openingParenIndex === -1) return join(dir, `${name} (1)${ext}`);
+
+  const maybeNumber = Number(name.slice(openingParenIndex + 2, -1));
+  if (isNaN(maybeNumber)) return join(dir, `${name} (1)${ext}`);
+
+  return join(dir, `${name.slice(0, openingParenIndex)} (${maybeNumber + 1})${ext}`);
 }

--- a/apps/server/src/utils/fileManagement.ts
+++ b/apps/server/src/utils/fileManagement.ts
@@ -56,7 +56,7 @@ export function generateUniqueFileName(directory: string, filename: string): str
   const extension = extname(filename);
   const baseName = basename(filename, extension);
 
-  let counter = Number(baseName.match(/\((\d)\)$/)?.at(1) ?? 0);
+  let counter = getProjectNumber(baseName);
   let uniqueFilename = filename;
 
   while (fileExists(uniqueFilename)) {


### PR DESCRIPTION
every project load was causing a renumber so I
moved the `generateUniqueFileName` logic from the ´loadProject´ function to the `createProject` function
and changed the deafult / new show funtions to use `create` instead of `load`