### PR TITLE
fix: prevent dropping a group inside another

### DIFF
--- a/apps/client/src/features/rundown/rundown-event/RundownEvent.tsx
+++ b/apps/client/src/features/rundown/rundown-event/RundownEvent.tsx
@@ -163,7 +163,7 @@ export default function RundownEvent({
             icon: IoSwapVertical,
             onClick: () => {
               if (!selectedEventId) return;
-              swapEvents({ from: selectedEventId, to: eventId });
+              swapEvents(selectedEventId, eventId);
               clearSelectedEventId();
             },
             disabled: selectedEventId == null || selectedEventId === eventId,

--- a/apps/client/src/features/rundown/rundown-group/RundownGroup.tsx
+++ b/apps/client/src/features/rundown/rundown-group/RundownGroup.tsx
@@ -92,7 +92,7 @@ export default function RundownGroup({ data, hasCursor, collapsed, onCollapse }:
   };
 
   const binderColours = data.colour && getAccessibleColour(data.colour);
-  const isValidDrop = over?.id && canDrop(over.data.current?.type, over.data.current?.parent);
+  const isValidDrop = isDragging && over?.id && canDrop(over.data.current?.type, over.data.current?.parent);
 
   const [planOffset, planOffsetLabel] = (() => {
     if (data.targetDuration === null) {

--- a/apps/client/src/features/rundown/rundown.utils.ts
+++ b/apps/client/src/features/rundown/rundown.utils.ts
@@ -160,14 +160,23 @@ export function makeSortableList(order: EntryId[], entries: RundownEntries): Ent
  * Checks whether a drop operation is valid
  * Currently only used for validating dropping groups
  */
-export function canDrop(targetType?: SupportedEntry | 'end-group', targetParent?: EntryId | null): boolean {
+export function canDrop(
+  targetType: SupportedEntry | 'end-group',
+  targetParent: EntryId | null,
+  order?: 'after' | 'before',
+  isTargetCollapsed?: boolean,
+): boolean {
   // this would mean inserting a group inside another
   if (targetType === 'end-group') {
     return false;
   }
 
   // this means swapping places with another group
+  // !!! if the user is dragging down, they could be inserting into a group depending on whether the group is collapsed
   if (targetType === 'group') {
+    if (order !== undefined && order === 'after' && !isTargetCollapsed) {
+      return false;
+    }
     return true;
   }
 


### PR DESCRIPTION
Fixes two issues related to reordering:
- reordering groups would cause groups to be inserted one inside the other
- previous logic allowed groups to be added at the top of a group