### PR TITLE
fix: add setup-node step back to resolve npm access issues

### DIFF
--- a/.github/workflows/build_cli.yml
+++ b/.github/workflows/build_cli.yml
@@ -14,6 +14,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # This step is only needed to setup the permissions to update npm as pnpm will setup the correct node version
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
 

--- a/.github/workflows/build_resolver.yml
+++ b/.github/workflows/build_resolver.yml
@@ -14,6 +14,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # This step is only needed to setup the permissions to update npm as pnpm will setup the correct node version
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
 


### PR DESCRIPTION
Looks like without the `setup-node` step the `npm` path [is not setup correctly](https://github.com/cpvalente/ontime/actions/runs/18590215455)

can do some more reading [here](https://github.com/actions/runner-images/issues/9644)