### PR TITLE
add electron and esbuild to allow list for postinstall builds

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,14 +1,16 @@
-# https://pnpm.io/pnpm-workspace_yaml
 packages:
-  - "apps/*"
-  - "packages/*"
+  - apps/*
+  - packages/*
 catalog:
   typescript: 5.5.3
-  "@typescript-eslint/eslint-plugin": 7.16.1
-  "@typescript-eslint/parser": 7.16.1
-  "@types/node": 22.15.26
+  '@typescript-eslint/eslint-plugin': 7.16.1
+  '@typescript-eslint/parser': 7.16.1
+  '@types/node': 22.15.26
   prettier: 3.3.1
   eslint: 8.56.0
   eslint-config-prettier: 9.1.0
   eslint-plugin-prettier: 5.1.3
   vitest: 3.2.1
+onlyBuiltDependencies:
+  - electron
+  - esbuild


### PR DESCRIPTION
I forgot about enabling these packages so their `postinstall` lifecycle scripts are ran.