### PR TITLE
fix(views): center timer digits with flexbox for embedded browser compatibility

### DIFF
--- a/apps/client/src/views/editor/pip-timer/PipTimer.scss
+++ b/apps/client/src/views/editor/pip-timer/PipTimer.scss
@@ -28,9 +28,9 @@
 
   .timer-container {
     flex: 1;
-    align-content: center;
-    justify-self: center;
-    align-self: center;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
 
     width: 100%;
     overflow: hidden;

--- a/apps/client/src/views/timer/Timer.scss
+++ b/apps/client/src/views/timer/Timer.scss
@@ -82,9 +82,9 @@
 
   .timer-container {
     flex: 1;
-    align-content: center;
-    justify-self: center;
-    align-self: center;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
 
     width: 100%;
     overflow: hidden;


### PR DESCRIPTION
This is claudes suggestion. It seems to work just as well locally. I could not test in a CEF based browser
Addresses #2126