### PR TITLE
fix: notify runtimeStore of events bieng groupd

### DIFF
--- a/apps/server/src/api-data/rundown/rundown.service.ts
+++ b/apps/server/src/api-data/rundown/rundown.service.ts
@@ -383,8 +383,8 @@ export async function groupEntries(entryIds: EntryId[]): Promise<Rundown> {
     // notify runtime that rundown has changed
     updateRuntimeOnChange(rundownMetadata);
 
-    // we dont need to notify the timer since the grouping does not affect the runtime
-    notifyChanges(rundownMetadata, revision, { external: true });
+    // we need to notify the timer since we might be grouping a running event
+    notifyChanges(rundownMetadata, revision, { external: true, timer: true });
   });
 
   return rundownResult;


### PR DESCRIPTION
fixes the edge case were grouping the running event would not update group metadata