### PR TITLE
refactor: debounce writing to disk

### DIFF
--- a/apps/server/src/api-data/rundown/rundown.dao.ts
+++ b/apps/server/src/api-data/rundown/rundown.dao.ts
@@ -110,11 +110,6 @@ export function createTransaction(options: TransactionOptions): Transaction {
   function commit(shouldProcess: boolean = true) {
     // if the rundown is mutable we persist the changes
     if (options.mutableRundown) {
-      // schedule a database update
-      setImmediate(async () => {
-        await getDataProvider().setRundown(cachedRundown.id, cachedRundown);
-      });
-
       // update fields which are agnostic of whether the rundown is processed
       cachedRundown.revision = cachedRundown.revision + 1;
       cachedRundown.title = rundown.title;
@@ -135,16 +130,17 @@ export function createTransaction(options: TransactionOptions): Transaction {
         cachedRundown.flatOrder = metadata.flatEntryOrder;
         rundownMetadata = metadata;
       }
+
+      // persist after all mutations are applied
+      getDataProvider().setRundown(cachedRundown.id, cachedRundown);
     }
 
     // if the customFields are mutable we persist the changes
     if (options.mutableCustomFields) {
-      // schedule a database update
-      setImmediate(async () => {
-        await getDataProvider().setCustomFields(projectCustomFields);
-      });
-
       projectCustomFields = customFields;
+
+      // persist after reassignment
+      getDataProvider().setCustomFields(projectCustomFields);
     }
 
     return {
@@ -598,10 +594,8 @@ export const rundownMutation = {
 /**
  * Exposes a way to update a rundown which is not active
  */
-export function updateBackgroundRundown(rundownId: string, rundown: Rundown) {
-  setImmediate(async () => {
-    await getDataProvider().setRundown(rundownId, rundown);
-  });
+export async function updateBackgroundRundown(rundownId: string, rundown: Rundown) {
+  await getDataProvider().setRundown(rundownId, rundown);
 }
 
 /**
@@ -698,9 +692,7 @@ export function init(initialRundown: Readonly<Rundown>, initialCustomFields: Rea
   rundownMetadata = metadata;
 
   // defer writing to the database
-  setImmediate(async () => {
-    await getDataProvider().setRundown(cachedRundown.id, cachedRundown);
-  });
+  getDataProvider().setRundown(cachedRundown.id, cachedRundown);
 
   return { rundown, rundownMetadata, customFields, revision: rundown.revision };
 }

--- a/apps/server/src/api-data/rundown/rundown.service.ts
+++ b/apps/server/src/api-data/rundown/rundown.service.ts
@@ -499,7 +499,7 @@ export async function editCustomField(
       if (rundownId !== rundown.id) {
         const backgroundRundown = structuredClone(projectRundowns[rundownId]);
         customFieldMutation.renameUsages(backgroundRundown, oldKey, newKey);
-        updateBackgroundRundown(rundownId, backgroundRundown);
+        await updateBackgroundRundown(rundownId, backgroundRundown);
       }
     }
 
@@ -539,7 +539,7 @@ export async function deleteCustomField(key: CustomFieldKey, projectRundowns: Pr
     if (rundownId !== rundown.id) {
       const backgroundRundown = structuredClone(projectRundowns[rundownId]);
       customFieldMutation.removeUsages(backgroundRundown, key);
-      updateBackgroundRundown(rundownId, backgroundRundown);
+      await updateBackgroundRundown(rundownId, backgroundRundown);
     }
   }
 

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -25,7 +25,7 @@ import { integrationRouter } from './api-integration/integration.router.js';
 
 // Import adapters
 import { socket } from './adapters/WebsocketAdapter.js';
-import { getDataProvider } from './classes/data-provider/DataProvider.js';
+import { getDataProvider, flushPendingWrites } from './classes/data-provider/DataProvider.js';
 
 // Services
 import { logger } from './classes/Logger.js';
@@ -265,6 +265,10 @@ export const startIntegrations = async () => {
  */
 export const shutdown = async (exitCode = 0) => {
   consoleHighlight(`Ontime shutting down with code ${exitCode}`);
+
+  await flushPendingWrites().catch((_error) => {
+    /** nothing do to here */
+  });
 
   // clear the restore file if it was a normal exit
   // 0 means it was a SIGNAL


### PR DESCRIPTION
The idea of this PR is to debounce writing to the disk
this means we accept a window were a crash could lose data since the last write (as of now, 3 seconds)

we expect that this would give improvements to batch operations like import
we could consider widening the window to about 20 seconds which would likely give us a good performance when people are filling in the rundowns at the added risk of data loss