### PR TITLE
fix: generate share links client side when in web browser to enable easy clipboard access

### DIFF
--- a/apps/client/src/common/utils/linkUtils.ts
+++ b/apps/client/src/common/utils/linkUtils.ts
@@ -1,3 +1,4 @@
+import { OntimeView } from 'ontime-types';
 import type { MouseEvent } from 'react';
 
 import { baseURI, serverURL } from '../../externals';
@@ -39,6 +40,38 @@ export function handleLinks(
   const destination = new URL(externalServerUrl);
   destination.pathname = externalBaseURI ? `${externalBaseURI}/${location}` : location;
   openLink(destination.toString());
+}
+
+interface BuildShareUrlOptions {
+  baseUrl: string;
+  path: string;
+  lockNav: boolean;
+  lockConfig: boolean;
+  preset?: string;
+}
+
+/**
+ * Builds a share URL client-side, mirroring the server's generateShareUrl logic.
+ * Only valid when authenticate: false — authenticated URLs require the server (password hash).
+ */
+export function buildShareUrl(
+  { baseUrl, path, lockNav, lockConfig, preset }: BuildShareUrlOptions,
+  externalBaseURI: string = baseURI,
+): string {
+  const url = new URL(baseUrl);
+
+  // companion links point to the root
+  if (path !== '<<companion>>') {
+    const shouldMaskPath = Boolean(preset) && (path === OntimeView.Cuesheet || lockConfig);
+    const maybePresetPath = shouldMaskPath ? `preset/${preset}` : preset || path;
+    url.pathname = externalBaseURI ? `${externalBaseURI}/${maybePresetPath}` : maybePresetPath;
+
+    if (lockNav) {
+      url.searchParams.append('n', '1');
+    }
+  }
+
+  return url.toString();
 }
 
 export function linkToOtherHost(

--- a/apps/client/src/features/sharing/GenerateLinkForm.tsx
+++ b/apps/client/src/features/sharing/GenerateLinkForm.tsx
@@ -15,6 +15,7 @@ import Switch from '../../common/components/switch/Switch';
 import { useUpdateUrlPreset } from '../../common/hooks-query/useUrlPresets';
 import { safeCopyToClipboard } from '../../common/utils/copyToClipboard';
 import { preventEscape } from '../../common/utils/keyEvent';
+import { buildShareUrl } from '../../common/utils/linkUtils';
 import { isUrlSafe } from '../../common/utils/regex';
 import { isOntimeCloud, serverURL } from '../../externals';
 import * as Panel from '../app-settings/panel-utils/PanelUtils';
@@ -106,45 +107,55 @@ export default function GenerateLinkForm({ hostOptions, pathOptions, presets, is
   const onSubmit = async (options: GenerateLinkFormOptions) => {
     try {
       setFormState('loading');
+
+      // Resolve canonical path and preset alias
+      let resolvedPath: string;
+      let resolvedPreset: string | undefined;
+
       if (options.path === OntimeView.Cuesheet) {
         const urlPreset = await createPresetFromOptions((options as CuesheetLinkOptions).alias, {
           read: cuesheetReadRef.current?.value ?? 'full',
           write: cuesheetWriteRef.current?.value ?? 'full',
         });
-
         if (!urlPreset) {
           throw new Error('Failed to create URL preset for Cuesheet');
         }
-
-        const url = await generateUrl({
-          baseUrl: options.baseUrl,
-          path: options.path,
-          authenticate: options.authenticate,
-          lockConfig: options.lockConfig,
-          lockNav: options.lockNav,
-          preset: urlPreset.alias,
-        });
-        await safeCopyToClipboard(url);
-        setUrl(url);
+        resolvedPath = options.path;
+        resolvedPreset = urlPreset.alias;
       } else {
-        const presetPath = options.path.startsWith('preset-') ? options.path.replace('preset-', '') : undefined;
-        const path = presetPath ? presets.find((preset) => preset.alias === presetPath)?.target : options.path;
-        if (!path) {
-          throw new Error(`Could not resolve preset: ${path}`);
+        resolvedPreset = options.path.startsWith('preset-') ? options.path.replace('preset-', '') : undefined;
+        resolvedPath = resolvedPreset
+          ? (presets.find((preset) => preset.alias === resolvedPreset)?.target ?? '')
+          : options.path;
+        if (!resolvedPath) {
+          throw new Error(`Could not resolve preset: ${resolvedPreset}`);
         }
+      }
 
-        const url = await generateUrl({
+      // Generate URL: client-side when not authenticating (avoids async gap that breaks clipboard in browsers)
+      // Authenticated URLs require the server to inject the password hash token
+      let url: string;
+      if (options.authenticate) {
+        url = await generateUrl({
           baseUrl: options.baseUrl,
-          path,
+          path: resolvedPath,
           authenticate: options.authenticate,
           lockConfig: options.lockConfig,
           lockNav: options.lockNav,
-          preset: presetPath,
+          preset: resolvedPreset,
         });
-
-        await safeCopyToClipboard(url);
-        setUrl(url);
+      } else {
+        url = buildShareUrl({
+          baseUrl: options.baseUrl,
+          path: resolvedPath,
+          lockNav: options.lockNav,
+          lockConfig: options.lockConfig,
+          preset: resolvedPreset,
+        });
       }
+
+      await safeCopyToClipboard(url);
+      setUrl(url);
       reset(options, {
         keepValues: true,
         keepDirty: false,


### PR DESCRIPTION
This is a potential fix for #2063 - depends on how we need this to work for Ontime cloud? Also this does not fix the fact that some of the Copy-Tag button components used throughout the app don't work consistently. Need to do more thorough assessment, but initial thought - could all of this link generation be done client side? What does it need from the server? 

(Other than in ontime cloud's case where it needs the server id string, but could then mutate that client side?)