### PR TITLE
refactor: improve app quit in windows

### DIFF
--- a/apps/electron/src/menu/applicationMenu.js
+++ b/apps/electron/src/menu/applicationMenu.js
@@ -28,7 +28,7 @@ const {
 function getApplicationMenu(askToQuit, clientUrl, serverUrl, redirectWindow, showDialog, download) {
   const template = [
     ...(isMac ? [makeMacMenu(askToQuit)] : []),
-    makeFileMenu(serverUrl, redirectWindow, showDialog, download),
+    makeFileMenu(askToQuit, serverUrl, redirectWindow, showDialog, download),
     makeEditMenu(),
     makeViewMenu(clientUrl),
     makeSettingsMenu(redirectWindow),
@@ -56,7 +56,7 @@ function makeMacMenu(askToQuit) {
       {
         label: 'Quit',
         click: askToQuit,
-        accelerator: isMac ? 'Cmd+Q' : 'Alt+F4',
+        accelerator: 'Cmd+Q',
       },
     ],
   };
@@ -86,7 +86,7 @@ function makeEditMenu() {
  * @param {function} download - function to download a resource from url
  * @returns {Object}
  */
-function makeFileMenu(serverUrl, redirectWindow, showDialog, download) {
+function makeFileMenu(askToQuit, serverUrl, redirectWindow, showDialog, download) {
   const downloadProject = () => {
     try {
       download(serverUrl + downloadPath);
@@ -134,7 +134,9 @@ function makeFileMenu(serverUrl, redirectWindow, showDialog, download) {
         ],
       },
       { type: 'separator' },
-      { role: isMac ? 'close' : 'quit' },
+      isMac
+        ? { role: 'close' }
+        : { label: 'Quit', click: askToQuit, accelerator: 'Alt+F4' },
     ],
   };
 }


### PR DESCRIPTION
In MacOS when the user clicks cmd+q we bring the app to foreground and show the shutdown page.
This change makes a similar flow for alt + f4 in windows

Hopefully an improvement to #2011 