### PR TITLE
feat: improve smart time entry

### DIFF
--- a/packages/utils/src/date-utils/parseUserTime.test.ts
+++ b/packages/utils/src/date-utils/parseUserTime.test.ts
@@ -30,6 +30,22 @@ describe('test parseUserTime()', () => {
     }
   });
 
+  describe('infer unit from bigger unit', () => {
+    const testData = [
+      { value: '1h2', expect: MILLIS_PER_HOUR + 2 * MILLIS_PER_MINUTE },
+      { value: '1h2s', expect: MILLIS_PER_HOUR + 2 * MILLIS_PER_SECOND },
+      { value: '1m2', expect: MILLIS_PER_MINUTE + 2 * MILLIS_PER_SECOND },
+      { value: '1m2s', expect: MILLIS_PER_MINUTE + 2 * MILLIS_PER_SECOND },
+    ];
+
+    for (const s of testData) {
+      it(`handles ${s.value}`, () => {
+        expect(typeof parseUserTime(s.value)).toBe('number');
+        expect(parseUserTime(s.value)).toBe(s.expect);
+      });
+    }
+  });
+
   describe('parses strings correctly', () => {
     const ts = [
       { value: '1.1.1', expect: MILLIS_PER_HOUR + MILLIS_PER_MINUTE + MILLIS_PER_SECOND },

--- a/packages/utils/src/date-utils/parseUserTime.ts
+++ b/packages/utils/src/date-utils/parseUserTime.ts
@@ -116,12 +116,14 @@ function checkMatchers(value: string): number | null {
   // if there's a number after 'h' without a unit and it's not followed by 's', treat it as minutes
   const implicitMinutesValue = hoursMatch?.[2] ? parse(hoursMatch[2]) : 0;
 
-  const minutesMatch = /(\d+)m/i.exec(value);
+  const minutesMatch = /(\d+)m(?:(\d+)?)/i.exec(value);
   // only use implicit minutes if there's no explicit minutes match
   const minutesMatchValue = minutesMatch ? parse(minutesMatch[1]) : implicitMinutesValue;
+  // if there's a number after 'm' without a unit treat it as seconds
+  const implicitSecondsValue = minutesMatch?.[2] ? parse(minutesMatch[2]) : 0;
 
   const secondsMatch = /(\d+)s/i.exec(value);
-  const secondsMatchValue = secondsMatch ? parse(secondsMatch[1]) : 0;
+  const secondsMatchValue = secondsMatch ? parse(secondsMatch[1]) : implicitSecondsValue;
 
   if (hoursMatch || minutesMatch || secondsMatch) {
     return (


### PR DESCRIPTION
`1m3` -> 1m 3s