### PR TITLE
fix: pass options to project download to allow folders beginning with a dot

### DIFF
--- a/apps/server/src/api-data/db/db.controller.ts
+++ b/apps/server/src/api-data/db/db.controller.ts
@@ -109,7 +109,7 @@ export async function projectDownload(req: Request, res: Response) {
     return;
   }
 
-  res.download(pathToFile, filename, (error) => {
+  res.download(pathToFile, filename, { dotfiles: 'allow' }, (error) => {
     if (error) {
       const message = getErrorMessage(error);
       res.status(500).send({ message });


### PR DESCRIPTION
Looks like when express got upgraded to v5 it bumped a dependency on a package called [send](https://www.npmjs.com/package/send) which [changed](https://github.com/pillarjs/send/compare/0.19.0...1.2.0#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R459) a default for `res.download` and now disallows folders beginning with a dot by default. For linux detected systems Ontime uses the `.Ontime` folder which means project downloads simply were returning a 404.