### PR TITLE
refactor: block event xlsx import

### DIFF
--- a/apps/client/src/views/cuesheet/__tests__/cuesheet.utils.test.ts
+++ b/apps/client/src/views/cuesheet/__tests__/cuesheet.utils.test.ts
@@ -96,7 +96,7 @@ describe('makeTable()', () => {
           "Is Public? (x)",
           "Skip?",
           "lighting",
-          "Timer Type",
+          "Type",
         ],
         [
           "00:00:00",

--- a/apps/client/src/views/cuesheet/__tests__/cuesheet.utils.test.ts
+++ b/apps/client/src/views/cuesheet/__tests__/cuesheet.utils.test.ts
@@ -96,6 +96,7 @@ describe('makeTable()', () => {
           "Is Public? (x)",
           "Skip?",
           "lighting",
+          "Timer Type",
         ],
         [
           "00:00:00",
@@ -107,6 +108,7 @@ describe('makeTable()', () => {
           "test title 1",
           "",
           "x",
+          "",
           "",
           "",
         ],

--- a/apps/client/src/views/cuesheet/cuesheet.utils.ts
+++ b/apps/client/src/views/cuesheet/cuesheet.utils.ts
@@ -59,6 +59,7 @@ export const makeTable = (headerData: ProjectData, rundown: OntimeRundown, custo
     'isPublic',
     'skip',
     ...customFieldKeys,
+    'type',
   ];
 
   const fieldTitles = [
@@ -73,6 +74,7 @@ export const makeTable = (headerData: ProjectData, rundown: OntimeRundown, custo
     'Is Public? (x)',
     'Skip?',
     ...customFieldLabels,
+    'Type',
   ];
 
   // add header row to data

--- a/apps/client/src/views/cuesheet/cuesheet.utils.ts
+++ b/apps/client/src/views/cuesheet/cuesheet.utils.ts
@@ -74,7 +74,7 @@ export const makeTable = (headerData: ProjectData, rundown: OntimeRundown, custo
     'Is Public? (x)',
     'Skip?',
     ...customFieldLabels,
-    'Timer Type',
+    'Type',
   ];
 
   // add header row to data

--- a/apps/client/src/views/cuesheet/cuesheet.utils.ts
+++ b/apps/client/src/views/cuesheet/cuesheet.utils.ts
@@ -74,7 +74,7 @@ export const makeTable = (headerData: ProjectData, rundown: OntimeRundown, custo
     'Is Public? (x)',
     'Skip?',
     ...customFieldLabels,
-    'Type',
+    'Timer Type',
   ];
 
   // add header row to data

--- a/apps/server/src/utils/parser.ts
+++ b/apps/server/src/utils/parser.ts
@@ -215,7 +215,7 @@ export const parseExcel = (
         const maybeTimeType = makeString(column, '');
         if (maybeTimeType === 'block') {
           event.type = SupportedEvent.Block;
-        } else if (maybeTimeType === '' || isKnownTimerType(maybeTimeType)) {
+        } else if (maybeTimeType === '' || maybeTimeType === 'event' || isKnownTimerType(maybeTimeType)) {
           event.type = SupportedEvent.Event;
           event.timerType = validateTimerType(maybeTimeType);
         } else {


### PR DESCRIPTION
addresses #1310

## Changes made:
- exported type under Type column on frontend
- added a condition to check if `maybeTimeType` is equal to 'event' (without this, the flow falls into the else block where none of the events get imported, only the blocks get imported)

## Screenshots

- CSV export
![image](https://github.com/user-attachments/assets/ee6a6870-abbc-4113-ae73-1230865596d4)

- Excel
![image](https://github.com/user-attachments/assets/5cd26eb8-70a2-4d32-b386-080e0943f984)

- Preview during importing excel

![image](https://github.com/user-attachments/assets/2e3a3406-bb74-4e9d-9d82-50df98126575)

![image](https://github.com/user-attachments/assets/378f1534-d226-46a2-9261-813f59ec6530)

