### PR TITLE
fix: ensure filename sanitation in all routes

### DIFF
--- a/apps/server/src/api-data/db/db.controller.ts
+++ b/apps/server/src/api-data/db/db.controller.ts
@@ -8,6 +8,7 @@ import {
 import { getErrorMessage } from 'ontime-utils';
 
 import type { Request, Response } from 'express';
+import sanitize from 'sanitize-filename';
 
 import {
   doesProjectExist,
@@ -74,7 +75,8 @@ export async function createProjectFile(req: Request, res: Response<{ filename: 
  */
 export async function quickProjectFile(req: Request, res: Response<{ filename: string } | ErrorResponse>) {
   try {
-    const filename = await projectService.createProject(req.body.project.title || 'untitled', req.body);
+    const nameFromTitle = req.body.project.title ? sanitize(req.body.project.title) : 'untitled';
+    const filename = await projectService.createProject(nameFromTitle, req.body);
     res.status(200).send({
       filename,
     });

--- a/apps/server/src/utils/upload.ts
+++ b/apps/server/src/utils/upload.ts
@@ -2,6 +2,7 @@ import multer from 'multer';
 import path from 'path';
 import fs from 'fs';
 import { rm } from 'fs/promises';
+import sanitize from 'sanitize-filename';
 
 import { getAppDataPath, publicDir } from '../setup/index.js';
 
@@ -39,7 +40,8 @@ export const storage = multer.diskStorage({
 
     ensureDirectory(publicDir.uploadsDir);
 
-    const filePath = path.join(publicDir.uploadsDir, file.originalname);
+    const sanitisedName = sanitize(file.originalname);
+    const filePath = path.join(publicDir.uploadsDir, sanitisedName);
 
     // Check if file already exists
     fs.access(filePath, fs.constants.F_OK, (err) => {


### PR DESCRIPTION
this is an attempt at fixing the user issue with the unescaped characters

The user seemed to have gotten a file named `'MemoriaÃ'$'\302\205'' Kamili Skolimowskiej 2025.json'` which broke the load

It turned out that our quick project and upload routes did not sanitise the file name. I was unable to find any other routes where the sanitation did not happen