### PR TITLE
fix: prevent settings reflow on small width screens

### DIFF
--- a/apps/client/src/features/app-settings/panel-content/PanelContent.module.scss
+++ b/apps/client/src/features/app-settings/panel-content/PanelContent.module.scss
@@ -9,7 +9,8 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  width: 100%;
+  flex: 1 1 auto;
+  min-width: 0;
   position: relative;
 }
 

--- a/apps/client/src/features/app-settings/panel-list/PanelList.module.scss
+++ b/apps/client/src/features/app-settings/panel-list/PanelList.module.scss
@@ -7,6 +7,8 @@ ul {
 
 .tabs {
   width: min(30vw, 300px);
+  flex: 0 0 min(30vw, 300px);
+  min-width: min(30vw, 300px);
   display: flex;
   flex-direction: column;
   overflow-y: auto;


### PR DESCRIPTION
Fixes a small issue where the settings navigation menu would reflow and cause layout shifts

To reproduce:
- shrink the browser window to about 500px
- navigate to editor settings
- select Project settings (now has two lines)
- select other navigation entry (project settings now has a single line)

