### PR TITLE
refactor: add opts and logic to allow submit on enter only under cuesheet line cell for time inputs

### DIFF
--- a/apps/client/src/common/components/input/text-input/useReactiveTextInput.tsx
+++ b/apps/client/src/common/components/input/text-input/useReactiveTextInput.tsx
@@ -18,6 +18,7 @@ export default function useReactiveTextInput(
     onCancelUpdate?: () => void;
     allowSubmitSameValue?: boolean;
     allowKeyboardNavigation?: boolean;
+    allowSubmitOnEnterOnly?: boolean;
   },
 ): UseReactiveTextInputReturn {
   const [text, setText] = useState<string>(initialText);
@@ -50,9 +51,16 @@ export default function useReactiveTextInput(
    * @param {string} valueToSubmit
    */
   const handleSubmit = useCallback(
-    (valueToSubmit: string) => {
+    (valueToSubmit: string, triggeredKey?: string) => {
       // No need to update if it hasn't changed
       if (valueToSubmit === initialText && !options?.allowSubmitSameValue) {
+        options?.onCancelUpdate?.();
+      } else if (
+        valueToSubmit === initialText &&
+        options?.allowSubmitOnEnterOnly &&
+        triggeredKey !== 'Enter' &&
+        triggeredKey !== 'mod + Enter'
+      ) {
         options?.onCancelUpdate?.();
       } else {
         const cleanVal = valueToSubmit.trim();
@@ -105,7 +113,7 @@ export default function useReactiveTextInput(
         'Enter',
         () => {
           isKeyboardSubmitting.current = true;
-          handleSubmit(text);
+          handleSubmit(text, 'Enter');
           // clear flag after blur has been processed
           setTimeout(() => {
             isKeyboardSubmitting.current = false;
@@ -119,7 +127,7 @@ export default function useReactiveTextInput(
         'mod + Enter',
         () => {
           isKeyboardSubmitting.current = true;
-          handleSubmit(text);
+          handleSubmit(text, 'mod + Enter');
           // clear flag after blur has been processed
           setTimeout(() => {
             isKeyboardSubmitting.current = false;

--- a/apps/client/src/common/components/input/text-input/useReactiveTextInput.tsx
+++ b/apps/client/src/common/components/input/text-input/useReactiveTextInput.tsx
@@ -56,7 +56,6 @@ export default function useReactiveTextInput(
       if (valueToSubmit === initialText && !options?.allowSubmitSameValue) {
         options?.onCancelUpdate?.();
       } else if (
-        valueToSubmit === initialText &&
         options?.allowSubmitOnEnterOnly &&
         triggeredKey !== 'Enter' &&
         triggeredKey !== 'mod + Enter'

--- a/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/SingleLineCell.tsx
+++ b/apps/client/src/views/cuesheet/cuesheet-table/cuesheet-table-elements/SingleLineCell.tsx
@@ -18,6 +18,7 @@ const SingleLineCell = forwardRef(
     const { value, onChange, onBlur, onKeyDown } = useReactiveTextInput(initialValue, submitCallback, ref, {
       allowSubmitSameValue,
       allowKeyboardNavigation: true,
+      allowSubmitOnEnterOnly: true,
       submitOnEnter: true, // single line should submit on enter
       submitOnCtrlEnter: true,
       onCancelUpdate: handleCancelUpdate,


### PR DESCRIPTION
## Changes made

- added a `allowSubmitOnEnterOnly` field under opts for `useReactiveTextInput` hook
- passing an optional parameter of `triggeredKey` under handleSubmit to keep track of whether user pressed submit or not
- added an else-if check under `handleSubmit` which implements the behavior to cancel update unless user pressed enter or mod+enter to submit the same value
- passed the `allowSubmitOnEnterOnly` option as true under `<SingleLineCell />` under cuesheet-table-elements

Working demo:


https://github.com/user-attachments/assets/748b0b24-0d78-44ba-a02c-0c347c8c1ac8

