### PR TITLE
refactor: cuesheet time format

### DIFF
--- a/apps/client/src/declarations/declaration.d.ts
+++ b/apps/client/src/declarations/declaration.d.ts
@@ -31,6 +31,7 @@ declare module '@tanstack/react-table' {
     options: {
       showDelayedTimes: boolean;
       hideTableSeconds: boolean;
+      timeFormat: TimeFormat;
     };
   }
 }

--- a/apps/client/src/views/cuesheet/cuesheet-table/CuesheetTable.tsx
+++ b/apps/client/src/views/cuesheet/cuesheet-table/CuesheetTable.tsx
@@ -14,6 +14,7 @@ import CuesheetTableSettings from './cuesheet-table-settings/CuesheetTableSettin
 import useColumnManager from './useColumnManager';
 
 import style from './CuesheetTable.module.scss';
+import useSettings from '../../../common/hooks-query/useSettings';
 
 interface CuesheetTableProps {
   data: OntimeEntry[];
@@ -32,6 +33,9 @@ export default function CuesheetTable(props: CuesheetTableProps) {
   const selectedRef = useRef<HTMLTableRowElement | null>(null);
   const tableContainerRef = useRef<HTMLDivElement | null>(null);
   useFollowComponent({ followRef: selectedRef, scrollRef: tableContainerRef, doFollow: followSelected });
+
+  const { data: settings } = useSettings();
+  const timeFormat = settings.timeFormat;
 
   const { listeners } = useTableNav();
 
@@ -77,6 +81,7 @@ export default function CuesheetTable(props: CuesheetTableProps) {
       options: {
         showDelayedTimes,
         hideTableSeconds,
+        timeFormat,
       },
     },
   });

--- a/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/TimeInput.tsx
+++ b/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/TimeInput.tsx
@@ -3,11 +3,13 @@ import { millisToString, parseUserTime } from 'ontime-utils';
 
 import SingleLineCell from './SingleLineCell';
 import TextLikeInput from './TextLikeInput';
+import { TimeFormat } from 'ontime-types';
 
 interface TimeInputDurationProps {
   initialValue: number;
   lockedValue: boolean;
   delayed?: boolean;
+  timeFormat?: TimeFormat;
   onSubmit: (value: string) => void;
 }
 
