### PR TITLE
feat: allow existing custom fields to keep its type

### DIFF
--- a/apps/server/src/api-data/excel/excel.utils.ts
+++ b/apps/server/src/api-data/excel/excel.utils.ts
@@ -33,10 +33,11 @@ export function getCustomFieldData(
     // we lower case the excel key to make it easier to match
     const columnNameInExcel = importMap.custom[ontimeLabel].toLowerCase();
     const maybeExistingColour = existingCustomFields[keyInCustomFields]?.colour ?? '';
+    const maybeExistingType = existingCustomFields[keyInCustomFields]?.type ?? 'text';
 
     // 1. add the custom field to the merged custom fields
     mergedCustomFields[keyInCustomFields] = {
-      type: 'text', // we currently only support text custom fields
+      type: maybeExistingType,
       colour: maybeExistingColour,
       label: ontimeLabel,
     };


### PR DESCRIPTION
inspired by #1972

this is very small change that just allows predefined custom fields to keep their type when importing from excel 