### PR TITLE
refactor(client): move saved view-params indicator and clear per route

### DIFF
--- a/apps/client/src/common/components/navigation-menu/NavigationMenu.tsx
+++ b/apps/client/src/common/components/navigation-menu/NavigationMenu.tsx
@@ -1,9 +1,9 @@
 import { Dialog } from '@base-ui/react/dialog';
 import { useDisclosure, useFullscreen } from '@mantine/hooks';
 import { memo } from 'react';
-import { IoClose, IoContract, IoExpand, IoLockClosedOutline, IoRefreshOutline, IoSwapVertical } from 'react-icons/io5';
+import { IoClose, IoContract, IoExpand, IoLockClosedOutline, IoSwapVertical } from 'react-icons/io5';
 import { LuCoffee } from 'react-icons/lu';
-import { useLocation, useSearchParams } from 'react-router';
+import { useLocation } from 'react-router';
 
 import { isLocalhost, supportsFullscreen } from '../../../externals';
 import { canUseWakeLock, useKeepAwakeOptions } from '../../../features/keep-awake/useWakeLock';
@@ -11,7 +11,6 @@ import { navigatorConstants } from '../../../viewerConfig';
 import useUrlPresets from '../../hooks-query/useUrlPresets';
 import { useIsSmallScreen } from '../../hooks/useIsSmallScreen';
 import { useClientStore } from '../../stores/clientStore';
-import { hasCustomParams, RESERVED_PARAMS, useSavedViewParams } from '../../stores/savedViewParams';
 import { useViewOptionsStore } from '../../stores/viewOptions';
 import IconButton from '../buttons/IconButton';
 import { RenameClientModal } from '../client-modal/RenameClientModal';
