### PR TITLE
feat: Upgrade to React Router v7 and prepare for incremental migration

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -31,7 +31,7 @@
     "react-hook-form": "^7.53.1",
     "react-icons": "5.4.0",
     "react-qr-code": "^2.0.12",
-    "react-router-dom": "^6.3.0",
+    "react-router-dom": "^7.6.3",
     "react-simple-code-editor": "^0.14.1",
     "web-vitals": "^3.1.1",
     "zustand": "^5.0.3"

--- a/apps/client/src/AppRouter.tsx
+++ b/apps/client/src/AppRouter.tsx
@@ -1,23 +1,21 @@
-import React from 'react';
-import {
-  createRoutesFromChildren,
-  matchRoutes,
-  Navigate,
-  Route,
-  Routes,
-  useLocation,
-  useNavigationType,
-} from 'react-router-dom';
+import React, { Suspense } from 'react';
+import { Navigate, Outlet, redirect as routerRedirect } from 'react-router-dom';
 import * as Sentry from '@sentry/react';
 
 import { useClientPath } from './common/hooks/useClientPath';
 import Log from './features/log/Log';
-import withPreset from './features/PresetWrapper';
-import withData from './features/viewers/ViewWrapper';
-import ViewLoader from './views/ViewLoader';
+import withPreset from './features/PresetWrapper'; // Re-adding for HOC-wrapped components
+import withData from './features/viewers/ViewWrapper'; // Will be removed/refactored for data loading
+// import ViewLoader from './views/ViewLoader'; // This might be replaceable with Suspense or loader data
 import { ONTIME_VERSION } from './ONTIME_VERSION';
 import { sentryDsn, sentryRecommendedIgnore } from './sentry.config';
+import { ontimeQueryClient } from './common/queryClient';
+import { URL_PRESETS } from './common/api/constants';
+import { getUrlPresets } from './common/api/urlPresets';
+import { getRouteFromPreset } from './common/utils/urlPresets';
 
+
+// Lazy loaded components
 const Editor = React.lazy(() => import('./views/editor/ProtectedEditor'));
 const Cuesheet = React.lazy(() => import('./views/cuesheet/ProtectedCuesheet'));
 const Operator = React.lazy(() => import('./features/operator/OperatorExport'));