@@ -18,7 +20,7 @@ interface ParentFocusableInput extends HTMLInputElement {
 export default memo(TimeInputDuration);
 
 function TimeInputDuration(props: PropsWithChildren<TimeInputDurationProps>) {
-  const { initialValue, lockedValue, delayed, onSubmit, children } = props;
+  const { initialValue, lockedValue, delayed, timeFormat, onSubmit, children } = props;
 
   const [isEditing, setIsEditing] = useState(false);
   const [value, setValue] = useState(initialValue);
@@ -84,7 +86,7 @@ function TimeInputDuration(props: PropsWithChildren<TimeInputDurationProps>) {
     [initialValue, lockedValue, onSubmit],
   );
 
-  const timeString = millisToString(value);
+  const timeString = millisToString(value, { timeFormat });
 
   return isEditing ? (
     <SingleLineCell

--- a/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/cuesheetCols.tsx
+++ b/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/cuesheetCols.tsx
@@ -17,7 +17,7 @@ function MakeStart({ getValue, row, table }: CellContext<OntimeEntry, unknown>) 
   }
 
   const { handleUpdateTimer } = table.options.meta;
-  const { showDelayedTimes, hideTableSeconds } = table.options.meta.options;
+  const { showDelayedTimes, hideTableSeconds, timeFormat } = table.options.meta.options;
 
   const update = (newValue: string) => handleUpdateTimer(row.original.id, 'timeStart', newValue);
 
@@ -26,13 +26,13 @@ function MakeStart({ getValue, row, table }: CellContext<OntimeEntry, unknown>) 
   const delayValue = (row.original as OntimeEvent)?.delay ?? 0;
 
   const displayTime = showDelayedTimes ? startTime + delayValue : startTime;
-  let formattedTime = millisToString(displayTime);
+  let formattedTime = millisToString(displayTime, { timeFormat });
   if (hideTableSeconds) {
     formattedTime = removeSeconds(formattedTime);
   }
 
   return (
-    <TimeInput initialValue={startTime} onSubmit={update} lockedValue={isStartLocked} delayed={delayValue !== 0}>
+    <TimeInput initialValue={startTime} onSubmit={update} lockedValue={isStartLocked} delayed={delayValue !== 0} timeFormat={timeFormat}>
       {formattedTime}
       <DelayIndicator delayValue={delayValue} tooltipPrefix={millisToString(startTime)} />
     </TimeInput>
@@ -45,7 +45,7 @@ function MakeEnd({ getValue, row, table }: CellContext<OntimeEntry, unknown>) {
   }
 
   const { handleUpdateTimer } = table.options.meta;
-  const { showDelayedTimes, hideTableSeconds } = table.options.meta.options;
+  const { showDelayedTimes, hideTableSeconds, timeFormat } = table.options.meta.options;
 
   const update = (newValue: string) => handleUpdateTimer(row.original.id, 'timeEnd', newValue);
 
@@ -54,13 +54,13 @@ function MakeEnd({ getValue, row, table }: CellContext<OntimeEntry, unknown>) {
   const delayValue = (row.original as OntimeEvent)?.delay ?? 0;
 
   const displayTime = showDelayedTimes ? endTime + delayValue : endTime;
-  let formattedTime = millisToString(displayTime);
+  let formattedTime = millisToString(displayTime, { timeFormat });
   if (hideTableSeconds) {
     formattedTime = removeSeconds(formattedTime);
   }
 
   return (
-    <TimeInput initialValue={endTime} onSubmit={update} lockedValue={isEndLocked} delayed={delayValue !== 0}>
+    <TimeInput initialValue={endTime} onSubmit={update} lockedValue={isEndLocked} delayed={delayValue !== 0} timeFormat={timeFormat}>
       {formattedTime}
       <DelayIndicator delayValue={delayValue} tooltipPrefix={millisToString(endTime)} />
     </TimeInput>

--- a/packages/utils/src/date-utils/timeFormatting.ts
+++ b/packages/utils/src/date-utils/timeFormatting.ts
@@ -1,4 +1,4 @@
-import type { MaybeNumber, TimerType } from 'ontime-types';
+import type { MaybeNumber, TimeFormat, TimerType } from 'ontime-types';
 
 import { millisToSeconds, secondsToHours, secondsToMinutes } from './conversionUtils.js';
 
@@ -9,6 +9,7 @@ export function pad(val: number): string {
 type FormatOptions = {
   fallback?: string;
   direction?: TimerType.CountDown | TimerType.CountUp;
+  timeFormat?: TimeFormat;
 };
 
 /**
@@ -27,7 +28,11 @@ export function millisToString(millis?: MaybeNumber, options?: FormatOptions): s
   const totalSeconds = Math.abs(millisToSeconds(millis, options?.direction));
   const seconds = totalSeconds % 60;
   const minutes = secondsToMinutes(totalSeconds) % 60;
-  const hours = secondsToHours(totalSeconds);
+  let hours = secondsToHours(totalSeconds);
+
+  if (options?.timeFormat === '12') {
+    hours = hours % 12;
+  }
 
   return `${isNegative ? '-' : ''}${[hours, minutes, seconds].map(pad).join(':')}`;
 }


### PR DESCRIPTION
## Changes made:
- added `timeFormat` as a type under Tanstack table's declaration
- get `timeFormat` with `useSettings` from `<CuesheetTable>`
- add `timeFormat` as an optional prop under `<TimeInput>` that is under cuesheet-elements
- add `timeFormat` as an option under `FormatOptions` and change the hour formatting based on that inside `millisToString` util

Issue: There's an issue currently with the Duration column in the table. If we toggle the focus between `timeEnd` and `duration` column, the formatting of the duration seems to add an additional '12h'

For example: if timeStart is 1:05:00 and timeEnd is 1:25:00, and we toggle focus, the duration changes from '20m' to '12h20m' 