### PR TITLE
Fix: Correct boundary condition in applyDelay

### DIFF
--- a/apps/server/src/api-data/rundown/rundown.dao.ts
+++ b/apps/server/src/api-data/rundown/rundown.dao.ts
@@ -329,7 +329,7 @@ function applyDelay(rundown: Rundown, delay: OntimeDelay) {
 
   // if the delay is empty, or the last element
   // there is nothing do apply
-  if (delay.duration === 0 || delayIndex === rundown.order.length - 1) {
+  if (delay.duration === 0 || delayIndex === rundownMetadata.flatEntryOrder.length - 1) {
     return;
   }
 


### PR DESCRIPTION
The `applyDelay` function had a condition that incorrectly used `rundown.order.length` instead of `rundownMetadata.flatEntryOrder.length` to check if a delay entry was the last in the sequence. `rundown.order` only contains top-level entries, while `flatEntryOrder` contains all entries, including those within blocks, which is the relevant list for this check.

This commit corrects the condition to use `rundownMetadata.flatEntryOrder.length`.

Existing tests in `rundown.dao.test.ts` (specifically the test `removes delays in last position without applying changes`) already cover this scenario and pass with the correction, ensuring the fix behaves as expected.