### PR TITLE
refactor: change offset classes depending on playback state

### DIFF
--- a/apps/client/src/features/overview/Overview.module.scss
+++ b/apps/client/src/features/overview/Overview.module.scss
@@ -52,3 +52,11 @@
 .behind {
   color: $ontime-delay-text;
 }
+
+.active {
+  color: $playback-start;
+}
+
+.inactive {
+  color: $muted-gray;
+}

--- a/apps/client/src/features/overview/Overview.tsx
+++ b/apps/client/src/features/overview/Overview.tsx
@@ -7,7 +7,7 @@ import useProjectData from '../../common/hooks-query/useProjectData';
 import { cx, enDash, timerPlaceholder } from '../../common/utils/styleUtils';
 
 import { TimeColumn, TimeRow } from './composite/TimeLayout';
-import { calculateEndAndDaySpan, formatedTime, getOffsetText } from './overviewUtils';
+import { calculateEndAndDaySpan, formatedTime, getOffsetClasses, getOffsetText } from './overviewUtils';
 
 import style from './Overview.module.scss';
 
@@ -163,10 +163,10 @@ function ProgressOverview() {
 }
 
 function RuntimeOverview() {
-  const { clock, offset } = useRuntimePlaybackOverview();
+  const { clock, offset, playback } = useRuntimePlaybackOverview();
 
   const offsetText = getOffsetText(offset);
-  const offsetClasses = offset === null ? undefined : offset <= 0 ? style.behind : style.ahead;
+  const offsetClasses = getOffsetClasses(offset, playback);
 
   return (
     <>

--- a/apps/client/src/features/overview/overviewUtils.ts
+++ b/apps/client/src/features/overview/overviewUtils.ts
@@ -1,7 +1,8 @@
-import { MaybeNumber } from 'ontime-types';
+import { MaybeNumber, Playback } from 'ontime-types';
 import { dayInMs, millisToString } from 'ontime-utils';
 
 import { enDash, timerPlaceholder } from '../../common/utils/styleUtils';
+import style from './Overview.module.scss';
 
 /**
  * Encapsulates the logic for formatting time in overview
@@ -33,4 +34,21 @@ export function getOffsetText(offset: MaybeNumber): string {
     return enDash;
   }
   return millisToString(offset, { fallback: enDash });
+}
+
+/**
+ * Gives offset styling class depending on offset and playback state
+ * @param offset
+ * @param playback
+ * @returns
+ */
+export function getOffsetClasses(offset: MaybeNumber, playback: Playback): string | undefined {
+  if (offset === null) return undefined;
+
+  if (playback === Playback.Stop) return style.inactive;
+
+  if (offset === 0) return style.active;
+  if (offset > 0) return style.ahead;
+
+  return style.behind;
 }


### PR DESCRIPTION
## Changes made
- add classes for `active` and `inactive` state under `Overview.module.scss`
- create a `getOffsetClasses` utility which checks the logic and returns the offset classes depending on offset and playback state

#### Few questions I had:
- how do we want to handle other playback states? currently, when playback is stopped, it becomes muted gray and then for other playback states, it changes to either `active`, `ahead` or `behind` classes. do we want to have logic for other playback states such as `pause`, `armed`, etc?

- the `active` and `ahead` classes are both green in color. the `active` state is a shade darker (green-600) than `ahead` (green-500). do we want to keep them same or if continue keeping them different then assign any other shade of green to either of the classes?

do let me know if there's any changes to be made