### PR TITLE
fix: timer-legacy view not served in desktop distributions

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -125,6 +125,13 @@
           "**/*",
           "*{.ts}"
         ]
+      },
+      {
+        "from": "../server/src/html/",
+        "to": "extraResources/html/",
+        "filter": [
+          "**/*"
+        ]
       }
     ]
   }

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -117,8 +117,9 @@ app.use(`${prefix}/external`, (req, res) => {
 app.use(`${prefix}/user`, express.static(publicDir.userDir, { etag: false, lastModified: true }));
 
 // Serve legacy timer for old browsers that don't support modern JS
+// dotfiles must be allowed since the install path can contain dot directories (eg AppImage mounts in /tmp/.mount_*)
 app.get(`${prefix}/timer-legacy`, authenticateAndRedirect, (_req, res) => {
-  res.sendFile(srcFiles.timerLegacy);
+  res.sendFile(srcFiles.timerLegacy, { dotfiles: 'allow' });
 });
 
 // Base route for static files


### PR DESCRIPTION
The server serves html/timer-legacy.html and html/login.html from disk at runtime, relative to the bundled server. The Docker image copies these files but the electron packaging did not, so the view 404ed in all desktop distributions.

Additionally, (at least on Linux) AppImages mount at /tmp/.mount_*, a hidden directory. Express sendFile by default refuses paths containing dot-segments (returns 404 without touching disk), so the view failed on Linux even with the file packaged. Allow dotfiles for this route; the request path is fixed so no user input is affected.

This is a followup fix for #2012 