### PR TITLE
refactor(operator): hide groups where all events have passed

### DIFF
--- a/apps/client/src/features/operator/Operator.tsx
+++ b/apps/client/src/features/operator/Operator.tsx
@@ -171,15 +171,11 @@ function Operator({ rundown, rundownMetadata, customFields, settings }: Operator
           }
 
           if (isOntimeGroup(entry)) {
-            const allEventsArePast = entry.entries.every((nestedEntryId) => {
-              const nestedEntry = rundown.entries[nestedEntryId];
-              if (!isOntimeEvent(nestedEntry)) return false;
+            const { isPast } = rundownMetadata[entry.id];
 
-              const { isPast } = rundownMetadata[nestedEntryId];
-              return isPast;
-            });
+            const isCurrentParent = selectedEventId ? rundownMetadata[selectedEventId].groupId === entry.id : false;
 
-            if (hidePast && allEventsArePast) {
+            if (hidePast && isPast && !isCurrentParent) {
               return null;
             }
 


### PR DESCRIPTION
## Changes made
- added a check under `<Operator />` where if all events are passed within a group, then not to render the group, provided the settings has been checked for hiding past events

Note: I was wondering if it would make sense to add an option under settings to hide groups or not separately. Not sure if it's a good idea to include it since if I opt in to not see the past events, I would not want to see that group either

## Working

https://github.com/user-attachments/assets/0af8df08-feec-4334-98da-22b8a41e4aae

