### PR TITLE
Feat switch rundown api

### DIFF
--- a/apps/resolver/src/main.ts
+++ b/apps/resolver/src/main.ts
@@ -14,6 +14,9 @@ export { TimerPhase, Playback, runtimeStorePlaceholder, OffsetMode } from 'ontim
 export type { SimpleTimerState } from 'ontime-types';
 export { SimplePlayback, SimpleDirection } from 'ontime-types';
 
+// Client
+export type { ClientList, Client } from 'ontime-types';
+
 // entries
 export type {
   OntimeEntry,

--- a/apps/server/src/api-integration/integration.controller.ts
+++ b/apps/server/src/api-integration/integration.controller.ts
@@ -12,7 +12,7 @@ import { DeepPartial } from 'ts-essentials';
 
 import { socket } from '../adapters/WebsocketAdapter.js';
 import { getCurrentRundown, getProjectCustomFields } from '../api-data/rundown/rundown.dao.js';
-import { editEntry } from '../api-data/rundown/rundown.service.js';
+import { editEntry, loadRundown } from '../api-data/rundown/rundown.service.js';
 import { willCauseRegeneration } from '../api-data/rundown/rundown.utils.js';
 import { ONTIME_VERSION } from '../ONTIME_VERSION.js';
 import { auxTimerService } from '../services/aux-timer-service/AuxTimerService.js';
@@ -306,6 +306,15 @@ const actionHandlers: Record<ApiActionTag, ActionHandler> = {
     const mode = coerceEnum<OffsetMode>(payload, OffsetMode);
     runtimeService.setOffsetMode(mode);
     return { payload: 'success' };
+  },
+  rundown: async (payload) => {
+    assert.isObject(payload);
+    if ('load' in payload) {
+      assert.isString(payload.load);
+      await loadRundown(payload.load);
+      return { payload: 'success' };
+    }
+    throw new Error('No matching method provided');
   },
 };
 

--- a/packages/types/src/api/websocket/api.type.ts
+++ b/packages/types/src/api/websocket/api.type.ts
@@ -142,6 +142,18 @@ export type OffsetmodeResponse = {
   payload: 'success';
 };
 
+export type RundownAction = {
+  tag: 'rundown';
+  payload: {
+    /** load a rundown by id */
+    load: string;
+  };
+};
+export type RundownLoadResponse = {
+  tag: 'rundown-load';
+  payload: 'success';
+};
+
 export type ApiAction =
   | VersionAction
   | PollAction
@@ -156,7 +168,8 @@ export type ApiAction =
   | AddtimeAction
   | AuxtimerAction
   | ClientAction
-  | OffsetmodeAction;
+  | OffsetmodeAction
+  | RundownAction;
 
 export type ApiResponse =
   | VersionResponse
@@ -172,6 +185,7 @@ export type ApiResponse =
   | AddtimeResponse
   | AuxtimerResponse
   | ClientResponse
-  | OffsetmodeResponse;
+  | OffsetmodeResponse
+  | RundownLoadResponse;
 
 export type ApiActionTag = ApiAction['tag'];


### PR DESCRIPTION
#2079

unsure what a good naming for the api would be (load or switch or...)
should we make it a nested api, will there be mor actions needed on **rundown** from the api
should we add a way for the user to see the id in the UI

osc example
```url
/api/rundown/load "abcd"
```

http example
```url
/api/rundown&load=abcd
/api/rundown/load/abcd
```

websocket
```json
{"rundown": {"load": "abcd"}}
```