### PR TITLE
User Docker metadata action to setup tags

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -37,7 +37,7 @@ jobs:
         run: pnpm build:docker
 
       - name: Docker Login
-        uses: docker/login-action@v2.1.0
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -56,8 +56,7 @@ jobs:
             type=raw,value=nightly,enable=${{ github.event.release.prerelease == true }}
 
       - name: Build and push stable release
-        if: github.event.release.prerelease == false
-        uses: docker/build-push-action@v4.0.0
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
           file: ./Dockerfile


### PR DESCRIPTION
The docker metadata action will setup the following tags on regular release like `4.2.1` -> `v4.2.1, v4, latest` on a pre-release like `v4.2.1-beta.1` it will set tags to `v4.2.1-beta.1, nightly`. The tags will start with a `v` regardless of if the created tag starts with a `v` or not.

This does add the concept of the major version tag so `v4` docker tag will always point to the latest `v4` release which I do see in a lot of images and can be useful for end users. 