### PR TITLE
Fix: automation

### DIFF
--- a/apps/server/src/api-data/automation/__tests__/automation.service.test.ts
+++ b/apps/server/src/api-data/automation/__tests__/automation.service.test.ts
@@ -468,6 +468,16 @@ describe('testConditions()', () => {
         value: 'Title',
         state: 'Title',
       },
+      {
+        description: 'case sensitive',
+        value: 'title',
+        state: 'Title',
+      },
+      {
+        description: 'number does contain string',
+        value: '10',
+        state: 2105,
+      },
     ])('$description', ({ value, state }) => {
       expect(
         testConditions([{ field: 'test.path', operator: 'contains', value }], 'all', {
@@ -485,35 +495,14 @@ describe('testConditions()', () => {
   describe('not_contains', () => {
     test.each([
       {
+        description: 'number does not contain substring',
+        value: '456',
+        state: 12345,
+      },
+      {
         description: 'substring not in string',
         value: 'sound',
         state: 'testing-lighting-10',
-      },
-      {
-        description: 'case sensitive',
-        value: 'title', // TODO: is this the desired behavior?
-        state: 'Title',
-      },
-    ])('$description', ({ value, state }) => {
-      expect(
-        testConditions([{ field: 'test.path', operator: 'not_contains', value }], 'all', {
-          test: { path: state },
-        } as unknown as RuntimeState),
-      ).toBe(true);
-      expect(
-        testConditions([{ field: 'test.path', operator: 'contains', value }], 'all', {
-          test: { path: state },
-        } as unknown as RuntimeState),
-      ).toBe(false);
-    });
-  });
-
-  describe('edge case contains', () => {
-    test.each([
-      {
-        description: 'number does not contain string',
-        value: '10',
-        state: 10, // TODO: is this the desired behavior? All the fields contain the value when converted to string.
       },
       {
         description: 'string and undefined',
@@ -535,24 +524,14 @@ describe('testConditions()', () => {
         value: 'false',
         state: false,
       },
-      {
-        description: 'number does not contain substring',
-        value: '234',
-        state: 12345, // TODO: is this the desired behavior?
-      },
-      {
-        description: 'number does not contain different substring',
-        value: '456',
-        state: 12345, // TODO: is this the desired behavior?
-      },
     ])('$description', ({ value, state }) => {
       expect(
-        testConditions([{ field: 'test.path', operator: 'contains', value }], 'all', {
+        testConditions([{ field: 'test.path', operator: 'not_contains', value }], 'all', {
           test: { path: state },
         } as unknown as RuntimeState),
-      ).toBe(false);
+      ).toBe(true);
       expect(
-        testConditions([{ field: 'test.path', operator: 'not_contains', value }], 'all', {
+        testConditions([{ field: 'test.path', operator: 'contains', value }], 'all', {
           test: { path: state },
         } as unknown as RuntimeState),
       ).toBe(false);

--- a/apps/server/src/api-data/automation/automation.service.ts
+++ b/apps/server/src/api-data/automation/automation.service.ts
@@ -17,7 +17,7 @@ import { isOntimeCloud } from '../../setup/environment.js';
 import { emitOSC } from './clients/osc.client.js';
 import { emitHTTP } from './clients/http.client.js';
 import { getAutomationsEnabled, getAutomations, getAutomationTriggers } from './automation.dao.js';
-import { isEquivalent, isGreaterThan, isLessThan } from './automation.utils.js';
+import { isContained, isEquivalent, isGreaterThan, isLessThan } from './automation.utils.js';
 import { toOntimeAction } from './clients/ontime.client.js';
 
 /**
@@ -100,9 +100,9 @@ export function testConditions(
       case 'less_than':
         return isLessThan(fieldValue, value);
       case 'contains':
-        return typeof fieldValue === 'string' && fieldValue.includes(value);
+        return isContained(fieldValue, lowerCasedValue);
       case 'not_contains':
-        return typeof fieldValue === 'string' && !fieldValue.includes(value);
+        return !isContained(fieldValue, lowerCasedValue);
       default: {
         operator satisfies never;
         return false;

--- a/apps/server/src/api-data/automation/automation.utils.ts
+++ b/apps/server/src/api-data/automation/automation.utils.ts
@@ -165,6 +165,21 @@ export function isEquivalent(a: unknown, b: string): boolean {
   return a == b;
 }
 
+export function isContained(a: unknown, b: string): boolean {
+  // handle the case where we are comparing boolean strings
+  if (typeof a === 'boolean') {
+    return false;
+  }
+  // make string comparisons case insensitive
+  if (typeof a === 'string') {
+    return a.toLowerCase().includes(b);
+  }
+  if (typeof a === 'number') {
+    return a.toString().toLowerCase().includes(b);
+  }
+  return false;
+}
+
 /**
  * Utility encapsulates logic for comparing two strings which may encode numbers
  * @example isGreaterThan('10', '5') // true


### PR DESCRIPTION
continues the work from @DelBiss in pr #1933 

decisions that we need to make:
- should all comparisons be lower cased?
- "some value" `contains` "" should that be true?
- should all `not_` operations always be the invers of their counterpart?