### PR TITLE
fix: use flat order when building flat rundown

### DIFF
--- a/apps/client/src/common/hooks-query/useRundown.ts
+++ b/apps/client/src/common/hooks-query/useRundown.ts
@@ -55,7 +55,7 @@ export function useFlatRundown() {
   // update data whenever the revision changes
   useEffect(() => {
     if (data.revision !== -1 || data.revision !== prevRevision) {
-      const flatRundown = data.order.map((id) => data.entries[id]);
+      const flatRundown = data.flatOrder.map((id) => data.entries[id]);
       setFlatRundown(flatRundown);
       setPrevRevision(data.revision);
     }


### PR DESCRIPTION
I've pretty behind on the ins and outs of the rundown architecture but this seems like the right move that the flatRundow should be built off the flatOrder. This resolves the issue of find not working on events inside groups (saw the issue during one of the demos in that live stream). Im not seeing that this has an impact in other areas but it's hard for to tell as I don't really understand the React-isms going on.

closes #1834 