### PR TITLE
feat(client): add rundown default to inherit parent group colour

### DIFF
--- a/apps/client/src/common/hooks/useEntryAction.ts
+++ b/apps/client/src/common/hooks/useEntryAction.ts
@@ -16,6 +16,7 @@ import {
   TimeStrategy,
   isOntimeEvent,
   isOntimeGroup,
+  isOntimeMilestone,
 } from 'ontime-types';
 import {
   MILLIS_PER_SECOND,
@@ -82,6 +83,7 @@ function useEntryActionsForRundown(scopedRundownId: string | undefined) {
     defaultDangerTime,
     defaultTimerType,
     defaultEndAction,
+    inheritGroupColour,
   } = useEditorSettings();
 
   const resolveCurrentRundownQueryKey = useCallback(() => {
@@ -239,6 +241,14 @@ function useEntryActionsForRundown(scopedRundownId: string | undefined) {
         }
       }
 
+      if (inheritGroupColour && (isOntimeEvent(newEntry) || isOntimeMilestone(newEntry)) && !newEntry.colour) {
+        const parentId = resolveInsertParent(rundownData, newEntry);
+        const maybeParent = parentId ? rundownData.entries[parentId] : null;
+        if (maybeParent && isOntimeGroup(maybeParent)) {
+          newEntry.colour = maybeParent.colour;
+        }
+      }
+
       try {
         await addEntryMutation([rundownId, newEntry]);
       } catch (error) {
@@ -254,6 +264,7 @@ function useEntryActionsForRundown(scopedRundownId: string | undefined) {
       defaultTimerType,
       defaultEndAction,
       defaultTimeStrategy,
+      inheritGroupColour,
       addEntryMutation,
     ],
   );

--- a/apps/client/src/common/stores/editorSettings.ts
+++ b/apps/client/src/common/stores/editorSettings.ts
@@ -12,8 +12,10 @@ type EditorSettingsStore = {
   defaultDangerTime: string;
   defaultTimerType: TimerType;
   defaultEndAction: EndAction;
+  inheritGroupColour: boolean;
   setDefaultDuration: (defaultDuration: string) => void;
   setLinkPrevious: (linkPrevious: boolean) => void;
+  setInheritGroupColour: (inheritGroupColour: boolean) => void;
   setTimeStrategy: (timeStrategy: TimeStrategy) => void;
   setWarnTime: (warnTime: string) => void;
   setDangerTime: (dangerTime: string) => void;
@@ -29,6 +31,7 @@ export const editorSettingsDefaults = {
   dangerTime: '00:01:00', // 60000 same as backend
   timerType: TimerType.CountDown,
   endAction: EndAction.None,
+  inheritGroupColour: false,
 };
 
 enum EditorSettingsKeys {
@@ -39,6 +42,7 @@ enum EditorSettingsKeys {
   DefaultDangerTime = 'ontime-default-danger-time',
   DefaultTimerType = 'ontime-default-timer-type',
   DefaultEndAction = 'ontime-default-end-action',
+  InheritGroupColour = 'ontime-inherit-group-colour',
 }
 
 export const useEditorSettings = create<EditorSettingsStore>((set) => {
@@ -58,6 +62,10 @@ export const useEditorSettings = create<EditorSettingsStore>((set) => {
     defaultEndAction: validateEndAction(
       localStorage.getItem(EditorSettingsKeys.DefaultEndAction),
       editorSettingsDefaults.endAction,
+    ),
+    inheritGroupColour: booleanFromLocalStorage(
+      EditorSettingsKeys.InheritGroupColour,
+      editorSettingsDefaults.inheritGroupColour,
     ),
 
     setDefaultDuration: (defaultDuration) =>
@@ -96,6 +104,11 @@ export const useEditorSettings = create<EditorSettingsStore>((set) => {
       set(() => {
         localStorage.setItem(EditorSettingsKeys.DefaultEndAction, String(defaultEndAction));
         return { defaultEndAction };
+      }),
+    setInheritGroupColour: (inheritGroupColour) =>
+      set(() => {
+        localStorage.setItem(EditorSettingsKeys.InheritGroupColour, String(inheritGroupColour));
+        return { inheritGroupColour };
       }),
   };
 });

--- a/apps/client/src/features/app-settings/panel/manage-panel/RundownDefaultSettings.tsx
+++ b/apps/client/src/features/app-settings/panel/manage-panel/RundownDefaultSettings.tsx
@@ -16,6 +16,7 @@ export default function RundownDefaultSettings() {
     defaultDangerTime,
     defaultTimerType,
     defaultEndAction,
+    inheritGroupColour,
     setDefaultDuration,
     setLinkPrevious,
     setTimeStrategy,
@@ -23,6 +24,7 @@ export default function RundownDefaultSettings() {
     setDangerTime,
     setDefaultTimerType,
     setDefaultEndAction,
+    setInheritGroupColour,
   } = useEditorSettings((state) => state);
 
   const durationInMs = parseUserTime(defaultDuration);
@@ -43,6 +45,13 @@ export default function RundownDefaultSettings() {
                 description='Whether the start time of new events should be linked to the previous event end time'
               />
               <Switch size='large' checked={linkPrevious} onCheckedChange={setLinkPrevious} />
+            </Panel.ListItem>
+            <Panel.ListItem>
+              <Panel.Field
+                title='Inherit group colour'
+                description='Whether new events and milestones inherit the colour of their parent group'
+              />
+              <Switch size='large' checked={inheritGroupColour} onCheckedChange={setInheritGroupColour} />
             </Panel.ListItem>
             <Panel.ListItem>
               <Panel.Field


### PR DESCRIPTION
New events and milestones can optionally inherit the colour of their parent group at creation time, controlled by a new "Inherit group colour" toggle in the Rundown defaults panel. Applied as a one-time snapshot and only when the entry has no explicit colour and the parent group has one.