### PR TITLE
fix: prevent storage key conflicts between stages

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@getontime/cli",
-    "version": "3.16.0",
+    "version": "3.16.1",
     "author": "Carlos Valente",
     "description": "Time keeping for live events",
     "repository": "https://github.com/cpvalente/ontime",

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ontime-ui",
-  "version": "3.16.0",
+  "version": "3.16.1",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/apps/client/src/common/components/view-params-editor/ViewParamsSection.tsx
+++ b/apps/client/src/common/components/view-params-editor/ViewParamsSection.tsx
@@ -1,6 +1,7 @@
 import { IoChevronDown } from 'react-icons/io5';
 import { useLocalStorage } from '@mantine/hooks';
 
+import { baseURI } from '../../../externals';
 import { cx } from '../../utils/styleUtils';
 
 import ParamInput from './ParamInput';
@@ -17,7 +18,7 @@ interface ViewParamsSectionProps {
 export default function ViewParamsSection(props: ViewParamsSectionProps) {
   const { title, collapsible, options } = props;
 
-  const [collapsed, setCollapsed] = useLocalStorage({ key: `params-${title}`, defaultValue: false });
+  const [collapsed, setCollapsed] = useLocalStorage({ key: `${baseURI}params-${title}`, defaultValue: false });
 
   const handleCollapse = () => {
     if (collapsible) {

--- a/apps/client/src/common/context/AppContext.tsx
+++ b/apps/client/src/common/context/AppContext.tsx
@@ -1,5 +1,6 @@
 import { createContext, PropsWithChildren, useCallback, useEffect, useState } from 'react';
 
+import { baseURI } from '../../externals';
 import useSettings from '../hooks-query/useSettings';
 
 interface AppContextType {
@@ -26,7 +27,7 @@ export const AppContextProvider = ({ children }: PropsWithChildren) => {
 
   useEffect(() => {
     if (status === 'pending') return;
-    const previousEditor = sessionStorage.getItem(storageKeys.editor);
+    const previousEditor = sessionStorage.getItem(`${baseURI}${storageKeys.editor}`);
 
     if (previousEditor && previousEditor === data.editorKey) {
       setEditorAuth(true);
@@ -34,7 +35,7 @@ export const AppContextProvider = ({ children }: PropsWithChildren) => {
       setEditorAuth(data.editorKey == null || data.editorKey === '');
     }
 
-    const previousOperator = sessionStorage.getItem(storageKeys.operator);
+    const previousOperator = sessionStorage.getItem(`${baseURI}${storageKeys.operator}`);
     if (previousOperator && previousOperator === data.operatorKey) {
       setOperatorAuth(true);
     } else {
@@ -55,14 +56,14 @@ export const AppContextProvider = ({ children }: PropsWithChildren) => {
       if (permission === 'editor') {
         const correct = isValid(pin, data.editorKey);
         if (correct) {
-          sessionStorage.setItem(storageKeys.editor, pin);
+          sessionStorage.setItem(`${baseURI}${storageKeys.editor}`, pin);
         }
         setEditorAuth(correct);
         return correct;
       } else if (permission === 'operator') {
         const correct = isValid(pin, data.operatorKey);
         if (correct) {
-          sessionStorage.setItem(storageKeys.operator, pin);
+          sessionStorage.setItem(`${baseURI}${storageKeys.operator}`, pin);
         }
         setOperatorAuth(correct);
         return correct;

--- a/apps/client/src/common/stores/appModeStore.ts
+++ b/apps/client/src/common/stores/appModeStore.ts
@@ -1,12 +1,14 @@
 import { create } from 'zustand';
 
+import { baseURI } from '../../externals';
+
 export enum AppMode {
   Run = 'run',
   Edit = 'edit',
   Freeze = 'freeze',
 }
 
-const appModeKey = 'ontime-app-mode';
+const appModeKey = `${baseURI}ontime-app-mode`;
 
 function getModeFromSession() {
   return sessionStorage.getItem(appModeKey) === AppMode.Run ? AppMode.Run : AppMode.Edit;

--- a/apps/client/src/common/stores/clientStore.ts
+++ b/apps/client/src/common/stores/clientStore.ts
@@ -1,6 +1,8 @@
 import { ClientList } from 'ontime-types';
 import { create } from 'zustand';
 
+import { baseURI } from '../../externals';
+
 interface ClientStore {
   name?: string;
   setName: (newValue: string) => void;
@@ -15,7 +17,7 @@ interface ClientStore {
   setClients: (clients: ClientList) => void;
 }
 
-const clientNameKey = 'ontime-client-name';
+const clientNameKey = `${baseURI}ontime-client-name`;
 
 function persistNameInStorage(newValue: string) {
   localStorage.setItem(clientNameKey, newValue);

--- a/apps/client/src/common/stores/viewOptions.ts
+++ b/apps/client/src/common/stores/viewOptions.ts
@@ -1,6 +1,8 @@
+// eslint-disable-next-line simple-import-sort/imports
 import { create } from 'zustand';
 
 import { booleanFromLocalStorage } from '../utils/localStorage';
+import { baseURI } from '../../externals';
 
 enum LocalEventKeys {
   Mirror = 'ontime-view-mirror',
@@ -12,11 +14,11 @@ type ViewOptionsStore = {
 };
 
 export const useViewOptionsStore = create<ViewOptionsStore>()((set) => ({
-  mirror: booleanFromLocalStorage(LocalEventKeys.Mirror, false),
+  mirror: booleanFromLocalStorage(`${baseURI}${LocalEventKeys.Mirror}`, false),
   toggleMirror: (newValue?: boolean) =>
     set((state) => {
       const val = typeof newValue === 'undefined' ? !state.mirror : newValue;
-      localStorage.setItem(LocalEventKeys.Mirror, String(val));
+      localStorage.setItem(`${baseURI}${LocalEventKeys.Mirror}`, String(val));
       return { mirror: val };
     }),
 }));

--- a/apps/client/src/features/app-settings/panel/sources-panel/import-map/importMapUtils.ts
+++ b/apps/client/src/features/app-settings/panel/sources-panel/import-map/importMapUtils.ts
@@ -1,5 +1,7 @@
 import { ImportCustom, ImportMap } from 'ontime-utils';
 
+import { baseURI } from '../../../../../externals';
+
 export type NamedImportMap = typeof namedImportMap;
 
 // Record of label and import name
@@ -64,11 +66,11 @@ export function convertToImportMap(namedImportMap: NamedImportMap): ImportMap {
 }
 
 export function persistImportMap(options: NamedImportMap) {
-  localStorage.setItem('ontime-import-options', JSON.stringify(options));
+  localStorage.setItem(`${baseURI}ontime-import-options`, JSON.stringify(options));
 }
 
 function getPersistImportMap(): unknown {
-  const options = localStorage.getItem('ontime-import-options');
+  const options = localStorage.getItem(`${baseURI}ontime-import-options`);
   if (!options) {
     throw new Error('no import options found');
   }

--- a/apps/client/src/features/control/playback/add-time/AddTime.tsx
+++ b/apps/client/src/features/control/playback/add-time/AddTime.tsx
@@ -6,6 +6,7 @@ import { MILLIS_PER_HOUR, MILLIS_PER_SECOND, parseUserTime } from 'ontime-utils'
 
 import TimeInput from '../../../../common/components/input/time-input/TimeInput';
 import { setPlayback } from '../../../../common/hooks/useSocket';
+import { baseURI } from '../../../../externals';
 import { tooltipDelayMid } from '../../../../ontimeConfig';
 import TapButton from '../tap-button/TapButton';
 
@@ -17,7 +18,7 @@ interface AddTimeProps {
 
 export default function AddTime(props: AddTimeProps) {
   const { playback } = props;
-  const [time, setTime] = useLocalStorage({ key: 'add-time', defaultValue: 300_000 }); // 5 minutes
+  const [time, setTime] = useLocalStorage({ key: `${baseURI}add-time`, defaultValue: 300_000 }); // 5 minutes
 
   const handleTimeChange = (_field: string, value: string) => {
     const newTime = parseUserTime(value);

--- a/apps/client/src/views/cuesheet/cuesheet-table/useColumnManager.tsx
+++ b/apps/client/src/views/cuesheet/cuesheet-table/useColumnManager.tsx
@@ -3,13 +3,18 @@ import { useLocalStorage } from '@mantine/hooks';
 import { ColumnDef } from '@tanstack/react-table';
 import { OntimeRundownEntry } from 'ontime-types';
 
+import { baseURI } from '../../../externals';
+
 export default function useColumnManager(columns: ColumnDef<OntimeRundownEntry>[]) {
-  const [columnVisibility, setColumnVisibility] = useLocalStorage({ key: 'table-hidden', defaultValue: {} });
+  const [columnVisibility, setColumnVisibility] = useLocalStorage({ key: `${baseURI}table-hidden`, defaultValue: {} });
   const [columnOrder, saveColumnOrder] = useLocalStorage<string[]>({
-    key: 'table-order',
+    key: `${baseURI}table-order`,
     defaultValue: columns.map((col) => col.id as string),
   });
-  const [columnSizing, setColumnSizing] = useLocalStorage({ key: 'table-sizes', defaultValue: {} });
+  const [columnSizing, setColumnSizing] = useLocalStorage({
+    key: `${baseURI}table-sizes`,
+    defaultValue: {},
+  });
 
   // if the columns change, we update the dataset
   useEffect(() => {

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ontime-electron",
-  "version": "3.16.0",
+  "version": "3.16.1",
   "author": "Carlos Valente",
   "description": "Time keeping for live events",
   "repository": "https://github.com/cpvalente/ontime",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -2,7 +2,7 @@
   "name": "ontime-server",
   "type": "module",
   "main": "src/index.ts",
-  "version": "3.16.0",
+  "version": "3.16.1",
   "exports": "./src/index.js",
   "dependencies": {
     "@googleapis/sheets": "^5.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ontime",
-  "version": "3.16.0",
+  "version": "3.16.1",
   "description": "Time keeping for live events",
   "keywords": [
     "ontime",


### PR DESCRIPTION
Fixes an issue where two stages could add conflicting data to localStorage
this is because the keys did not differentiate between the stages, and the stage differentiation hash is not part of the origin

Fixes the issue mentioned in #1729 

We will need a similar (but more elegant) change in v4

## NOTE: DO NOT MERGE THIS BRANCH