### PR TITLE
fix: enable cjs interop while we migrate packages

### DIFF
--- a/apps/client/src/features/app-settings/panel/settings-panel/composite/StyleEditor.tsx
+++ b/apps/client/src/features/app-settings/panel/settings-panel/composite/StyleEditor.tsx
@@ -1,8 +1,9 @@
 import { memo } from 'react';
 import Editor from 'react-simple-code-editor';
-import Prism from 'virtual:prismjs';
-import 'prismjs/components/prism-css';
+
 import 'prismjs/themes/prism-tomorrow.min.css';
+import Prism from 'virtual:prismjs';
+
 import style from './StyleEditor.module.scss';
 
 interface CodeEditorProps {

--- a/apps/client/vite.config.js
+++ b/apps/client/vite.config.js
@@ -17,6 +17,11 @@ const ReactCompilerConfig = {
 
 export default defineConfig({
   base: './', // Ontime cloud: we use relative paths to allow them to reference a dynamic base set at runtime
+  legacy: {
+    // Temporary compatibility for CJS packages affected by Vite 8 interop changes.
+    // ie: react-simple-code-editor
+    inconsistentCjsInterop: true,
+  },
   define: {
     // we pass along the NODE_ENV here in case it is a docker build
     'import.meta.env.IS_DOCKER': process.env.NODE_ENV === 'docker',


### PR DESCRIPTION
It looks like vite has changed how we interop with cjs imports
https://vite.dev/guide/migration

for now I have enabled compatibility mode since we dont know what is broken

You can verify by opening the CSS Editor modal in master, it should crash the UI without the fix

I have added a todo to migrate to something else than `react-simple-code-editor`