### PR TITLE
fix: restore process sets currentDay

### DIFF
--- a/apps/server/src/services/restore-service/__tests__/restore.parser.test.ts
+++ b/apps/server/src/services/restore-service/__tests__/restore.parser.test.ts
@@ -13,6 +13,7 @@ describe('isRestorePoint()', () => {
       pausedAt: 3,
       firstStart: 1,
       startEpoch: 1,
+      currentDay: 0,
     };
     expect(isRestorePoint(restorePoint)).toBe(true);
 
@@ -24,6 +25,21 @@ describe('isRestorePoint()', () => {
       pausedAt: null,
       firstStart: 1,
       startEpoch: 1,
+      currentDay: 2,
+    };
+    expect(isRestorePoint(restorePoint)).toBe(true);
+  });
+
+  it('accepts null start fields', () => {
+    const restorePoint: RestorePoint = {
+      playback: Playback.Stop,
+      selectedEventId: null,
+      startedAt: null,
+      addedTime: 0,
+      pausedAt: null,
+      firstStart: null,
+      startEpoch: null,
+      currentDay: null,
     };
     expect(isRestorePoint(restorePoint)).toBe(true);
   });
@@ -59,6 +75,40 @@ describe('isRestorePoint()', () => {
         addedTime: 0,
         pausedAt: null,
         groupStartAt: 10,
+        startEpoch: 1,
+      };
+      expect(isRestorePoint(restorePoint)).toBe(false);
+    });
+    it('with missing firstStart', () => {
+      const restorePoint = {
+        playback: Playback.Roll,
+        selectedEventId: '123',
+        startedAt: null,
+        addedTime: 0,
+        pausedAt: null,
+        startEpoch: 1,
+      };
+      expect(isRestorePoint(restorePoint)).toBe(false);
+    });
+    it('with missing startEpoch', () => {
+      const restorePoint = {
+        playback: Playback.Roll,
+        selectedEventId: '123',
+        startedAt: null,
+        addedTime: 0,
+        pausedAt: null,
+        firstStart: 1,
+      };
+      expect(isRestorePoint(restorePoint)).toBe(false);
+    });
+    it('with missing currentDay', () => {
+      const restorePoint = {
+        playback: Playback.Roll,
+        selectedEventId: '123',
+        startedAt: null,
+        addedTime: 0,
+        pausedAt: null,
+        firstStart: 1,
         startEpoch: 1,
       };
       expect(isRestorePoint(restorePoint)).toBe(false);

--- a/apps/server/src/services/restore-service/__tests__/restore.service.test.ts
+++ b/apps/server/src/services/restore-service/__tests__/restore.service.test.ts
@@ -17,6 +17,7 @@ describe('restoreService', () => {
         pausedAt: 9087,
         firstStart: 1234,
         startEpoch: 1234,
+        currentDay: 0,
       };
 
       const mockRead = vi.fn().mockResolvedValue(expected);
@@ -35,6 +36,7 @@ describe('restoreService', () => {
         pausedAt: null,
         firstStart: 1234,
         startEpoch: 1234,
+        currentDay: null,
       };
 
       const mockRead = vi.fn().mockResolvedValue(expected);
@@ -82,12 +84,46 @@ describe('restoreService', () => {
         pausedAt: 1234,
         firstStart: 1234,
         startEpoch: 1234,
+        currentDay: 0,
       };
 
       const mockWrite = vi.fn().mockResolvedValue(undefined);
 
       await restoreService.save(testData, mockWrite);
       expect(mockWrite).toHaveBeenCalledWith(testData);
+    });
+
+    it('writes updated data when values change', async () => {
+      const firstData: RestorePoint = {
+        playback: Playback.Play,
+        selectedEventId: '2345',
+        startedAt: 2345,
+        addedTime: 2345,
+        pausedAt: 2345,
+        firstStart: 2345,
+        startEpoch: 2345,
+        currentDay: 0,
+      };
+
+      const updatedData: RestorePoint = {
+        playback: Playback.Pause,
+        selectedEventId: '3456',
+        startedAt: 3456,
+        addedTime: 3456,
+        pausedAt: 3456,
+        firstStart: 3456,
+        startEpoch: 3456,
+        currentDay: 1,
+      };
+
+      const mockWrite = vi.fn().mockResolvedValue(undefined);
+
+      await restoreService.save(firstData, mockWrite);
+      await restoreService.save(updatedData, mockWrite);
+
+      expect(mockWrite).toHaveBeenCalledTimes(2);
+      expect(mockWrite).toHaveBeenNthCalledWith(1, firstData);
+      expect(mockWrite).toHaveBeenNthCalledWith(2, updatedData);
     });
 
     it('handles write failures gracefully', async () => {
@@ -99,6 +135,7 @@ describe('restoreService', () => {
         pausedAt: 5678,
         firstStart: 5678,
         startEpoch: 5678,
+        currentDay: 0,
       };
 
       const mockWrite = vi.fn().mockRejectedValue(new Error('Write failed'));

--- a/apps/server/src/services/restore-service/restore.parser.ts
+++ b/apps/server/src/services/restore-service/restore.parser.ts
@@ -21,6 +21,7 @@ export function isRestorePoint(restorePoint: unknown): restorePoint is RestorePo
       'pausedAt',
       'firstStart',
       'startEpoch',
+      'currentDay',
     ])
   ) {
     return false;
@@ -51,6 +52,10 @@ export function isRestorePoint(restorePoint: unknown): restorePoint is RestorePo
   }
 
   if (!is.number(restorePoint.startEpoch) && restorePoint.startEpoch !== null) {
+    return false;
+  }
+
+  if (!is.number(restorePoint.currentDay) && restorePoint.currentDay !== null) {
     return false;
   }
 

--- a/apps/server/src/services/restore-service/restore.type.ts
+++ b/apps/server/src/services/restore-service/restore.type.ts
@@ -8,4 +8,5 @@ export type RestorePoint = {
   pausedAt: MaybeNumber;
   firstStart: MaybeNumber;
   startEpoch: MaybeNumber;
+  currentDay: MaybeNumber;
 };

--- a/apps/server/src/services/runtime-service/runtime.service.ts
+++ b/apps/server/src/services/runtime-service/runtime.service.ts
@@ -759,6 +759,7 @@ function broadcastResult(_target: any, _propertyKey: string, descriptor: Propert
           pausedAt: state._timer.pausedAt,
           firstStart: state.rundown.actualStart,
           startEpoch: state._startEpoch,
+          currentDay: state.rundown.currentDay,
         })
         .catch((_e) => {
           //we don't do anything with the error here

--- a/apps/server/src/stores/runtimeState.ts
+++ b/apps/server/src/stores/runtimeState.ts
@@ -246,12 +246,19 @@ export function load(
     patchTimer(initialData);
     const startEpoch = initialData?.startEpoch;
     const firstStart = initialData?.firstStart;
+    const currentDay = initialData?.currentDay;
     if (
       (firstStart === null || typeof firstStart === 'number') &&
       (startEpoch === null || typeof startEpoch === 'number')
     ) {
       runtimeState.rundown.actualStart = firstStart;
       runtimeState._startEpoch = startEpoch;
+      if (firstStart !== null && runtimeState.rundown.plannedStart !== null) {
+        runtimeState._startDayOffset = findDayOffset(runtimeState.rundown.plannedStart, firstStart);
+      }
+      if (currentDay !== undefined) {
+        runtimeState.rundown.currentDay = currentDay;
+      }
       const { absolute, relative } = getRuntimeOffset(runtimeState);
       runtimeState.offset.absolute = absolute;
       runtimeState.offset.relative = relative;


### PR DESCRIPTION
currentDay did not get persisted across restores and was lost.
This caused some bugs in some of our views which assume current day is there as long as we were playing