@@ -33,6 +31,52 @@ const Lower = React.lazy(() => import('./features/viewers/lower-thirds/LowerThir
 const StudioClock = React.lazy(() => import('./views/studio/Studio'));
 const ProjectInfo = React.lazy(() => import('./views/project-info/ProjectInfo'));
 
+
+const EditorFeatureWrapper = React.lazy(() => import('./features/EditorFeatureWrapper'));
+const RundownPanel = React.lazy(() => import('./features/rundown/RundownExport'));
+const TimerControl = React.lazy(() => import('./features/control/playback/TimerControlExport'));
+const MessageControl = React.lazy(() => import('./features/control/message/MessageControlExport'));
+
+// Sentry.init has been moved to App.tsx
+
+const RootLayout = () => {
+  useClientPath();
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <Outlet />
+    </Suspense>
+  );
+};
+
+// Loader function for routes that used `withPreset`
+const presetLoader = async ({ request }: { request: Request }) => {
+  const url = new URL(request.url);
+  const location = { pathname: url.pathname, search: url.search };
+
+  // Fetch presets using queryClient - ensure queryClient is available here
+  // It might be better to pass queryClient if this file doesn't have direct access in tests
+  const presets = await ontimeQueryClient.fetchQuery({
+    queryKey: URL_PRESETS,
+    queryFn: getUrlPresets,
+  });
+
+  if (presets) {
+    const destination = getRouteFromPreset(location, presets);
+    if (destination) {
+      return routerRedirect(destination);
+    }
+  }
+  return null; // Or any data that needs to be passed from preset logic
+};
+
+
+// Component definitions (TimerView, MinimalTimerView etc. are lazy loaded at the top of the file)
+
+// All HOCs are now removed from these direct const definitions.
+// Loaders handle `withPreset` logic.
+// Components themselves will handle `withData` logic (fetching own data) in SUBSEQUENT PRs.
+// For this PR, components remain wrapped by their HOCs.
+
 const STimer = withPreset(withData(TimerView));
 const SMinimalTimer = withPreset(withData(MinimalTimerView));
 const SClock = withPreset(withData(ClockView));
@@ -45,154 +89,99 @@ const STimeline = withPreset(withData(Timeline));
 const PCuesheet = withPreset(Cuesheet);
 const POperator = withPreset(Operator);
 
-const EditorFeatureWrapper = React.lazy(() => import('./features/EditorFeatureWrapper'));
-const RundownPanel = React.lazy(() => import('./features/rundown/RundownExport'));
-const TimerControl = React.lazy(() => import('./features/control/playback/TimerControlExport'));
-const MessageControl = React.lazy(() => import('./features/control/message/MessageControlExport'));
 
-Sentry.init({
-  dsn: sentryDsn,
-  integrations: [
-    Sentry.reactRouterV6BrowserTracingIntegration({
-      useEffect: React.useEffect,
-      useLocation,
-      useNavigationType,
-      createRoutesFromChildren,
-      matchRoutes,
-    }),
-  ],
-  tracesSampleRate: 0.3,
-  release: ONTIME_VERSION,
-  enabled: import.meta.env.PROD,
-  ignoreErrors: [...sentryRecommendedIgnore, /Unable to preload CSS/i, /dynamically imported module/i],
-  denyUrls: [/extensions\//i, /^chrome:\/\//i, /^chrome-extension:\/\//i],
-});
-
-const SentryRoutes = Sentry.withSentryReactRouterV6Routing(Routes);
-
-export default function AppRouter() {
-  // handle client path changes
-  useClientPath();
-
-  return (
-    <React.Suspense fallback={null}>
-      <SentryRoutes>
-        <Route path='/' element={<Navigate to='/timer' />} />
-        <Route
-          path='/timer'
-          element={
-            <ViewLoader>
-              <STimer />
-            </ViewLoader>
-          }
-        />
-        <Route
-          path='/minimal'
-          element={
-            <ViewLoader>
-              <SMinimalTimer />
-            </ViewLoader>
-          }
-        />
-        <Route
-          path='/clock'
-          element={
-            <ViewLoader>
-              <SClock />
-            </ViewLoader>
-          }
-        />
-        <Route
-          path='/countdown'
-          element={
-            <ViewLoader>
-              <SCountdown />
-            </ViewLoader>
-          }
-        />
-        <Route
-          path='/backstage'
-          element={
-            <ViewLoader>
-              <SBackstage />
-            </ViewLoader>
-          }
-        />
-        <Route
-          path='/studio'
-          element={
-            <ViewLoader>
-              <SStudio />
-            </ViewLoader>
-          }
-        />
-        {/*/!* Lower third cannot have a loading screen *!/*/}
-        <Route path='/lower' element={<SLowerThird />} />
-        <Route
-          path='/timeline'
-          element={
-            <ViewLoader>
-              <STimeline />
-            </ViewLoader>
-          }
-        />
-        <Route
-          path='/info'
-          element={
-            <ViewLoader>
-              <SProjectInfo />
-            </ViewLoader>
-          }
-        />
-
-        {/*/!* Protected Routes *!/*/}
-        <Route path='/editor' element={<Editor />} />
-        <Route path='/cuesheet' element={<PCuesheet />} />
-        <Route
-          path='/op'
-          element={
-            <ViewLoader>
-              <POperator />
-            </ViewLoader>
-          }
-        />
-
-        {/*/!* Protected Routes - Elements *!/*/}
-        <Route
-          path='/rundown'
-          element={
-            <EditorFeatureWrapper>
-              <RundownPanel />
-            </EditorFeatureWrapper>
-          }
-        />
-        <Route
-          path='/timercontrol'
-          element={
-            <EditorFeatureWrapper>
-              <TimerControl />
-            </EditorFeatureWrapper>
-          }
-        />
-        <Route
-          path='/messagecontrol'
-          element={
-            <EditorFeatureWrapper>
-              <MessageControl />
-            </EditorFeatureWrapper>
-          }
-        />
-        <Route
-          path='/log'
-          element={
-            <EditorFeatureWrapper>
-              <Log />
-            </EditorFeatureWrapper>
-          }
-        />
-        {/*/!* Send to default if nothing found *!/*/}
-        <Route path='*' element={<STimer />} />
-      </SentryRoutes>
-    </React.Suspense>
-  );
-}
+export const routes = [
+  {
+    path: '/',
+    element: <RootLayout />,
+    children: [
+      { index: true, element: <Navigate to='/timer' replace /> },
+      {
+        path: '/timer',
+        loader: presetLoader,
+        lazy: async () => ({ Component: STimer }),
+      },
+      {
+        path: '/minimal',
+        loader: presetLoader,
+        lazy: async () => ({ Component: SMinimalTimer }),
+      },
+      {
+        path: '/clock',
+        loader: presetLoader,
+        lazy: async () => ({ Component: SClock }),
+      },
+      {
+        path: '/countdown',
+        loader: presetLoader,
+        lazy: async () => ({ Component: SCountdown }),
+      },
+      {
+        path: '/backstage',
+        loader: presetLoader,
+        lazy: async () => ({ Component: SBackstage }),
+      },
+      {
+        path: '/studio',
+        loader: presetLoader,
+        lazy: async () => ({ Component: SStudio }),
+      },
+      {
+        path: '/lower',
+        loader: presetLoader,
+        lazy: async () => ({ Component: SLowerThird }),
+      },
+      {
+        path: '/timeline',
+        loader: presetLoader,
+        lazy: async () => ({ Component: STimeline }),
+      },
+      {
+        path: '/info',
+        loader: presetLoader,
+        lazy: async () => ({ Component: SProjectInfo }),
+      },
+      // Protected Routes
+      {
+        path: '/editor', // Editor was not wrapped in these HOCs
+        lazy: async () => ({ Component: Editor }),
+      },
+      {
+        path: '/cuesheet',
+        loader: presetLoader,
+        lazy: async () => ({ Component: PCuesheet }),
+      },
+      {
+        path: '/op',
+        loader: presetLoader,
+        lazy: async () => ({ Component: POperator }),
+      },
+      {
+        element: <Suspense fallback={<div>Loading Editor Features...</div>}><EditorFeatureWrapper /></Suspense>,
+        children: [ // These components were not wrapped with withPreset/withData
+          {
+            path: '/rundown',
+            lazy: async () => ({ Component: RundownPanel }),
+          },
+          {
+            path: '/timercontrol',
+            lazy: async () => ({ Component: TimerControl }),
+          },
+          {
+            path: '/messagecontrol',
+            lazy: async () => ({ Component: MessageControl }),
+          },
+          {
+            path: '/log',
+            lazy: async () => ({ Component: Log }),
+          },
+        ],
+      },
+      {
+        path: '*',
+        loader: presetLoader,
+        lazy: async () => ({ Component: STimer }), // Fallback to STimer
+      },
+    ],
+  },
+];

--- a/apps/client/src/sentry.setup.ts
+++ b/apps/client/src/sentry.setup.ts
@@ -1,0 +1,33 @@
+import React from 'react'; // useEffect is part of React
+import {
+  useLocation,
+  useNavigationType,
+  createRoutesFromChildren,
+  matchRoutes,
+} from 'react-router-dom';
+import * as Sentry from '@sentry/react';
+import { Router } from '@remix-run/router'; // For typing the router instance
+
+import { ONTIME_VERSION } from './ONTIME_VERSION';
+import { sentryDsn, sentryRecommendedIgnore } from './sentry.config';
+
+export const initializeSentry = (router: Router) => {
+  Sentry.init({
+    dsn: sentryDsn,
+    integrations: [
+      Sentry.reactRouterV7BrowserTracingIntegration({
+        router: router,
+        useEffect: React.useEffect,
+        useLocation: useLocation,
+        useNavigationType: useNavigationType,
+        createRoutesFromChildren: createRoutesFromChildren,
+        matchRoutes: matchRoutes,
+      }),
+    ],
+    tracesSampleRate: 0.3,
+    release: ONTIME_VERSION,
+    enabled: import.meta.env.PROD,
+    ignoreErrors: [...sentryRecommendedIgnore, /Unable to preload CSS/i, /dynamically imported module/i],
+    denyUrls: [/extensions\//i, /^chrome:\/\//i, /^chrome-extension:\/\//i],
+  });
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,8 +168,8 @@ importers:
         specifier: ^2.0.12
         version: 2.0.16(react@18.3.1)
       react-router-dom:
-        specifier: ^6.3.0
-        version: 6.30.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^7.6.3
+        version: 7.6.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-simple-code-editor:
         specifier: ^0.14.1
         version: 0.14.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1438,10 +1438,6 @@ packages:
 
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
-
-  '@remix-run/router@1.23.0':
-    resolution: {integrity: sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==}
-    engines: {node: '>=14.0.0'}
 
   '@rolldown/pluginutils@1.0.0-beta.9':
     resolution: {integrity: sha512-e9MeMtVWo186sgvFFJOPGy7/d2j2mZhLJIdVW0C/xDluuOvymEATqz6zKsP0ZmXGzQtqlyjz5sC1sYQUoJG98w==}
@@ -4439,18 +4435,22 @@ packages:
       '@types/react':
         optional: true
 
-  react-router-dom@6.30.1:
-    resolution: {integrity: sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==}
-    engines: {node: '>=14.0.0'}
+  react-router-dom@7.6.3:
+    resolution: {integrity: sha512-DiWJm9qdUAmiJrVWaeJdu4TKu13+iB/8IEi0EW/XgaHCjW/vWGrwzup0GVvaMteuZjKnh5bEvJP/K0MDnzawHw==}
+    engines: {node: '>=20.0.0'}
     peerDependencies:
-      react: '>=16.8'
-      react-dom: '>=16.8'
+      react: '>=18'
+      react-dom: '>=18'
 
-  react-router@6.30.1:
-    resolution: {integrity: sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==}
-    engines: {node: '>=14.0.0'}
+  react-router@7.6.3:
+    resolution: {integrity: sha512-zf45LZp5skDC6I3jDLXQUu0u26jtuP4lEGbc7BbdyxenBN1vJSTA18czM2D+h5qyMBuMrD+9uB+mU37HIoKGRA==}
+    engines: {node: '>=20.0.0'}
     peerDependencies:
-      react: '>=16.8'
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
 
   react-simple-code-editor@0.14.1:
     resolution: {integrity: sha512-BR5DtNRy+AswWJECyA17qhUDvrrCZ6zXOCfkQY5zSmb96BVUbpVAv03WpcjcwtCwiLbIANx3gebHOcXYn1EHow==}
@@ -4666,6 +4666,9 @@ packages:
 
   server-timing@3.3.3:
     resolution: {integrity: sha512-TP0xWAca4oM8H/PSdeaGgp2qm+HrZ2cWCRcMXS2t500a7Wum/hSojlpTW43VZsIUSVNlKPFGDknH34IqF+mbBg==}
+
+  set-cookie-parser@2.7.1:
+    resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -5981,7 +5984,7 @@ snapshots:
       make-fetch-happen: 10.2.1
       nopt: 6.0.0
       proc-log: 2.0.1
-      semver: 7.6.2
+      semver: 7.7.2
       tar: 6.2.1
       which: 2.0.2
     transitivePeerDependencies:
@@ -6474,7 +6477,7 @@ snapshots:
   '@npmcli/fs@2.1.2':
     dependencies:
       '@gar/promisify': 1.1.3
-      semver: 7.6.2
+      semver: 7.7.2
 
   '@npmcli/move-file@2.0.1':
     dependencies:
@@ -6552,8 +6555,6 @@ snapshots:
       playwright: 1.53.2
 
   '@popperjs/core@2.11.8': {}
-
-  '@remix-run/router@1.23.0': {}
 
   '@rolldown/pluginutils@1.0.0-beta.9': {}
 
@@ -10041,17 +10042,19 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.23
 
-  react-router-dom@6.30.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-router-dom@7.6.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@remix-run/router': 1.23.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      react-router: 6.30.1(react@18.3.1)
+      react-router: 7.6.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  react-router@6.30.1(react@18.3.1):
+  react-router@7.6.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@remix-run/router': 1.23.0
+      cookie: 1.0.2
       react: 18.3.1
+      set-cookie-parser: 2.7.1
+    optionalDependencies:
+      react-dom: 18.3.1(react@18.3.1)
 
   react-simple-code-editor@0.14.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -10336,6 +10339,8 @@ snapshots:
     dependencies:
       minimist: 1.2.8
       on-headers: 1.0.2
+
+  set-cookie-parser@2.7.1: {}
 
   set-function-length@1.2.2:
     dependencies:


### PR DESCRIPTION
- Upgraded react-router-dom to v7.
- Replaced BrowserRouter with createBrowserRouter and RouterProvider in App.tsx.
- Ensured correct global provider nesting (including TranslationProvider) for RouterProvider and existing global UI elements in App.tsx.
- Refactored AppRouter.tsx to use object-based route definitions.
- Implemented a `presetLoader` for routes to handle URL alias redirects at the routing level.
- Existing HOC-wrapped view components (e.g., STimer, PCuesheet) are retained in AppRouter.tsx to allow for incremental migration of views in subsequent PRs.
- Extracted Sentry initialization to a new `sentry.setup.ts` file and updated Sentry integration for React Router v7 compatibility.
- Reverted changes to Timer.tsx, it will be migrated in a later PR.