### PR TITLE
refactor: handle prefix on login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ override.css
 
 # working stuff
 **/TODO.md
+**.local.**
 
 # docker utils
 ontime-db

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -17,7 +17,7 @@ import { consoleSuccess, consoleHighlight, consoleError } from './utils/console.
 // Import middleware configuration
 import { bodyParser } from './middleware/bodyParser.js';
 import { compressedStatic } from './middleware/staticGZip.js';
-import { loginRouter, makeAuthenticateMiddleware } from './middleware/authenticate.js';
+import { makeLoginRouter, makeAuthenticateMiddleware } from './middleware/authenticate.js';
 
 // Import Routers
 import { appRouter } from './api-data/index.js';
@@ -83,6 +83,7 @@ app.options('*splat', cors()); // enable pre-flight cors
 app.use(bodyParser);
 app.use(cookieParser());
 const { authenticate, authenticateAndRedirect } = makeAuthenticateMiddleware(prefix);
+const loginRouter = makeLoginRouter(prefix);
 
 // implement health check route
 app.get(`${prefix}/health`, (_req, res) => {


### PR DESCRIPTION
This PR solves a few issues for users running Ontime behind a password
- post-login redirect should account for prefix
- scope cookies to each path by prefix

@alex-Arc I have tested this locally with Docker and it seems fine, but it would be good to have a second pair of eyes
Reach out if you have time to look together