### PR TITLE
refactor: adjusting flow for adding automations

### DIFF
--- a/apps/client/src/features/rundown/entry-editor/composite/EventEditorTriggers.module.scss
+++ b/apps/client/src/features/rundown/entry-editor/composite/EventEditorTriggers.module.scss
@@ -4,18 +4,6 @@
   gap: 0.75rem;
 }
 
-.section,
-.formSection {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.sectionTitle {
-  font-size: $aux-text-size;
-  color: $label-gray;
-}
-
 .triggerList {
   display: flex;
   flex-direction: column;
@@ -25,25 +13,14 @@
   overflow: hidden;
 }
 
-.triggerForm {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.formFields {
+.triggerHeader {
   display: grid;
-  grid-template-columns: 8rem 1fr;
-  gap: 0.75rem;
-  align-items: end;
-}
-
-.formActions {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 0.75rem;
-  min-height: 2rem;
+  grid-template-columns: 8rem 1fr 2rem;
+  gap: 0.5rem;
+  padding: 0.375rem 0.75rem;
+  font-size: $aux-text-size;
+  color: $label-gray;
+  border-bottom: 1px solid $white-10;
 }
 
 .trigger {
@@ -51,40 +28,10 @@
   display: grid;
   grid-template-columns: 8rem 1fr 2rem;
   align-items: center;
+  gap: 0.5rem;
   min-height: 2.5rem;
 
   &:not(:first-child) {
     border-top: 1px solid $white-10;
   }
-}
-
-.triggerMeta {
-  min-width: 0;
-}
-
-.metaLabel {
-  color: $label-gray;
-  font-size: $aux-text-size;
-  line-height: 1.2;
-  margin-bottom: 0.125rem;
-}
-
-.automationTitle {
-  overflow-wrap: anywhere;
-}
-
-.validationError,
-.validationSuccess {
-  display: flex;
-  align-items: center;
-  gap: 0.375rem;
-  font-size: $aux-text-size;
-}
-
-.validationError {
-  color: $red-500;
-}
-
-.validationSuccess {
-  color: $green-500;
 }

--- a/apps/client/src/features/rundown/entry-editor/composite/EventEditorTriggers.module.scss
+++ b/apps/client/src/features/rundown/entry-editor/composite/EventEditorTriggers.module.scss
@@ -33,4 +33,16 @@
   &:not(:first-child) {
     border-top: 1px solid $white-10;
   }
+
+  &[data-duplicate] {
+    > button:not(:last-child) {
+      border-color: $orange-500;
+    }
+  }
+}
+
+.duplicateMessage {
+  padding-left: 0.75rem;
+  font-size: $aux-text-size;
+  color: $orange-500;
 }

--- a/apps/client/src/features/rundown/entry-editor/composite/EventEditorTriggers.module.scss
+++ b/apps/client/src/features/rundown/entry-editor/composite/EventEditorTriggers.module.scss
@@ -20,7 +20,6 @@
   padding: 0.375rem 0.75rem;
   font-size: $aux-text-size;
   color: $label-gray;
-  border-bottom: 1px solid $white-10;
 }
 
 .trigger {

--- a/apps/client/src/features/rundown/entry-editor/composite/EventEditorTriggers.tsx
+++ b/apps/client/src/features/rundown/entry-editor/composite/EventEditorTriggers.tsx
@@ -1,4 +1,4 @@
-import { NormalisedAutomation, TimerLifeCycle, Trigger, timerLifecycleValues } from 'ontime-types';
+import { TimerLifeCycle, Trigger, timerLifecycleValues } from 'ontime-types';
 import { generateId } from 'ontime-utils';
 import { Fragment, useCallback } from 'react';
 import { IoAdd, IoTrash } from 'react-icons/io5';

--- a/apps/client/src/features/rundown/entry-editor/composite/EventEditorTriggers.tsx
+++ b/apps/client/src/features/rundown/entry-editor/composite/EventEditorTriggers.tsx
@@ -123,7 +123,7 @@ export default function EventEditorTriggers({ triggers, eventId }: EventEditorTr
       )}
       {allAutomationOptions.length === 0 ? (
         <Editor.Label>
-          No automations defined. <a href='?settings=automation'>Manage automations</a> to add some.
+          No automations defined.
         </Editor.Label>
       ) : (
         <Button variant='ghosted' onClick={handleAdd} disabled={getNextAvailable() === null}>

--- a/apps/client/src/features/rundown/entry-editor/composite/EventEditorTriggers.tsx
+++ b/apps/client/src/features/rundown/entry-editor/composite/EventEditorTriggers.tsx
@@ -1,7 +1,7 @@
 import { NormalisedAutomation, TimerLifeCycle, Trigger, timerLifecycleValues } from 'ontime-types';
 import { generateId } from 'ontime-utils';
-import { Fragment, useCallback, useMemo, useState } from 'react';
-import { IoAlertCircle, IoCheckmarkCircle, IoTrash } from 'react-icons/io5';
+import { Fragment, useCallback } from 'react';
+import { IoAdd, IoTrash } from 'react-icons/io5';
 
 import Button from '../../../../common/components/buttons/Button';
 import IconButton from '../../../../common/components/buttons/IconButton';
@@ -21,174 +21,100 @@ interface EventEditorTriggersProps {
 
 export default function EventEditorTriggers({ triggers, eventId }: EventEditorTriggersProps) {
   const { data: automationSettings, status: automationStatus } = useAutomationSettings();
+  const { updateEntry } = useEntryActionsContext();
   const automationsEnabled = automationStatus === 'pending' ? undefined : automationSettings.enabledAutomations;
-  const showTriggers = triggers.length > 0;
+
+  const automationIds = Object.keys(automationSettings.automations);
+  const hasAutomations = automationIds.length > 0;
+
+  const handleAdd = () => {
+    const id = generateId();
+    const newTrigger: Trigger = {
+      id,
+      title: '',
+      trigger: TimerLifeCycle.onStart,
+      automationId: automationIds[0],
+    };
+    updateEntry({ id: eventId, triggers: [...triggers, newTrigger] });
+  };
+
+  const handleDelete = useCallback(
+    (triggerId: string) => {
+      updateEntry({ id: eventId, triggers: triggers.filter((t) => t.id !== triggerId) });
+    },
+    [eventId, triggers, updateEntry],
+  );
+
+  const handleChange = useCallback(
+    (triggerId: string, field: 'trigger' | 'automationId', value: string) => {
+      const newTriggers = triggers.map((t) => (t.id === triggerId ? { ...t, [field]: value } : t));
+      updateEntry({ id: eventId, triggers: newTriggers });
+    },
+    [eventId, triggers, updateEntry],
+  );
+
+  const triggerOptions = eventTriggerOptions.map((cycle) => ({ value: cycle, label: cycle }));
+
+  const automationOptions = Object.values(automationSettings.automations).map(({ id, title }) => ({
+    value: id,
+    label: title,
+  }));
+
+  const filteredTriggers: Record<string, Trigger[]> = {};
+  timerLifecycleValues.forEach((triggerType) => {
+    const group = triggers.filter((t) => t.trigger === triggerType);
+    if (group.length) {
+      filteredTriggers[triggerType] = group;
+    }
+  });
 
   return (
     <div className={style.triggers}>
       {automationsEnabled === false && (
         <Info>Automations are disabled. Event triggers stay configured, but they will not run until enabled.</Info>
       )}
-      {showTriggers && (
-        <div className={style.section}>
-          <div className={style.sectionTitle}>Applied automations</div>
-          <ExistingEventTriggers triggers={triggers} eventId={eventId} automations={automationSettings.automations} />
+      {triggers.length > 0 && (
+        <div className={style.triggerList}>
+          <div className={style.triggerHeader}>
+            <span>Lifecycle</span>
+            <span>Automation</span>
+          </div>
+          {Object.entries(filteredTriggers).map(([triggerLifeCycle, triggerGroup]) => (
+            <Fragment key={triggerLifeCycle}>
+              {triggerGroup.map((trigger) => (
+                <div key={trigger.id} className={style.trigger}>
+                  <Select
+                    value={trigger.trigger}
+                    onValueChange={(value) => {
+                      if (value !== null) handleChange(trigger.id, 'trigger', value);
+                    }}
+                    options={triggerOptions}
+                  />
+                  <Select
+                    value={trigger.automationId}
+                    onValueChange={(value) => {
+                      if (value !== null) handleChange(trigger.id, 'automationId', value);
+                    }}
+                    options={automationOptions}
+                  />
+                  <IconButton variant='ghosted-destructive' onClick={() => handleDelete(trigger.id)}>
+                    <IoTrash />
+                  </IconButton>
+                </div>
+              ))}
+            </Fragment>
+          ))}
         </div>
       )}
-      <Editor.Panel className={style.formSection}>
-        <div className={style.sectionTitle}>Add automation</div>
-        <EventTriggerForm triggers={triggers} eventId={eventId} automations={automationSettings.automations} />
-      </Editor.Panel>
-    </div>
-  );
-}
-
-interface EventTriggerFormProps {
-  eventId: string;
-  triggers?: Trigger[];
-  automations: NormalisedAutomation;
-}
-
-function EventTriggerForm({ eventId, triggers, automations }: EventTriggerFormProps) {
-  const { updateEntry } = useEntryActionsContext();
-  const [automationId, setAutomationId] = useState<string | undefined>(undefined);
-  const [cycleValue, setCycleValue] = useState(TimerLifeCycle.onStart);
-
-  const handleSubmit = (triggerLifeCycle: TimerLifeCycle, automationId: string) => {
-    const newTriggers = triggers ?? new Array<Trigger>();
-    const id = generateId();
-    newTriggers.push({ id, title: '', trigger: triggerLifeCycle, automationId });
-    updateEntry({ id: eventId, triggers: newTriggers });
-  };
-
-  const getValidationError = (cycle: TimerLifeCycle, automationId?: string): string | undefined => {
-    if (automationId === undefined) {
-      return 'Select an automation';
-    }
-    if (!Object.keys(automations).includes(automationId)) {
-      return 'This automation does not exist';
-    }
-    if (triggers === undefined) {
-      return;
-    }
-    return Object.values(triggers).some((t) => t.automationId === automationId && t.trigger === cycle)
-      ? 'Automation can only be used once'
-      : undefined;
-  };
-
-  const validationError = getValidationError(cycleValue, automationId);
-  const validationLabel = validationError ?? 'Ready to add automation';
-
-  const triggerOptions = useMemo(
-    () => [
-      { value: null, label: 'Select lifecycle' },
-      ...eventTriggerOptions.map((cycle) => ({ value: cycle, label: cycle })),
-    ],
-    [], // eventTriggerOptions is a constant, no need for dependency
-  );
-
-  const automationOptions = useMemo(
-    () => [
-      { value: null, label: 'Select Automation' },
-      ...Object.values(automations).map(({ id, title }) => ({ value: id, label: title })),
-    ],
-    [automations], // This needs to be a dependency as it can change
-  );
-
-  return (
-    <div className={style.triggerForm}>
-      <div className={style.formFields}>
-        <div>
-          <Editor.Label>Lifecycle</Editor.Label>
-          <Select
-            value={cycleValue}
-            onValueChange={(value) => {
-              if (value !== null) setCycleValue(value);
-            }}
-            options={triggerOptions}
-          />
-        </div>
-
-        <div>
-          <Editor.Label>Automation</Editor.Label>
-          <Select
-            value={automationId ?? null}
-            onValueChange={(value) => {
-              if (value !== null) setAutomationId(value);
-            }}
-            options={automationOptions}
-          />
-        </div>
-      </div>
-
-      <div className={style.formActions}>
-        <div className={validationError ? style.validationError : style.validationSuccess}>
-          {validationError ? <IoAlertCircle /> : <IoCheckmarkCircle />}
-          <span>{validationLabel}</span>
-        </div>
-        <Button
-          disabled={validationError !== undefined}
-          onClick={() => automationId && handleSubmit(cycleValue, automationId)}
-        >
-          Add automation
+      {!hasAutomations ? (
+        <Editor.Label>
+          No automations defined. <a href='?settings=automation'>Manage automations</a> to add some.
+        </Editor.Label>
+      ) : (
+        <Button variant='ghosted' onClick={handleAdd}>
+          <IoAdd /> Add automation
         </Button>
-      </div>
-    </div>
-  );
-}
-
-interface ExistingEventTriggersProps {
-  eventId: string;
-  triggers: Trigger[];
-  automations: NormalisedAutomation;
-}
-
-function ExistingEventTriggers({ eventId, triggers, automations }: ExistingEventTriggersProps) {
-  const { updateEntry } = useEntryActionsContext();
-
-  const handleDelete = useCallback(
-    (triggerId: string) => {
-      const newTriggers = triggers.filter((trigger) => trigger.id !== triggerId);
-      updateEntry({ id: eventId, triggers: newTriggers });
-    },
-    [eventId, triggers, updateEntry],
-  );
-
-  const filteredTriggers: Record<string, Trigger[]> = {};
-
-  // sort triggers out into groups by the Lifecycle they are on
-  timerLifecycleValues.forEach((triggerType) => {
-    const thisTriggerType = triggers.filter((trigger) => trigger.trigger === triggerType);
-    if (thisTriggerType.length) {
-      Object.assign(filteredTriggers, { [triggerType]: thisTriggerType });
-    }
-  });
-
-  return (
-    <div className={style.triggerList}>
-      {Object.entries(filteredTriggers).map(([triggerLifeCycle, triggerGroup]) => (
-        <Fragment key={triggerLifeCycle}>
-          {triggerGroup.map((trigger) => {
-            const { id, automationId } = trigger;
-            const automationTitle = automations[automationId]?.title ?? '<MISSING AUTOMATION>';
-            return (
-              <div key={id} className={style.trigger}>
-                <div className={style.triggerMeta}>
-                  <div className={style.metaLabel}>Lifecycle</div>
-                  <div>{triggerLifeCycle}</div>
-                </div>
-                <div className={style.triggerMeta}>
-                  <div className={style.metaLabel}>Automation</div>
-                  <div className={style.automationTitle}>{automationTitle}</div>
-                </div>
-                <IconButton variant='ghosted-destructive' onClick={() => handleDelete(id)}>
-                  <IoTrash />
-                </IconButton>
-              </div>
-            );
-          })}
-        </Fragment>
-      ))}
+      )}
     </div>
   );
 }

--- a/apps/client/src/features/rundown/entry-editor/composite/EventEditorTriggers.tsx
+++ b/apps/client/src/features/rundown/entry-editor/composite/EventEditorTriggers.tsx
@@ -1,4 +1,4 @@
-import { TimerLifeCycle, Trigger } from 'ontime-types';
+import { Trigger } from 'ontime-types';
 import { generateId } from 'ontime-utils';
 import { IoAdd, IoTrash } from 'react-icons/io5';
 
@@ -30,35 +30,12 @@ export default function EventEditorTriggers({ triggers, eventId }: EventEditorTr
 
   const triggerOptions = eventTriggerOptions.map((cycle) => ({ value: cycle, label: cycle }));
 
-  const triggerRows = triggers.map((t) => {
-    const lifecycleOptions = triggerOptions.filter((opt) => {
-      const lifecycle = opt.value as TimerLifeCycle;
-      const usedIds = triggers.filter((o) => o.id !== t.id && o.trigger === lifecycle).map((o) => o.automationId);
-      return usedIds.length < allAutomationOptions.length;
-    });
-    const usedAutomationIds = triggers.filter((o) => o.id !== t.id && o.trigger === t.trigger).map((o) => o.automationId);
-    const automationOptions = allAutomationOptions.filter((opt) => !usedAutomationIds.includes(opt.value));
-    return { ...t, lifecycleOptions, automationOptions };
-  });
-
-  // returns the first lifecycle+automation pair not yet in use, or null if all are taken
-  const getNextAvailable = () => {
-    for (const lifecycle of eventTriggerOptions) {
-      const usedIds = triggers.filter((t) => t.trigger === lifecycle).map((t) => t.automationId);
-      const automation = allAutomationOptions.find((opt) => !usedIds.includes(opt.value));
-      if (automation) return { lifecycle, automationId: automation.value };
-    }
-    return null;
-  };
-
   const handleAdd = () => {
-    const next = getNextAvailable();
-    if (next === null) return;
     updateEntry({
       id: eventId,
       triggers: [
         ...triggers,
-        { id: generateId(), title: '', trigger: next.lifecycle, automationId: next.automationId },
+        { id: generateId(), title: '', trigger: eventTriggerOptions[0], automationId: allAutomationOptions[0].value },
       ],
     });
   };
@@ -68,27 +45,7 @@ export default function EventEditorTriggers({ triggers, eventId }: EventEditorTr
   };
 
   const handleChange = (triggerId: string, field: 'trigger' | 'automationId', value: string) => {
-    const newTriggers = triggers.map((t) => {
-      if (t.id !== triggerId) return t;
-      const updated = { ...t, [field]: value };
-      // when lifecycle changes, auto-resolve automationId if it now conflicts with another row
-      if (field === 'trigger') {
-        const newLifecycle = value as TimerLifeCycle;
-        const isConflict = triggers.some(
-          (other) => other.id !== triggerId && other.trigger === newLifecycle && other.automationId === t.automationId,
-        );
-        if (isConflict) {
-          const usedIds = triggers
-            .filter((other) => other.id !== triggerId && other.trigger === newLifecycle)
-            .map((other) => other.automationId);
-          const fallback = allAutomationOptions.find((opt) => !usedIds.includes(opt.value));
-          // no available automation for this lifecycle — reject the change
-          if (!fallback) return t;
-          updated.automationId = fallback.value;
-        }
-      }
-      return updated;
-    });
+    const newTriggers = triggers.map((t) => (t.id !== triggerId ? t : { ...t, [field]: value }));
     updateEntry({ id: eventId, triggers: newTriggers });
   };
 
@@ -103,21 +60,21 @@ export default function EventEditorTriggers({ triggers, eventId }: EventEditorTr
             <span>Lifecycle</span>
             <span>Automation</span>
           </div>
-          {triggerRows.map((trigger) => (
+          {triggers.map((trigger) => (
             <div key={trigger.id} className={style.trigger}>
               <Select
                 value={trigger.trigger}
                 onValueChange={(value) => {
                   if (value !== null) handleChange(trigger.id, 'trigger', value);
                 }}
-                options={trigger.lifecycleOptions}
+                options={triggerOptions}
               />
               <Select
                 value={trigger.automationId}
                 onValueChange={(value) => {
                   if (value !== null) handleChange(trigger.id, 'automationId', value);
                 }}
-                options={trigger.automationOptions}
+                options={allAutomationOptions}
               />
               <IconButton variant='ghosted-destructive' onClick={() => handleDelete(trigger.id)}>
                 <IoTrash />
@@ -127,11 +84,9 @@ export default function EventEditorTriggers({ triggers, eventId }: EventEditorTr
         </div>
       )}
       {allAutomationOptions.length === 0 ? (
-        <Editor.Label>
-          No automations defined.
-        </Editor.Label>
+        <Editor.Label>No automations defined.</Editor.Label>
       ) : (
-        <Button variant='ghosted' onClick={handleAdd} disabled={getNextAvailable() === null}>
+        <Button variant='ghosted' onClick={handleAdd}>
           <IoAdd /> Add automation
         </Button>
       )}

--- a/apps/client/src/features/rundown/entry-editor/composite/EventEditorTriggers.tsx
+++ b/apps/client/src/features/rundown/entry-editor/composite/EventEditorTriggers.tsx
@@ -77,7 +77,9 @@ export default function EventEditorTriggers({ triggers, eventId }: EventEditorTr
             .filter((other) => other.id !== triggerId && other.trigger === newLifecycle)
             .map((other) => other.automationId);
           const fallback = allAutomationOptions.find((opt) => !usedIds.includes(opt.value));
-          if (fallback) updated.automationId = fallback.value;
+          // no available automation for this lifecycle — reject the change
+          if (!fallback) return t;
+          updated.automationId = fallback.value;
         }
       }
       return updated;

--- a/apps/client/src/features/rundown/entry-editor/composite/EventEditorTriggers.tsx
+++ b/apps/client/src/features/rundown/entry-editor/composite/EventEditorTriggers.tsx
@@ -28,13 +28,12 @@ export default function EventEditorTriggers({ triggers, eventId }: EventEditorTr
   const hasAutomations = automationIds.length > 0;
 
   const handleAdd = () => {
+    const defaultLifecycle = TimerLifeCycle.onStart;
+    const usedIds = triggers.filter((t) => t.trigger === defaultLifecycle).map((t) => t.automationId);
+    const firstAvailable = automationIds.find((id) => !usedIds.includes(id));
+    if (firstAvailable === undefined) return;
     const id = generateId();
-    const newTrigger: Trigger = {
-      id,
-      title: '',
-      trigger: TimerLifeCycle.onStart,
-      automationId: automationIds[0],
-    };
+    const newTrigger: Trigger = { id, title: '', trigger: defaultLifecycle, automationId: firstAvailable };
     updateEntry({ id: eventId, triggers: [...triggers, newTrigger] });
   };
 
@@ -55,10 +54,15 @@ export default function EventEditorTriggers({ triggers, eventId }: EventEditorTr
 
   const triggerOptions = eventTriggerOptions.map((cycle) => ({ value: cycle, label: cycle }));
 
-  const automationOptions = Object.values(automationSettings.automations).map(({ id, title }) => ({
+  const allAutomationOptions = Object.values(automationSettings.automations).map(({ id, title }) => ({
     value: id,
     label: title,
   }));
+
+  const getAutomationOptionsForTrigger = (triggerId: string, lifecycle: TimerLifeCycle) => {
+    const usedIds = triggers.filter((t) => t.id !== triggerId && t.trigger === lifecycle).map((t) => t.automationId);
+    return allAutomationOptions.filter((opt) => !usedIds.includes(opt.value));
+  };
 
   const filteredTriggers: Record<string, Trigger[]> = {};
   timerLifecycleValues.forEach((triggerType) => {
@@ -95,7 +99,7 @@ export default function EventEditorTriggers({ triggers, eventId }: EventEditorTr
                     onValueChange={(value) => {
                       if (value !== null) handleChange(trigger.id, 'automationId', value);
                     }}
-                    options={automationOptions}
+                    options={getAutomationOptionsForTrigger(trigger.id, trigger.trigger)}
                   />
                   <IconButton variant='ghosted-destructive' onClick={() => handleDelete(trigger.id)}>
                     <IoTrash />
@@ -111,7 +115,13 @@ export default function EventEditorTriggers({ triggers, eventId }: EventEditorTr
           No automations defined. <a href='?settings=automation'>Manage automations</a> to add some.
         </Editor.Label>
       ) : (
-        <Button variant='ghosted' onClick={handleAdd}>
+        <Button
+          variant='ghosted'
+          onClick={handleAdd}
+          disabled={automationIds.every((id) =>
+            triggers.some((t) => t.trigger === TimerLifeCycle.onStart && t.automationId === id),
+          )}
+        >
           <IoAdd /> Add automation
         </Button>
       )}

--- a/apps/client/src/features/rundown/entry-editor/composite/EventEditorTriggers.tsx
+++ b/apps/client/src/features/rundown/entry-editor/composite/EventEditorTriggers.tsx
@@ -30,40 +30,39 @@ export default function EventEditorTriggers({ triggers, eventId }: EventEditorTr
 
   const triggerOptions = eventTriggerOptions.map((cycle) => ({ value: cycle, label: cycle }));
 
-  // per-row: exclude automations already used on the same lifecycle in other rows
-  function getAutomationOptionsForTrigger(triggerId: string, lifecycle: TimerLifeCycle) {
+  // returns automation options for a row, excluding automations already used on the same lifecycle
+  const getAutomationOptions = (triggerId: string, lifecycle: TimerLifeCycle) => {
     const usedIds = triggers.filter((t) => t.id !== triggerId && t.trigger === lifecycle).map((t) => t.automationId);
     return allAutomationOptions.filter((opt) => !usedIds.includes(opt.value));
-  }
+  };
 
-  // first lifecycle+automation pair not yet in use
-  function findFirstAvailable() {
+  // returns the first lifecycle+automation pair not yet in use, or null if all are taken
+  const getNextAvailable = () => {
     for (const lifecycle of eventTriggerOptions) {
       const usedIds = triggers.filter((t) => t.trigger === lifecycle).map((t) => t.automationId);
       const automation = allAutomationOptions.find((opt) => !usedIds.includes(opt.value));
       if (automation) return { lifecycle, automationId: automation.value };
     }
     return null;
-  }
+  };
 
-  const firstAvailable = findFirstAvailable();
-
-  function handleAdd() {
-    if (firstAvailable === null) return;
+  const handleAdd = () => {
+    const next = getNextAvailable();
+    if (next === null) return;
     updateEntry({
       id: eventId,
       triggers: [
         ...triggers,
-        { id: generateId(), title: '', trigger: firstAvailable.lifecycle, automationId: firstAvailable.automationId },
+        { id: generateId(), title: '', trigger: next.lifecycle, automationId: next.automationId },
       ],
     });
-  }
+  };
 
-  function handleDelete(triggerId: string) {
+  const handleDelete = (triggerId: string) => {
     updateEntry({ id: eventId, triggers: triggers.filter((t) => t.id !== triggerId) });
-  }
+  };
 
-  function handleChange(triggerId: string, field: 'trigger' | 'automationId', value: string) {
+  const handleChange = (triggerId: string, field: 'trigger' | 'automationId', value: string) => {
     const newTriggers = triggers.map((t) => {
       if (t.id !== triggerId) return t;
       const updated = { ...t, [field]: value };
@@ -84,7 +83,7 @@ export default function EventEditorTriggers({ triggers, eventId }: EventEditorTr
       return updated;
     });
     updateEntry({ id: eventId, triggers: newTriggers });
-  }
+  };
 
   return (
     <div className={style.triggers}>
@@ -111,7 +110,7 @@ export default function EventEditorTriggers({ triggers, eventId }: EventEditorTr
                 onValueChange={(value) => {
                   if (value !== null) handleChange(trigger.id, 'automationId', value);
                 }}
-                options={getAutomationOptionsForTrigger(trigger.id, trigger.trigger)}
+                options={getAutomationOptions(trigger.id, trigger.trigger)}
               />
               <IconButton variant='ghosted-destructive' onClick={() => handleDelete(trigger.id)}>
                 <IoTrash />
@@ -125,7 +124,7 @@ export default function EventEditorTriggers({ triggers, eventId }: EventEditorTr
           No automations defined. <a href='?settings=automation'>Manage automations</a> to add some.
         </Editor.Label>
       ) : (
-        <Button variant='ghosted' onClick={handleAdd} disabled={firstAvailable === null}>
+        <Button variant='ghosted' onClick={handleAdd} disabled={getNextAvailable() === null}>
           <IoAdd /> Add automation
         </Button>
       )}

--- a/apps/client/src/features/rundown/entry-editor/composite/EventEditorTriggers.tsx
+++ b/apps/client/src/features/rundown/entry-editor/composite/EventEditorTriggers.tsx
@@ -30,12 +30,35 @@ export default function EventEditorTriggers({ triggers, eventId }: EventEditorTr
 
   const triggerOptions = eventTriggerOptions.map((cycle) => ({ value: cycle, label: cycle }));
 
+  // hide lifecycles where this row's automation is already used by another row
+  const getLifecycleOptions = (triggerId: string, automationId: string) =>
+    triggerOptions.filter(
+      (opt) => !triggers.some((t) => t.id !== triggerId && t.trigger === opt.value && t.automationId === automationId),
+    );
+
+  // hide automations already used on the same lifecycle by other rows
+  const getAutomationOptions = (triggerId: string, lifecycle: string) => {
+    const usedIds = triggers.filter((t) => t.id !== triggerId && t.trigger === lifecycle).map((t) => t.automationId);
+    return allAutomationOptions.filter((opt) => !usedIds.includes(opt.value));
+  };
+
+  const getNextAvailable = () => {
+    for (const lifecycle of eventTriggerOptions) {
+      const usedIds = triggers.filter((t) => t.trigger === lifecycle).map((t) => t.automationId);
+      const automation = allAutomationOptions.find((opt) => !usedIds.includes(opt.value));
+      if (automation) return { lifecycle, automationId: automation.value };
+    }
+    return null;
+  };
+
   const handleAdd = () => {
+    const next = getNextAvailable();
+    if (!next) return;
     updateEntry({
       id: eventId,
       triggers: [
         ...triggers,
-        { id: generateId(), title: '', trigger: eventTriggerOptions[0], automationId: allAutomationOptions[0].value },
+        { id: generateId(), title: '', trigger: next.lifecycle, automationId: next.automationId },
       ],
     });
   };
@@ -67,14 +90,14 @@ export default function EventEditorTriggers({ triggers, eventId }: EventEditorTr
                 onValueChange={(value) => {
                   if (value !== null) handleChange(trigger.id, 'trigger', value);
                 }}
-                options={triggerOptions}
+                options={getLifecycleOptions(trigger.id, trigger.automationId)}
               />
               <Select
                 value={trigger.automationId}
                 onValueChange={(value) => {
                   if (value !== null) handleChange(trigger.id, 'automationId', value);
                 }}
-                options={allAutomationOptions}
+                options={getAutomationOptions(trigger.id, trigger.trigger)}
               />
               <IconButton variant='ghosted-destructive' onClick={() => handleDelete(trigger.id)}>
                 <IoTrash />
@@ -85,6 +108,8 @@ export default function EventEditorTriggers({ triggers, eventId }: EventEditorTr
       )}
       {allAutomationOptions.length === 0 ? (
         <Editor.Label>No automations defined.</Editor.Label>
+      ) : getNextAvailable() === null ? (
+        <Editor.Label>All trigger and automation combinations are in use.</Editor.Label>
       ) : (
         <Button variant='ghosted' onClick={handleAdd}>
           <IoAdd /> Add automation

--- a/apps/client/src/features/rundown/entry-editor/composite/EventEditorTriggers.tsx
+++ b/apps/client/src/features/rundown/entry-editor/composite/EventEditorTriggers.tsx
@@ -4,7 +4,6 @@ import { IoAdd, IoTrash } from 'react-icons/io5';
 
 import Button from '../../../../common/components/buttons/Button';
 import IconButton from '../../../../common/components/buttons/IconButton';
-import * as Editor from '../../../../common/components/editor-utils/EditorUtils';
 import Info from '../../../../common/components/info/Info';
 import Select from '../../../../common/components/select/Select';
 import { useEntryActionsContext } from '../../../../common/context/EntryActionsContext';
@@ -30,35 +29,17 @@ export default function EventEditorTriggers({ triggers, eventId }: EventEditorTr
 
   const triggerOptions = eventTriggerOptions.map((cycle) => ({ value: cycle, label: cycle }));
 
-  // hide lifecycles where this row's automation is already used by another row
-  const getLifecycleOptions = (triggerId: string, automationId: string) =>
-    triggerOptions.filter(
-      (opt) => !triggers.some((t) => t.id !== triggerId && t.trigger === opt.value && t.automationId === automationId),
-    );
-
-  // hide automations already used on the same lifecycle by other rows
-  const getAutomationOptions = (triggerId: string, lifecycle: string) => {
-    const usedIds = triggers.filter((t) => t.id !== triggerId && t.trigger === lifecycle).map((t) => t.automationId);
-    return allAutomationOptions.filter((opt) => !usedIds.includes(opt.value));
-  };
-
-  const getNextAvailable = () => {
-    for (const lifecycle of eventTriggerOptions) {
-      const usedIds = triggers.filter((t) => t.trigger === lifecycle).map((t) => t.automationId);
-      const automation = allAutomationOptions.find((opt) => !usedIds.includes(opt.value));
-      if (automation) return { lifecycle, automationId: automation.value };
-    }
-    return null;
-  };
+  const hasDuplicates = triggers.some((t, i) =>
+    triggers.some((u, j) => i !== j && t.trigger === u.trigger && t.automationId === u.automationId),
+  );
 
   const handleAdd = () => {
-    const next = getNextAvailable();
-    if (!next) return;
+    if (allAutomationOptions.length === 0) return;
     updateEntry({
       id: eventId,
       triggers: [
         ...triggers,
-        { id: generateId(), title: '', trigger: next.lifecycle, automationId: next.automationId },
+        { id: generateId(), title: '', trigger: eventTriggerOptions[0], automationId: allAutomationOptions[0].value },
       ],
     });
   };
@@ -90,14 +71,14 @@ export default function EventEditorTriggers({ triggers, eventId }: EventEditorTr
                 onValueChange={(value) => {
                   if (value !== null) handleChange(trigger.id, 'trigger', value);
                 }}
-                options={getLifecycleOptions(trigger.id, trigger.automationId)}
+                options={triggerOptions}
               />
               <Select
                 value={trigger.automationId}
                 onValueChange={(value) => {
                   if (value !== null) handleChange(trigger.id, 'automationId', value);
                 }}
-                options={getAutomationOptions(trigger.id, trigger.trigger)}
+                options={allAutomationOptions}
               />
               <IconButton variant='ghosted-destructive' onClick={() => handleDelete(trigger.id)}>
                 <IoTrash />
@@ -106,9 +87,8 @@ export default function EventEditorTriggers({ triggers, eventId }: EventEditorTr
           ))}
         </div>
       )}
-      {allAutomationOptions.length === 0 ? null : getNextAvailable() === null ? (
-        <Editor.Label>All trigger and automation combinations are in use.</Editor.Label>
-      ) : (
+      {hasDuplicates && <Info>Duplicate trigger combinations will only fire once per lifecycle event.</Info>}
+      {allAutomationOptions.length > 0 && (
         <Button variant='ghosted' onClick={handleAdd}>
           <IoAdd /> Add automation
         </Button>

--- a/apps/client/src/features/rundown/entry-editor/composite/EventEditorTriggers.tsx
+++ b/apps/client/src/features/rundown/entry-editor/composite/EventEditorTriggers.tsx
@@ -29,9 +29,16 @@ export default function EventEditorTriggers({ triggers, eventId }: EventEditorTr
 
   const triggerOptions = eventTriggerOptions.map((cycle) => ({ value: cycle, label: cycle }));
 
-  const hasDuplicates = triggers.some((t, i) =>
-    triggers.some((u, j) => i !== j && t.trigger === u.trigger && t.automationId === u.automationId),
-  );
+  const duplicateIds = new Set<string>();
+  const seen = new Map<string, string>();
+  for (const trigger of triggers) {
+    const key = `${trigger.trigger}:${trigger.automationId}`;
+    if (seen.has(key)) {
+      duplicateIds.add(trigger.id);
+    } else {
+      seen.set(key, trigger.id);
+    }
+  }
 
   const handleAdd = () => {
     if (allAutomationOptions.length === 0) return;
@@ -64,30 +71,45 @@ export default function EventEditorTriggers({ triggers, eventId }: EventEditorTr
             <span>Lifecycle</span>
             <span>Automation</span>
           </div>
-          {triggers.map((trigger) => (
-            <div key={trigger.id} className={style.trigger}>
-              <Select
-                value={trigger.trigger}
-                onValueChange={(value) => {
-                  if (value !== null) handleChange(trigger.id, 'trigger', value);
-                }}
-                options={triggerOptions}
-              />
-              <Select
-                value={trigger.automationId}
-                onValueChange={(value) => {
-                  if (value !== null) handleChange(trigger.id, 'automationId', value);
-                }}
-                options={allAutomationOptions}
-              />
-              <IconButton variant='ghosted-destructive' onClick={() => handleDelete(trigger.id)}>
-                <IoTrash />
-              </IconButton>
-            </div>
-          ))}
+          {triggers.map((trigger) => {
+            const isDuplicate = duplicateIds.has(trigger.id);
+            const lifecycleOptions = isDuplicate
+              ? triggerOptions.map((opt) => (opt.value === trigger.trigger ? { ...opt, label: `${opt.label} *` } : opt))
+              : triggerOptions;
+            const automationOptions = isDuplicate
+              ? allAutomationOptions.map((opt) =>
+                  opt.value === trigger.automationId ? { ...opt, label: `${opt.label} *` } : opt,
+                )
+              : allAutomationOptions;
+            return (
+              <div key={trigger.id} className={style.trigger} data-duplicate={isDuplicate || undefined}>
+                <Select
+                  value={trigger.trigger}
+                  onValueChange={(value) => {
+                    if (value !== null) handleChange(trigger.id, 'trigger', value);
+                  }}
+                  options={lifecycleOptions}
+                />
+                <Select
+                  value={trigger.automationId}
+                  onValueChange={(value) => {
+                    if (value !== null) handleChange(trigger.id, 'automationId', value);
+                  }}
+                  options={automationOptions}
+                />
+                <IconButton variant='ghosted-destructive' onClick={() => handleDelete(trigger.id)}>
+                  <IoTrash />
+                </IconButton>
+              </div>
+            );
+          })}
         </div>
       )}
-      {hasDuplicates && <Info>Duplicate trigger combinations will only fire once per lifecycle event.</Info>}
+      {duplicateIds.size > 0 && (
+        <span className={style.duplicateMessage}>
+          * Duplicate combinations will only fire once per lifecycle event.
+        </span>
+      )}
       {allAutomationOptions.length > 0 && (
         <Button variant='ghosted' onClick={handleAdd}>
           <IoAdd /> Add automation

--- a/apps/client/src/features/rundown/entry-editor/composite/EventEditorTriggers.tsx
+++ b/apps/client/src/features/rundown/entry-editor/composite/EventEditorTriggers.tsx
@@ -1,6 +1,5 @@
-import { TimerLifeCycle, Trigger, timerLifecycleValues } from 'ontime-types';
+import { TimerLifeCycle, Trigger } from 'ontime-types';
 import { generateId } from 'ontime-utils';
-import { Fragment, useCallback } from 'react';
 import { IoAdd, IoTrash } from 'react-icons/io5';
 
 import Button from '../../../../common/components/buttons/Button';
@@ -24,53 +23,68 @@ export default function EventEditorTriggers({ triggers, eventId }: EventEditorTr
   const { updateEntry } = useEntryActionsContext();
   const automationsEnabled = automationStatus === 'pending' ? undefined : automationSettings.enabledAutomations;
 
-  const automationIds = Object.keys(automationSettings.automations);
-  const hasAutomations = automationIds.length > 0;
-
-  const handleAdd = () => {
-    const defaultLifecycle = TimerLifeCycle.onStart;
-    const usedIds = triggers.filter((t) => t.trigger === defaultLifecycle).map((t) => t.automationId);
-    const firstAvailable = automationIds.find((id) => !usedIds.includes(id));
-    if (firstAvailable === undefined) return;
-    const id = generateId();
-    const newTrigger: Trigger = { id, title: '', trigger: defaultLifecycle, automationId: firstAvailable };
-    updateEntry({ id: eventId, triggers: [...triggers, newTrigger] });
-  };
-
-  const handleDelete = useCallback(
-    (triggerId: string) => {
-      updateEntry({ id: eventId, triggers: triggers.filter((t) => t.id !== triggerId) });
-    },
-    [eventId, triggers, updateEntry],
-  );
-
-  const handleChange = useCallback(
-    (triggerId: string, field: 'trigger' | 'automationId', value: string) => {
-      const newTriggers = triggers.map((t) => (t.id === triggerId ? { ...t, [field]: value } : t));
-      updateEntry({ id: eventId, triggers: newTriggers });
-    },
-    [eventId, triggers, updateEntry],
-  );
-
-  const triggerOptions = eventTriggerOptions.map((cycle) => ({ value: cycle, label: cycle }));
-
   const allAutomationOptions = Object.values(automationSettings.automations).map(({ id, title }) => ({
     value: id,
     label: title,
   }));
 
-  const getAutomationOptionsForTrigger = (triggerId: string, lifecycle: TimerLifeCycle) => {
+  const triggerOptions = eventTriggerOptions.map((cycle) => ({ value: cycle, label: cycle }));
+
+  // per-row: exclude automations already used on the same lifecycle in other rows
+  function getAutomationOptionsForTrigger(triggerId: string, lifecycle: TimerLifeCycle) {
     const usedIds = triggers.filter((t) => t.id !== triggerId && t.trigger === lifecycle).map((t) => t.automationId);
     return allAutomationOptions.filter((opt) => !usedIds.includes(opt.value));
-  };
+  }
 
-  const filteredTriggers: Record<string, Trigger[]> = {};
-  timerLifecycleValues.forEach((triggerType) => {
-    const group = triggers.filter((t) => t.trigger === triggerType);
-    if (group.length) {
-      filteredTriggers[triggerType] = group;
+  // first lifecycle+automation pair not yet in use
+  function findFirstAvailable() {
+    for (const lifecycle of eventTriggerOptions) {
+      const usedIds = triggers.filter((t) => t.trigger === lifecycle).map((t) => t.automationId);
+      const automation = allAutomationOptions.find((opt) => !usedIds.includes(opt.value));
+      if (automation) return { lifecycle, automationId: automation.value };
     }
-  });
+    return null;
+  }
+
+  const firstAvailable = findFirstAvailable();
+
+  function handleAdd() {
+    if (firstAvailable === null) return;
+    updateEntry({
+      id: eventId,
+      triggers: [
+        ...triggers,
+        { id: generateId(), title: '', trigger: firstAvailable.lifecycle, automationId: firstAvailable.automationId },
+      ],
+    });
+  }
+
+  function handleDelete(triggerId: string) {
+    updateEntry({ id: eventId, triggers: triggers.filter((t) => t.id !== triggerId) });
+  }
+
+  function handleChange(triggerId: string, field: 'trigger' | 'automationId', value: string) {
+    const newTriggers = triggers.map((t) => {
+      if (t.id !== triggerId) return t;
+      const updated = { ...t, [field]: value };
+      // when lifecycle changes, auto-resolve automationId if it now conflicts with another row
+      if (field === 'trigger') {
+        const newLifecycle = value as TimerLifeCycle;
+        const isConflict = triggers.some(
+          (other) => other.id !== triggerId && other.trigger === newLifecycle && other.automationId === t.automationId,
+        );
+        if (isConflict) {
+          const usedIds = triggers
+            .filter((other) => other.id !== triggerId && other.trigger === newLifecycle)
+            .map((other) => other.automationId);
+          const fallback = allAutomationOptions.find((opt) => !usedIds.includes(opt.value));
+          if (fallback) updated.automationId = fallback.value;
+        }
+      }
+      return updated;
+    });
+    updateEntry({ id: eventId, triggers: newTriggers });
+  }
 
   return (
     <div className={style.triggers}>
@@ -83,45 +97,35 @@ export default function EventEditorTriggers({ triggers, eventId }: EventEditorTr
             <span>Lifecycle</span>
             <span>Automation</span>
           </div>
-          {Object.entries(filteredTriggers).map(([triggerLifeCycle, triggerGroup]) => (
-            <Fragment key={triggerLifeCycle}>
-              {triggerGroup.map((trigger) => (
-                <div key={trigger.id} className={style.trigger}>
-                  <Select
-                    value={trigger.trigger}
-                    onValueChange={(value) => {
-                      if (value !== null) handleChange(trigger.id, 'trigger', value);
-                    }}
-                    options={triggerOptions}
-                  />
-                  <Select
-                    value={trigger.automationId}
-                    onValueChange={(value) => {
-                      if (value !== null) handleChange(trigger.id, 'automationId', value);
-                    }}
-                    options={getAutomationOptionsForTrigger(trigger.id, trigger.trigger)}
-                  />
-                  <IconButton variant='ghosted-destructive' onClick={() => handleDelete(trigger.id)}>
-                    <IoTrash />
-                  </IconButton>
-                </div>
-              ))}
-            </Fragment>
+          {triggers.map((trigger) => (
+            <div key={trigger.id} className={style.trigger}>
+              <Select
+                value={trigger.trigger}
+                onValueChange={(value) => {
+                  if (value !== null) handleChange(trigger.id, 'trigger', value);
+                }}
+                options={triggerOptions}
+              />
+              <Select
+                value={trigger.automationId}
+                onValueChange={(value) => {
+                  if (value !== null) handleChange(trigger.id, 'automationId', value);
+                }}
+                options={getAutomationOptionsForTrigger(trigger.id, trigger.trigger)}
+              />
+              <IconButton variant='ghosted-destructive' onClick={() => handleDelete(trigger.id)}>
+                <IoTrash />
+              </IconButton>
+            </div>
           ))}
         </div>
       )}
-      {!hasAutomations ? (
+      {allAutomationOptions.length === 0 ? (
         <Editor.Label>
           No automations defined. <a href='?settings=automation'>Manage automations</a> to add some.
         </Editor.Label>
       ) : (
-        <Button
-          variant='ghosted'
-          onClick={handleAdd}
-          disabled={automationIds.every((id) =>
-            triggers.some((t) => t.trigger === TimerLifeCycle.onStart && t.automationId === id),
-          )}
-        >
+        <Button variant='ghosted' onClick={handleAdd} disabled={firstAvailable === null}>
           <IoAdd /> Add automation
         </Button>
       )}

--- a/apps/client/src/features/rundown/entry-editor/composite/EventEditorTriggers.tsx
+++ b/apps/client/src/features/rundown/entry-editor/composite/EventEditorTriggers.tsx
@@ -30,11 +30,16 @@ export default function EventEditorTriggers({ triggers, eventId }: EventEditorTr
 
   const triggerOptions = eventTriggerOptions.map((cycle) => ({ value: cycle, label: cycle }));
 
-  // returns automation options for a row, excluding automations already used on the same lifecycle
-  const getAutomationOptions = (triggerId: string, lifecycle: TimerLifeCycle) => {
-    const usedIds = triggers.filter((t) => t.id !== triggerId && t.trigger === lifecycle).map((t) => t.automationId);
-    return allAutomationOptions.filter((opt) => !usedIds.includes(opt.value));
-  };
+  const triggerRows = triggers.map((t) => {
+    const lifecycleOptions = triggerOptions.filter((opt) => {
+      const lifecycle = opt.value as TimerLifeCycle;
+      const usedIds = triggers.filter((o) => o.id !== t.id && o.trigger === lifecycle).map((o) => o.automationId);
+      return usedIds.length < allAutomationOptions.length;
+    });
+    const usedAutomationIds = triggers.filter((o) => o.id !== t.id && o.trigger === t.trigger).map((o) => o.automationId);
+    const automationOptions = allAutomationOptions.filter((opt) => !usedAutomationIds.includes(opt.value));
+    return { ...t, lifecycleOptions, automationOptions };
+  });
 
   // returns the first lifecycle+automation pair not yet in use, or null if all are taken
   const getNextAvailable = () => {
@@ -98,21 +103,21 @@ export default function EventEditorTriggers({ triggers, eventId }: EventEditorTr
             <span>Lifecycle</span>
             <span>Automation</span>
           </div>
-          {triggers.map((trigger) => (
+          {triggerRows.map((trigger) => (
             <div key={trigger.id} className={style.trigger}>
               <Select
                 value={trigger.trigger}
                 onValueChange={(value) => {
                   if (value !== null) handleChange(trigger.id, 'trigger', value);
                 }}
-                options={triggerOptions}
+                options={trigger.lifecycleOptions}
               />
               <Select
                 value={trigger.automationId}
                 onValueChange={(value) => {
                   if (value !== null) handleChange(trigger.id, 'automationId', value);
                 }}
-                options={getAutomationOptions(trigger.id, trigger.trigger)}
+                options={trigger.automationOptions}
               />
               <IconButton variant='ghosted-destructive' onClick={() => handleDelete(trigger.id)}>
                 <IoTrash />

--- a/apps/client/src/features/rundown/entry-editor/composite/EventEditorTriggers.tsx
+++ b/apps/client/src/features/rundown/entry-editor/composite/EventEditorTriggers.tsx
@@ -106,9 +106,7 @@ export default function EventEditorTriggers({ triggers, eventId }: EventEditorTr
           ))}
         </div>
       )}
-      {allAutomationOptions.length === 0 ? (
-        <Editor.Label>No automations defined.</Editor.Label>
-      ) : getNextAvailable() === null ? (
+      {allAutomationOptions.length === 0 ? null : getNextAvailable() === null ? (
         <Editor.Label>All trigger and automation combinations are in use.</Editor.Label>
       ) : (
         <Button variant='ghosted' onClick={handleAdd}>

--- a/apps/server/src/api-data/automation/automation.service.ts
+++ b/apps/server/src/api-data/automation/automation.service.ts
@@ -47,7 +47,15 @@ export function triggerAutomations(cycle: TimerLifeCycle) {
     return;
   }
 
-  filteredTrigger.forEach((trigger) => {
+  // deduplicate — if the same automation appears multiple times on one lifecycle, fire it once
+  const seen = new Set<string>();
+  const uniqueTriggers = filteredTrigger.filter((t) => {
+    if (seen.has(t.automationId)) return false;
+    seen.add(t.automationId);
+    return true;
+  });
+
+  uniqueTriggers.forEach((trigger) => {
     const automation = automations[trigger.automationId];
     if (!automation || automation.outputs.length === 0) {
       return;


### PR DESCRIPTION
This addresses issue #2038 

Streamlining the editor flow for automations like so: 
<img width="968" height="380" alt="image" src="https://github.com/user-attachments/assets/5eafabd3-4bd1-4dd9-9d3e-7c0fd15c36e1" />


This means that automations auto-save but they are also editable now... I have tested with ontime actions but have not tested with OSC or HTTP automations yet.