### PR TITLE
fix: update data in background rundowns

### DIFF
--- a/apps/server/src/api-data/rundown/rundown.service.ts
+++ b/apps/server/src/api-data/rundown/rundown.service.ts
@@ -499,7 +499,7 @@ export async function editCustomField(
       if (rundownId !== rundown.id) {
         const backgroundRundown = structuredClone(projectRundowns[rundownId]);
         customFieldMutation.renameUsages(backgroundRundown, oldKey, newKey);
-        updateBackgroundRundown(rundown.id, backgroundRundown);
+        updateBackgroundRundown(rundownId, backgroundRundown);
       }
     }
 
@@ -539,7 +539,7 @@ export async function deleteCustomField(key: CustomFieldKey, projectRundowns: Pr
     if (rundownId !== rundown.id) {
       const backgroundRundown = structuredClone(projectRundowns[rundownId]);
       customFieldMutation.removeUsages(backgroundRundown, key);
-      updateBackgroundRundown(rundown.id, backgroundRundown);
+      updateBackgroundRundown(rundownId, backgroundRundown);
     }
   }
 


### PR DESCRIPTION
fixes a bug when updating background rundowns.
testing:
- create a custom field: `test`
- make a rundown and add an event with some data in `test
- make a second rundown also with an event in the `test` custom field
- in custom fields, rename `test` to `test-new`
- verify that the field is updated in both rundowns