@@ -38,21 +37,6 @@ function NavigationMenu({ isOpen, onClose }: NavigationMenuProps) {
   const { mirror, toggleMirror } = useViewOptionsStore();
   const { keepAwake, toggleKeepAwake } = useKeepAwakeOptions();
   const location = useLocation();
-  const [searchParams, setSearchParams] = useSearchParams();
-  const savedParams = useSavedViewParams((store) => store.params);
-  const clearSavedParams = useSavedViewParams((store) => store.clearAll);
-  const hasSavedChanges = hasCustomParams(searchParams) || Object.keys(savedParams).length > 0;
-
-  const clearViewSettings = () => {
-    clearSavedParams();
-    // reset the current view's URL, keeping only reserved (auth/preset) params
-    const preserved = new URLSearchParams();
-    RESERVED_PARAMS.forEach((key) => {
-      const value = searchParams.get(key);
-      if (value !== null) preserved.set(key, value);
-    });
-    setSearchParams(preserved);
-  };
 
   return (
     <Dialog.Root
@@ -93,13 +77,6 @@ function NavigationMenu({ isOpen, onClose }: NavigationMenuProps) {
               </NavigationMenuItem>
             )}
             <NavigationMenuItem onClick={handlers.open}>Rename Client</NavigationMenuItem>
-            {hasSavedChanges && (
-              <NavigationMenuItem onClick={clearViewSettings}>
-                Clear View Settings
-                <IoRefreshOutline />
-                <span className={style.note}>Saved</span>
-              </NavigationMenuItem>
-            )}
 
             <hr className={style.separator} />
 

--- a/apps/client/src/common/components/navigation-menu/client-link/ClientLink.module.scss
+++ b/apps/client/src/common/components/navigation-menu/client-link/ClientLink.module.scss
@@ -1,4 +1,30 @@
-.linkIcon {
+.trailing {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
   margin-left: auto;
+}
+
+.linkIcon {
   @include rotate-fourty-five;
+}
+
+.indicator {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background-color: $active-indicator;
+  pointer-events: none;
+  flex-shrink: 0;
+}
+
+.clear {
+  // resting state stays subtle so the row reads cleanly, full opacity on interaction
+  opacity: 0.6;
+  transition: opacity $transition-time-action;
+
+  &:hover,
+  &:focus-visible {
+    opacity: 1;
+  }
 }

--- a/apps/client/src/common/components/navigation-menu/client-link/ClientLink.tsx
+++ b/apps/client/src/common/components/navigation-menu/client-link/ClientLink.tsx
@@ -1,10 +1,11 @@
-import { PropsWithChildren } from 'react';
-import { IoArrowUp } from 'react-icons/io5';
-import { useLocation, useNavigate } from 'react-router';
+import { MouseEvent, PropsWithChildren } from 'react';
+import { IoArrowUp, IoCloseOutline } from 'react-icons/io5';
+import { useLocation, useNavigate, useSearchParams } from 'react-router';
 
 import { useElectronEvent } from '../../../hooks/useElectronEvent';
-import { stripReservedParams, useSavedViewParams } from '../../../stores/savedViewParams';
+import { hasCustomParams, RESERVED_PARAMS, stripReservedParams, useSavedViewParams } from '../../../stores/savedViewParams';
 import { handleLinks } from '../../../utils/linkUtils';
+import IconButton from '../../buttons/IconButton';
 import NavigationMenuItem from '../navigation-menu-item/NavigationMenuItem';
 
 import style from './ClientLink.module.scss';
@@ -19,7 +20,12 @@ export default function ClientLink({ current, to, postAction, children }: PropsW
   const { isElectron } = useElectronEvent();
   const navigate = useNavigate();
   const location = useLocation();
-  const { params: savedParams, save } = useSavedViewParams();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { params: savedParams, save, clear } = useSavedViewParams();
+
+  // the customisation of the view we are currently on lives in the URL until we
+  // navigate away; every other view reflects whatever was saved when we last left it
+  const isCustomised = current ? hasCustomParams(searchParams) : Boolean(savedParams[to]);
 
   /**
    * Save the params of the view we are leaving and resolve the destination,
@@ -32,30 +38,58 @@ export default function ClientLink({ current, to, postAction, children }: PropsW
     return `${to}${restored ? `?${restored}` : ''}`;
   };
 
-  if (isElectron) {
-    return (
-      <NavigationMenuItem
-        active={current}
-        onClick={() => {
-          handleLinks(resolveDestination());
-          postAction?.();
-        }}
-      >
-        {children}
-        <IoArrowUp className={style.linkIcon} />
-      </NavigationMenuItem>
-    );
-  }
+  /**
+   * Clear the saved settings for this route without navigating to it.
+   * When it is the current view, also reset the live URL to its defaults.
+   */
+  const clearViewSettings = (event: MouseEvent) => {
+    event.stopPropagation();
+    clear(to);
+    if (current) {
+      const preserved = new URLSearchParams();
+      RESERVED_PARAMS.forEach((key) => {
+        const value = searchParams.get(key);
+        if (value !== null) preserved.set(key, value);
+      });
+      setSearchParams(preserved);
+    }
+  };
+
+  const trailing = (isCustomised || isElectron) && (
+    <span className={style.trailing}>
+      {isCustomised && (
+        <>
+          <span className={style.indicator} aria-hidden data-testid='client-link__saved-indicator' />
+          <IconButton
+            variant='ghosted-white'
+            size='small'
+            className={style.clear}
+            aria-label='Clear saved view settings'
+            title='Clear saved view settings'
+            data-testid='client-link__clear'
+            onClick={clearViewSettings}
+          >
+            <IoCloseOutline />
+          </IconButton>
+        </>
+      )}
+      {isElectron && <IoArrowUp className={style.linkIcon} />}
+    </span>
+  );
+
+  const handleClick = () => {
+    if (isElectron) {
+      handleLinks(resolveDestination());
+    } else {
+      navigate(`/${resolveDestination()}`);
+    }
+    postAction?.();
+  };
 
   return (
-    <NavigationMenuItem
-      active={current}
-      onClick={() => {
-        navigate(`/${resolveDestination()}`);
-        postAction?.();
-      }}
-    >
+    <NavigationMenuItem active={current} onClick={handleClick}>
       {children}
+      {trailing}
     </NavigationMenuItem>
   );
 }

--- a/apps/client/src/common/stores/__tests__/savedViewParams.test.ts
+++ b/apps/client/src/common/stores/__tests__/savedViewParams.test.ts
@@ -39,6 +39,21 @@ describe('savedViewParams store', () => {
     expect(useSavedViewParams.getState().params).toEqual({});
   });
 
+  it('clears the saved params for a single view without touching others', () => {
+    useSavedViewParams.getState().save('timer', 'hideSeconds=true');
+    useSavedViewParams.getState().save('backstage', 'showProgress=false');
+    useSavedViewParams.getState().clear('timer');
+
+    expect(useSavedViewParams.getState().params).toEqual({ backstage: 'showProgress=false' });
+  });
+
+  it('is a no-op when clearing a view without saved params', () => {
+    useSavedViewParams.getState().save('backstage', 'showProgress=false');
+    useSavedViewParams.getState().clear('timer');
+
+    expect(useSavedViewParams.getState().params).toEqual({ backstage: 'showProgress=false' });
+  });
+
   it('clears all saved params', () => {
     useSavedViewParams.getState().save('timer', 'hideSeconds=true');
     useSavedViewParams.getState().clearAll();

--- a/apps/client/src/common/stores/savedViewParams.ts
+++ b/apps/client/src/common/stores/savedViewParams.ts
@@ -6,6 +6,7 @@ const RESERVED_PARAMS = new Set(['token', 'n', 'alias']);
 interface SavedViewParamsStore {
   params: Record<string, string>; // view key (e.g. "timer") -> search string without leading "?"
   save: (view: string, search: string) => void;
+  clear: (view: string) => void;
   clearAll: () => void;
 }
 
@@ -27,6 +28,13 @@ export const useSavedViewParams = create<SavedViewParamsStore>((set) => ({
       } else {
         delete params[view];
       }
+      return { params };
+    }),
+  clear: (view) =>
+    set((state) => {
+      if (!state.params[view]) return state;
+      const params = { ...state.params };
+      delete params[view];
       return { params };
     }),
   clearAll: () => set({ params: {} }),


### PR DESCRIPTION
The saved-changes indicator and clear action were global: one dot on the floating nav button and a single "Clear View Settings" menu row that wiped every view's saved params at once. This surfaces both per route inside the navigation menu instead.

- add a per-view clear() to the savedViewParams store
- ClientLink shows a saved-changes dot and an inline clear button on each route that carries customisation (live URL for the current view, saved params for the others); clearing a route does not navigate to it
- drop the redundant global "Clear View Settings" menu item


Claude-Session: https://claude.ai/code/session_015cNx7hBXyheBdWLLsPcScc