### PR TITLE
Network settings UX review: fix defects, surface addresses and status

### DIFF
--- a/apps/client/src/common/api/constants.ts
+++ b/apps/client/src/common/api/constants.ts
@@ -20,6 +20,7 @@ export const VIEW_SETTINGS = ['viewSettings'];
 export const CSS_OVERRIDE = ['cssOverride'];
 export const CLIENT_LIST = ['clientList'];
 export const REPORT = ['report'];
+export const SESSION_STATS = ['sessionStats'];
 export const TRANSLATION = ['translation'];
 
 // API URLs

--- a/apps/client/src/common/api/session.ts
+++ b/apps/client/src/common/api/session.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { GetInfo, LinkOptions } from 'ontime-types';
+import { GetInfo, LinkOptions, SessionStats } from 'ontime-types';
 
 import { apiEntryUrl } from './constants';
 import type { RequestOptions } from './requestOptions';
@@ -11,6 +11,14 @@ const sessionPath = `${apiEntryUrl}/session`;
  */
 export async function getInfo(options?: RequestOptions): Promise<GetInfo> {
   const res = await axios.get(`${sessionPath}/info`, { signal: options?.signal });
+  return res.data;
+}
+
+/**
+ * HTTP request to retrieve runtime session statistics
+ */
+export async function getSessionStats(options?: RequestOptions): Promise<SessionStats> {
+  const res = await axios.get(`${sessionPath}/`, { signal: options?.signal });
   return res.data;
 }
 

--- a/apps/client/src/common/components/client-modal/RedirectClientModal.tsx
+++ b/apps/client/src/common/components/client-modal/RedirectClientModal.tsx
@@ -102,14 +102,13 @@ export function RedirectClientModal({ id, isOpen, name, currentPath, origin, onC
                     if (value === null) return;
                     setSelected(value);
                   }}
-                  disabled={enabledPresets.length === 0}
                 />
               </label>
               <Button
                 variant='primary'
                 aria-label='Redirect to preset'
                 className={style.redirect}
-                disabled={enabledPresets.length === 0 || selected === '/'}
+                disabled={selected === '/' || selected === currentPath}
                 onClick={() => handleRedirect(selected)}
               >
                 Redirect <IoArrowForward />

--- a/apps/client/src/common/components/client-modal/RenameClientModal.tsx
+++ b/apps/client/src/common/components/client-modal/RenameClientModal.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 
 import Button from '../../../common/components/buttons/Button';
 import { setClientRemote } from '../../hooks/useSocket';
+import { isKeyEnter } from '../../utils/keyEvent';
 import Dialog from '../dialog/Dialog';
 import Input from '../input/input/Input';
 
@@ -33,7 +34,18 @@ export function RenameClientModal({ id, name: currentName = '', isOpen, onClose 
       showCloseButton
       onClose={onClose}
       bodyElements={
-        <Input height='large' placeholder='New name' value={name} onChange={(event) => setName(event.target.value)} />
+        <Input
+          autoFocus
+          height='large'
+          placeholder='New name'
+          value={name}
+          onChange={(event) => setName(event.target.value)}
+          onKeyDown={(event) => {
+            if (isKeyEnter(event) && canSubmit) {
+              handleRename();
+            }
+          }}
+        />
       }
       footerElements={
         <>

--- a/apps/client/src/common/hooks-query/useSessionStats.ts
+++ b/apps/client/src/common/hooks-query/useSessionStats.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
+import { SessionStats } from 'ontime-types';
+
+import { queryRefetchInterval } from '../../ontimeConfig';
+import { SESSION_STATS } from '../api/constants';
+import { getSessionStats } from '../api/session';
+import { ontimePlaceholderSessionStats } from '../models/Info';
+
+export default function useSessionStats() {
+  const { data, status, isError, refetch, isFetching } = useQuery<SessionStats>({
+    queryKey: SESSION_STATS,
+    queryFn: ({ signal }) => getSessionStats({ signal }),
+    placeholderData: (previousData, _previousQuery) => previousData,
+    refetchInterval: queryRefetchInterval,
+  });
+
+  return { data: data ?? ontimePlaceholderSessionStats, status, isError, refetch, isFetching };
+}

--- a/apps/client/src/common/models/Info.ts
+++ b/apps/client/src/common/models/Info.ts
@@ -1,8 +1,19 @@
-import { GetInfo } from 'ontime-types';
+import { GetInfo, Playback, SessionStats } from 'ontime-types';
 
 export const ontimePlaceholderInfo: GetInfo = {
   networkInterfaces: [],
   version: '4.0.0',
   serverPort: 4001,
   publicDir: '',
+};
+
+export const ontimePlaceholderSessionStats: SessionStats = {
+  startedAt: '',
+  connectedClients: 0,
+  lastConnection: null,
+  lastRequest: null,
+  projectName: '',
+  playback: Playback.Stop,
+  timezone: '',
+  version: '4.0.0',
 };

--- a/apps/client/src/common/stores/logger.ts
+++ b/apps/client/src/common/stores/logger.ts
@@ -11,6 +11,13 @@ type LogStore = {
   logs: Log[];
 };
 
+/**
+ * Ontime clients can be left running for days, and a busy integration generates
+ * a steady stream of entries. We keep a bounded window so the store cannot grow
+ * without limit; the full server-side history remains available in the log view.
+ */
+const maxLogEntries = 500;
+
 const logger = createStore<LogStore>(() => ({
   logs: [],
 }));
@@ -19,7 +26,7 @@ export const useLogData = () => useStore(logger);
 
 export const addLog = (log: Log) =>
   logger.setState((state) => ({
-    logs: [log, ...state.logs],
+    logs: [log, ...state.logs].slice(0, maxLogEntries),
   }));
 
 export const clearLogs = () => logger.setState({ logs: [] });

--- a/apps/client/src/features/app-settings/panel/network-panel/NetworkAddresses.tsx
+++ b/apps/client/src/features/app-settings/panel/network-panel/NetworkAddresses.tsx
@@ -1,0 +1,49 @@
+import AppLink from '../../../../common/components/link/app-link/AppLink';
+import useServerPort from '../../../../common/hooks-query/useServerPort';
+import { isDocker, isOntimeCloud } from '../../../../externals';
+import * as Panel from '../../panel-utils/PanelUtils';
+import InfoNif from './NetworkInterfaces';
+
+export default function NetworkAddresses() {
+  const { data } = useServerPort();
+
+  return (
+    <Panel.Section>
+      <Panel.Card>
+        <Panel.SubHeader>Server address</Panel.SubHeader>
+        <Panel.Divider />
+        <Panel.Section>
+          {isOntimeCloud ? (
+            <Panel.Description>
+              Ontime is running in the cloud and is reachable at the address of this page.
+            </Panel.Description>
+          ) : (
+            <>
+              <Panel.Description>
+                Ontime is streaming on the addresses below. Share one with another machine on the same network, or click
+                to open it here.
+              </Panel.Description>
+              <InfoNif />
+            </>
+          )}
+        </Panel.Section>
+        {!isDocker && (
+          <Panel.ListGroup>
+            <Panel.ListItem>
+              <Panel.Field
+                title='Server port'
+                description={
+                  data.pendingRestart
+                    ? 'A port change is pending, restart Ontime to apply it'
+                    : 'The port Ontime is listening on'
+                }
+                descriptionTone={data.pendingRestart ? 'warning' : 'default'}
+              />
+              <AppLink search='settings=settings__port'>{`Change port (${data.port})`}</AppLink>
+            </Panel.ListItem>
+          </Panel.ListGroup>
+        )}
+      </Panel.Card>
+    </Panel.Section>
+  );
+}

--- a/apps/client/src/features/app-settings/panel/network-panel/NetworkInterfaces.tsx
+++ b/apps/client/src/features/app-settings/panel/network-panel/NetworkInterfaces.tsx
@@ -18,14 +18,20 @@ export default function InfoNif() {
       {data.networkInterfaces.map((nif) => {
         // interfaces outside localhost wont have access
         if (nif.name === 'localhost' && !isLocalhost) return null;
-        const address = linkToOtherHost(nif.address);
+        // show the resolved URL so the label matches what copy and click actually give the user
+        const address = stripTrailingSlash(linkToOtherHost(nif.address));
 
         return (
           <CopyTag key={nif.name} copyValue={address} onClick={() => handleClick(address)}>
-            {`${nif.name} - ${nif.address}`} <IoArrowUp className={style.goIcon} />
+            {`${nif.name} - ${address}`} <IoArrowUp className={style.goIcon} />
           </CopyTag>
         );
       })}
     </Panel.InlineElements>
   );
+}
+
+/** URL.toString() adds a trailing slash to bare origins, which reads as noise in a copiable address */
+function stripTrailingSlash(url: string): string {
+  return url.endsWith('/') ? url.slice(0, -1) : url;
 }

--- a/apps/client/src/features/app-settings/panel/network-panel/NetworkLogExport.tsx
+++ b/apps/client/src/features/app-settings/panel/network-panel/NetworkLogExport.tsx
@@ -19,10 +19,16 @@ export default function LogExport() {
         <Panel.SubHeader>
           Event log
           <Button onClick={extract}>
-            Extract <IoArrowUp className={style.iconRotate} />
+            Open in new window <IoArrowUp className={style.iconRotate} />
           </Button>
         </Panel.SubHeader>
         <Panel.Divider />
+        <Panel.Section>
+          <Panel.Description>
+            Activity reported by the server, this client and any connected integrations. Entries are kept for this
+            session only.
+          </Panel.Description>
+        </Panel.Section>
         <Log />
       </Panel.Card>
     </Panel.Section>

--- a/apps/client/src/features/app-settings/panel/network-panel/NetworkLogPanel.tsx
+++ b/apps/client/src/features/app-settings/panel/network-panel/NetworkLogPanel.tsx
@@ -8,20 +8,26 @@ import { isDocker } from '../../../../externals';
 import type { PanelBaseProps } from '../../panel-list/PanelList';
 import * as Panel from '../../panel-utils/PanelUtils';
 import ClientControlPanel from './client-control/ClientControlPanel';
+import NetworkAddresses from './NetworkAddresses';
 import LogExport from './NetworkLogExport';
+import ServerStatus from './ServerStatus';
 
 export default function NetworkLogPanel({ location }: PanelBaseProps) {
+  const addressRef = useScrollIntoView<HTMLDivElement>('address', location);
+  const statusRef = useScrollIntoView<HTMLDivElement>('status', location);
   const clientsRef = useScrollIntoView<HTMLDivElement>('clients', location);
   const logRef = useScrollIntoView<HTMLDivElement>('log', location);
 
   return (
     <>
       <Panel.Header>Network</Panel.Header>
-      {isDocker && (
-        <Panel.Section>
-          <OntimeCloudStats />
-        </Panel.Section>
-      )}
+      <div ref={addressRef}>
+        <NetworkAddresses />
+      </div>
+      <div ref={statusRef}>
+        <ServerStatus />
+      </div>
+      {isDocker && <OntimeCloudStats />}
       <div ref={logRef}>
         <LogExport />
       </div>
@@ -51,9 +57,14 @@ function OntimeCloudStats() {
   }, []);
 
   return (
-    <Panel.SubHeader>
-      Ontime cloud
-      <Panel.Description>Current ping: {ping}ms</Panel.Description>
-    </Panel.SubHeader>
+    <Panel.Section>
+      <Panel.Card>
+        <Panel.SubHeader>Ontime cloud</Panel.SubHeader>
+        <Panel.Divider />
+        <Panel.Section>
+          <Panel.Description>Current ping: {ping}ms</Panel.Description>
+        </Panel.Section>
+      </Panel.Card>
+    </Panel.Section>
   );
 }

--- a/apps/client/src/features/app-settings/panel/network-panel/ServerStatus.tsx
+++ b/apps/client/src/features/app-settings/panel/network-panel/ServerStatus.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useState } from 'react';
+
+import Tag from '../../../../common/components/tag/Tag';
+import useSessionStats from '../../../../common/hooks-query/useSessionStats';
+import { formatDuration } from '../../../../common/utils/time';
+import * as Panel from '../../panel-utils/PanelUtils';
+
+/** uptime is shown in minutes, a slow tick keeps it moving between query refetches */
+const tickInterval = 30000;
+
+export default function ServerStatus() {
+  const { data, isError } = useSessionStats();
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    const tick = setInterval(() => setNow(Date.now()), tickInterval);
+    return () => clearInterval(tick);
+  }, []);
+
+  return (
+    <Panel.Section>
+      <Panel.Card>
+        <Panel.SubHeader>Server status</Panel.SubHeader>
+        <Panel.Divider />
+        <Panel.Section>
+          <Panel.Description>
+            A summary of the running server, useful when checking whether clients and integrations are reaching Ontime.
+          </Panel.Description>
+          {isError && <Panel.Error>Could not fetch session information</Panel.Error>}
+        </Panel.Section>
+        <Panel.ListGroup>
+          <Panel.ListItem>
+            <Panel.Field title='Connected clients' description='Ontime views and integrations currently connected' />
+            <Tag>{data.connectedClients}</Tag>
+          </Panel.ListItem>
+          <Panel.ListItem>
+            <Panel.Field title='Uptime' description='Time since the server was started' />
+            <Tag>{formatUptime(data.startedAt, now)}</Tag>
+          </Panel.ListItem>
+          <Panel.ListItem>
+            <Panel.Field title='Last client connection' description='When a client last connected to the server' />
+            <Tag>{formatSince(data.lastConnection, now)}</Tag>
+          </Panel.ListItem>
+          <Panel.ListItem>
+            <Panel.Field
+              title='Last integration request'
+              description='When an OSC, HTTP or websocket integration last reached the API'
+            />
+            <Tag>{formatSince(data.lastRequest, now)}</Tag>
+          </Panel.ListItem>
+          <Panel.ListItem>
+            <Panel.Field title='Server timezone' description='Timezone reported by the machine running Ontime' />
+            <Tag>{data.timezone || '—'}</Tag>
+          </Panel.ListItem>
+          <Panel.ListItem>
+            <Panel.Field title='Server version' description='Version of the Ontime server' />
+            <Tag>{data.version}</Tag>
+          </Panel.ListItem>
+        </Panel.ListGroup>
+      </Panel.Card>
+    </Panel.Section>
+  );
+}
+
+/** the placeholder carries an empty startedAt, which we show as unknown rather than a bogus duration */
+function formatUptime(startedAt: string, now: number): string {
+  if (!startedAt) {
+    return '—';
+  }
+  const elapsed = now - new Date(startedAt).getTime();
+  if (Number.isNaN(elapsed)) {
+    return '—';
+  }
+  return elapsed < 60000 ? 'less than a minute' : formatDuration(elapsed);
+}
+
+function formatSince(timestamp: string | null, now: number): string {
+  if (timestamp === null) {
+    return 'never';
+  }
+  const elapsed = now - new Date(timestamp).getTime();
+  if (Number.isNaN(elapsed)) {
+    return '—';
+  }
+  return elapsed < 60000 ? 'just now' : `${formatDuration(elapsed)} ago`;
+}

--- a/apps/client/src/features/app-settings/panel/network-panel/client-control/ClientControlPanel.module.scss
+++ b/apps/client/src/features/app-settings/panel/network-panel/client-control/ClientControlPanel.module.scss
@@ -1,11 +1,3 @@
-.fullWidth {
-  width: 100%;
-}
-
-.halfWidth {
-  width: 50%;
-}
-
 .halfWidthNoWrap {
   width: 50%;
   white-space: nowrap;

--- a/apps/client/src/features/app-settings/panel/network-panel/client-control/ClientControlPanel.module.scss
+++ b/apps/client/src/features/app-settings/panel/network-panel/client-control/ClientControlPanel.module.scss
@@ -16,6 +16,19 @@
   user-select: text;
 }
 
-.self {
+// the shared table applies a zebra stripe to even rows, which outranks a plain
+// class selector; we raise specificity and add an accent so the marker survives
+tr.self {
   background-color: $blue-1100;
+  box-shadow: inset 2px 0 0 0 $blue-500;
+}
+
+.blink {
+  animation: identify-blink 1s step-start infinite;
+}
+
+@keyframes identify-blink {
+  50% {
+    opacity: 0.35;
+  }
 }

--- a/apps/client/src/features/app-settings/panel/network-panel/client-control/ClientList.tsx
+++ b/apps/client/src/features/app-settings/panel/network-panel/client-control/ClientList.tsx
@@ -10,7 +10,6 @@ import Tag from '../../../../../common/components/tag/Tag';
 import Tooltip from '../../../../../common/components/tooltip/Tooltip';
 import { setClientRemote } from '../../../../../common/hooks/useSocket';
 import { useClientStore } from '../../../../../common/stores/clientStore';
-import { openLink } from '../../../../../common/utils/linkUtils';
 import { cx } from '../../../../../common/utils/styleUtils';
 import * as Panel from '../../../panel-utils/PanelUtils';
 
@@ -20,13 +19,15 @@ type ClientEntry = [string, Client];
 
 /**
  * Clients arrive in whatever order the server broadcast them, which shuffles rows
- * whenever a client reconnects. We keep the current client pinned to the top and
- * sort the rest by name so rows stay where the user last saw them.
+ * whenever a client reconnects. Sorting by name keeps rows where the user last saw them.
+ * Pass selfId to pin the current client to the top; only the ontime list can contain it.
  */
-function sortClients(clients: ClientEntry[], selfId: string): ClientEntry[] {
+function sortClients(clients: ClientEntry[], selfId?: string): ClientEntry[] {
   return [...clients].sort(([keyA, clientA], [keyB, clientB]) => {
-    if (keyA === selfId) return -1;
-    if (keyB === selfId) return 1;
+    if (selfId !== undefined) {
+      if (keyA === selfId) return -1;
+      if (keyB === selfId) return 1;
+    }
     return clientA.name.localeCompare(clientB.name);
   });
 }
@@ -57,10 +58,7 @@ export default function ClientList() {
         entries.filter(([_, { type }]) => type === 'ontime'),
         id,
       ),
-      otherClients: sortClients(
-        entries.filter(([_, { type }]) => type !== 'ontime'),
-        id,
-      ),
+      otherClients: sortClients(entries.filter(([_, { type }]) => type !== 'ontime')),
     };
   }, [clients, id]);
 
@@ -115,8 +113,8 @@ export default function ClientList() {
                       {name}
                     </Tooltip>
                   </Panel.InlineElements>
-                  <td>
-                    <CopyTag size='small' copyValue={clientUrl} onClick={() => openLink(clientUrl)}>
+                  <td className={style.copiable}>
+                    <CopyTag size='small' copyValue={clientUrl}>
                       {path}
                     </CopyTag>
                   </td>

--- a/apps/client/src/features/app-settings/panel/network-panel/client-control/ClientList.tsx
+++ b/apps/client/src/features/app-settings/panel/network-panel/client-control/ClientList.tsx
@@ -1,17 +1,35 @@
 import { useDisclosure } from '@mantine/hooks';
 import { Client } from 'ontime-types';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import Button from '../../../../../common/components/buttons/Button';
 import { RedirectClientModal } from '../../../../../common/components/client-modal/RedirectClientModal';
 import { RenameClientModal } from '../../../../../common/components/client-modal/RenameClientModal';
+import CopyTag from '../../../../../common/components/copy-tag/CopyTag';
 import Tag from '../../../../../common/components/tag/Tag';
+import Tooltip from '../../../../../common/components/tooltip/Tooltip';
 import { setClientRemote } from '../../../../../common/hooks/useSocket';
 import { useClientStore } from '../../../../../common/stores/clientStore';
+import { openLink } from '../../../../../common/utils/linkUtils';
 import { cx } from '../../../../../common/utils/styleUtils';
 import * as Panel from '../../../panel-utils/PanelUtils';
 
 import style from './ClientControlPanel.module.scss';
+
+type ClientEntry = [string, Client];
+
+/**
+ * Clients arrive in whatever order the server broadcast them, which shuffles rows
+ * whenever a client reconnects. We keep the current client pinned to the top and
+ * sort the rest by name so rows stay where the user last saw them.
+ */
+function sortClients(clients: ClientEntry[], selfId: string): ClientEntry[] {
+  return [...clients].sort(([keyA, clientA], [keyB, clientB]) => {
+    if (keyA === selfId) return -1;
+    if (keyB === selfId) return 1;
+    return clientA.name.localeCompare(clientB.name);
+  });
+}
 
 export default function ClientList() {
   const id = useClientStore((store) => store.id);
@@ -32,8 +50,19 @@ export default function ClientList() {
     redirectHandler.open();
   };
 
-  const ontimeClients = Object.entries(clients).filter(([_, { type }]) => type === 'ontime');
-  const otherClients = Object.entries(clients).filter(([_, { type }]) => type !== 'ontime');
+  const { ontimeClients, otherClients } = useMemo(() => {
+    const entries = Object.entries(clients);
+    return {
+      ontimeClients: sortClients(
+        entries.filter(([_, { type }]) => type === 'ontime'),
+        id,
+      ),
+      otherClients: sortClients(
+        entries.filter(([_, { type }]) => type !== 'ontime'),
+        id,
+      ),
+    };
+  }, [clients, id]);
 
   const targetClient: Client | undefined = clients[targetId];
 
@@ -59,54 +88,84 @@ export default function ClientList() {
       )}
       <Panel.Section>
         <Panel.Title>Ontime Clients ({ontimeClients.length})</Panel.Title>
+        <Panel.Description>
+          Every browser window and Ontime view connected to this server. Use Identify to find a machine in the room, or
+          Redirect to send it to another view.
+        </Panel.Description>
         <Panel.Table>
           <thead>
             <tr>
-              <td style={{ width: '20%' }}>Client Name</td>
-              <td>Path</td>
-              <td />
+              <th className={style.halfWidthNoWrap}>Client Name</th>
+              <th>Path</th>
+              <th />
             </tr>
           </thead>
           <tbody>
+            {ontimeClients.length === 0 && <Panel.TableEmpty label='No Ontime clients connected.' />}
             {ontimeClients.map(([key, client]) => {
-              const { identify, name, path } = client;
+              const { identify, name, origin, path } = client;
               const isCurrent = id === key;
+              const clientUrl = `${origin}${path}`;
+
               return (
                 <tr key={key} className={cx([isCurrent && style.self])}>
                   <Panel.InlineElements relation='inner' as='td'>
                     {isCurrent && <Tag>SELF</Tag>}
-                    {name}
+                    <Tooltip text={`Connected through ${origin}`} render={<span />}>
+                      {name}
+                    </Tooltip>
                   </Panel.InlineElements>
-                  <td className={style.copiable}>{path}</td>
+                  <td>
+                    <CopyTag size='small' copyValue={clientUrl} onClick={() => openLink(clientUrl)}>
+                      {path}
+                    </CopyTag>
+                  </td>
                   <Panel.InlineElements relation='inner' as='td'>
-                    <Button
-                      size='small'
-                      className={`${identify ? style.blink : ''}`}
-                      disabled={isCurrent}
-                      variant={identify ? 'primary' : 'subtle'}
-                      data-testid={isCurrent ? '' : 'not-self-identify'}
-                      onClick={() => {
-                        setIdentify({ target: key, identify: !identify });
-                      }}
+                    <Tooltip
+                      text={
+                        isCurrent
+                          ? 'This is the window you are using'
+                          : "Flash this client's name full-screen so you can find the machine in the room"
+                      }
+                      render={<span />}
                     >
-                      Identify
-                    </Button>
-                    <Button
-                      size='small'
-                      data-testid={isCurrent ? '' : 'not-self-rename'}
-                      onClick={() => openRename(key)}
+                      <Button
+                        size='small'
+                        className={cx([identify && style.blink])}
+                        disabled={isCurrent}
+                        variant={identify ? 'primary' : 'subtle'}
+                        data-testid={isCurrent ? '' : 'not-self-identify'}
+                        onClick={() => {
+                          setIdentify({ target: key, identify: !identify });
+                        }}
+                      >
+                        Identify
+                      </Button>
+                    </Tooltip>
+                    <Tooltip text="Give this client a name you'll recognise in this list" render={<span />}>
+                      <Button
+                        size='small'
+                        data-testid={isCurrent ? '' : 'not-self-rename'}
+                        onClick={() => openRename(key)}
+                      >
+                        Rename
+                      </Button>
+                    </Tooltip>
+                    <Tooltip
+                      text={
+                        isCurrent ? 'This is the window you are using' : 'Send this client to a different Ontime view'
+                      }
+                      render={<span />}
                     >
-                      Rename
-                    </Button>
-
-                    <Button
-                      size='small'
-                      disabled={isCurrent}
-                      data-testid={isCurrent ? '' : 'not-self-redirect'}
-                      onClick={() => openRedirect(key)}
-                    >
-                      Redirect
-                    </Button>
+                      <Button
+                        size='small'
+                        disabled={isCurrent}
+                        data-testid={isCurrent ? '' : 'not-self-redirect'}
+                        onClick={() => openRedirect(key)}
+                      >
+                        Redirect
+                      </Button>
+                    </Tooltip>
                   </Panel.InlineElements>
                 </tr>
               );
@@ -117,14 +176,20 @@ export default function ClientList() {
       <Panel.Divider />
       <Panel.Section>
         <Panel.Title>Other Clients ({otherClients.length})</Panel.Title>
+        <Panel.Description>
+          Integrations connected over OSC, HTTP or websocket. These cannot be controlled from Ontime.
+        </Panel.Description>
         <Panel.Table>
           <thead>
             <tr>
-              <td className={style.halfWidthNoWrap}>Client Name</td>
-              <td className={style.halfWidthNoWrap}>Client type</td>
+              <th className={style.halfWidthNoWrap}>Client Name</th>
+              <th className={style.halfWidthNoWrap}>Client type</th>
             </tr>
           </thead>
           <tbody>
+            {otherClients.length === 0 && (
+              <Panel.TableEmpty label='No integrations connected. OSC, HTTP and websocket clients appear here.' />
+            )}
             {otherClients.map(([key, client]) => {
               const { name, type } = client;
 

--- a/apps/client/src/features/app-settings/useAppSettingsMenu.tsx
+++ b/apps/client/src/features/app-settings/useAppSettingsMenu.tsx
@@ -68,6 +68,14 @@ const staticOptions = [
     label: 'Network',
     secondary: [
       {
+        id: 'network__address',
+        label: 'Server address',
+      },
+      {
+        id: 'network__status',
+        label: 'Server status',
+      },
+      {
         id: 'network__log',
         label: 'Event log',
       },

--- a/apps/client/src/features/log/Log.module.scss
+++ b/apps/client/src/features/log/Log.module.scss
@@ -51,3 +51,19 @@ $info-hover: $section-white;
   flex-wrap: wrap;
   padding-bottom: 0.5rem;
 }
+
+.search {
+  max-width: 16rem;
+}
+
+.count {
+  margin-left: auto;
+  font-size: $inner-section-text-size;
+  color: $secondary-text-gray;
+  white-space: nowrap;
+}
+
+.empty {
+  color: $info-gray;
+  padding: 0.5rem 0;
+}

--- a/apps/client/src/features/log/Log.tsx
+++ b/apps/client/src/features/log/Log.tsx
@@ -1,12 +1,15 @@
-import { LogOrigin } from 'ontime-types';
-import { useCallback, useState } from 'react';
+import { LogLevel, LogOrigin } from 'ontime-types';
+import { useCallback, useMemo, useState } from 'react';
 import { IoClose } from 'react-icons/io5';
 
 import Button from '../../common/components/buttons/Button';
+import Input from '../../common/components/input/input/Input';
 import { clearLogs, useLogData } from '../../common/stores/logger';
 import * as Panel from '../app-settings/panel-utils/PanelUtils';
 
 import style from './Log.module.scss';
+
+const issueLevels = new Set<LogLevel>([LogLevel.Warn, LogLevel.Error, LogLevel.Severe]);
 
 export default function Log() {
   const { logs: logData } = useLogData();
@@ -17,28 +20,45 @@ export default function Log() {
   const [showTx, setShowTx] = useState(true);
   const [showPlayback, setShowPlayback] = useState(true);
   const [showUser, setShowUser] = useState(true);
+  const [issuesOnly, setIssuesOnly] = useState(false);
+  const [search, setSearch] = useState('');
 
-  const matchers: LogOrigin[] = [];
-  if (showUser) {
-    matchers.push(LogOrigin.User);
-  }
-  if (showClient) {
-    matchers.push(LogOrigin.Client);
-  }
-  if (showServer) {
-    matchers.push(LogOrigin.Server);
-  }
-  if (showRx) {
-    matchers.push(LogOrigin.Rx);
-  }
-  if (showTx) {
-    matchers.push(LogOrigin.Tx);
-  }
-  if (showPlayback) {
-    matchers.push(LogOrigin.Playback);
-  }
+  const filteredData = useMemo(() => {
+    const matchers: LogOrigin[] = [];
+    if (showUser) {
+      matchers.push(LogOrigin.User);
+    }
+    if (showClient) {
+      matchers.push(LogOrigin.Client);
+    }
+    if (showServer) {
+      matchers.push(LogOrigin.Server);
+    }
+    if (showRx) {
+      matchers.push(LogOrigin.Rx);
+    }
+    if (showTx) {
+      matchers.push(LogOrigin.Tx);
+    }
+    if (showPlayback) {
+      matchers.push(LogOrigin.Playback);
+    }
 
-  const filteredData = logData.filter((entry) => matchers.some((match) => entry.origin === match));
+    const query = search.trim().toLowerCase();
+
+    return logData.filter((entry) => {
+      if (!matchers.some((match) => entry.origin === match)) {
+        return false;
+      }
+      if (issuesOnly && !issueLevels.has(entry.level)) {
+        return false;
+      }
+      if (query && !entry.text.toLowerCase().includes(query)) {
+        return false;
+      }
+      return true;
+    });
+  }, [logData, showUser, showClient, showServer, showRx, showTx, showPlayback, issuesOnly, search]);
 
   const disableOthers = useCallback((toEnable: LogOrigin) => {
     setShowUser(toEnable === LogOrigin.User);
@@ -48,6 +68,8 @@ export default function Log() {
     setShowTx(toEnable === LogOrigin.Tx);
     setShowPlayback(toEnable === LogOrigin.Playback);
   }, []);
+
+  const isFiltered = filteredData.length !== logData.length;
 
   return (
     <>
@@ -110,7 +132,26 @@ export default function Log() {
           <IoClose /> Clear
         </Button>
       </Panel.InlineElements>
+      <Panel.InlineElements className={style.buttonBar}>
+        <Input
+          placeholder='Search log'
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          className={style.search}
+        />
+        <Button variant={issuesOnly ? 'primary' : 'subtle'} size='small' onClick={() => setIssuesOnly((s) => !s)}>
+          Issues only
+        </Button>
+        <span className={style.count}>
+          {isFiltered ? `${filteredData.length} of ${logData.length} entries` : `${logData.length} entries`}
+        </span>
+      </Panel.InlineElements>
       <ul className={style.log}>
+        {filteredData.length === 0 && (
+          <li className={style.empty}>
+            {logData.length === 0 ? 'No log entries yet.' : 'No entries match the filters.'}
+          </li>
+        )}
         {filteredData.map((logEntry) => (
           <li key={logEntry.id} className={`${style.logEntry} ${style[logEntry.level]} `}>
             <span className={style.time}>{logEntry.time}</span>

--- a/e2e/tests/features/210-client-remote.spec.ts
+++ b/e2e/tests/features/210-client-remote.spec.ts
@@ -42,3 +42,45 @@ test('rename', async ({ context }) => {
 
   await expect(remotePage.getByTestId('identify-overlay')).toContainText('test');
 });
+
+/**
+ * The view select in the redirect modal lists the built-in Ontime views alongside any URL
+ * presets. It used to be disabled whenever no presets existed, which left a fresh project
+ * unable to redirect to a view at all. Strip the presets to cover that case.
+ */
+test('redirect to a built-in view with no url presets', async ({ context, request }) => {
+  const presetsUrl = '/data/url-presets';
+  const existingPresets = await (await request.get(presetsUrl)).json();
+
+  for (const preset of existingPresets) {
+    await request.delete(`${presetsUrl}/${preset.alias}`);
+  }
+
+  try {
+    const controllerPage = await context.newPage();
+    const remotePage = await context.newPage();
+
+    await controllerPage.goto('/editor?settings=network__clients');
+    await remotePage.goto('/timer');
+
+    await controllerPage.getByTestId('not-self-redirect').click();
+
+    // the select and its action stay usable even though there is nothing to pick from presets
+    const viewSelect = controllerPage.getByRole('combobox');
+    await expect(viewSelect).toBeEnabled();
+
+    await viewSelect.click();
+    await controllerPage.getByRole('option', { name: 'Studio Clock', exact: true }).click();
+
+    const redirectToView = controllerPage.getByLabel('Redirect to preset');
+    await expect(redirectToView).toBeEnabled();
+    await redirectToView.click();
+
+    await expect(remotePage.getByTestId('studio-view')).toBeVisible();
+  } finally {
+    // leave the project as we found it for any spec that runs after this one
+    for (const preset of existingPresets) {
+      await request.post(presetsUrl, { data: preset });
+    }
+  }
+});


### PR DESCRIPTION
## Summary

A UX/UI review of the Network settings panel, focused on low-risk, low-complexity changes: fix real defects first, then close the two gaps operators actually hit (which address to hand out, whether the setup is healthy).

**Verified defects fixed:**
- Redirect modal disabled its entire view Select whenever no URL presets existed, even though that Select also holds every built-in view — the control was dead on a fresh project
- Interface tags showed a bare IP while the copy/click action used a URL with the port, sending users to an address that can't connect
- Client table's self-row highlight lost to the shared table's zebra-stripe on CSS specificity on even rows
- Client table headers used `<td>` instead of `<th>`, so they got none of the shared header styling and no screen-reader association
- Log store grew without bound; capped at 500 entries
- Client rows followed broadcast insertion order and reshuffled on reconnect
- Rename modal had no autofocus or Enter-to-submit
- Identify button referenced a `blink` class that was never defined, so the flash feedback never rendered

**New in the panel:**
- Server address card (network interfaces + port, linking to the existing port settings form)
- Server status card, reading the previously-unconsumed `GET /api/session/` endpoint for uptime, connected clients, last connection/request, timezone, version
- Log search, an "issues only" filter, and a filtered/total entry count
- Relabelled the log's "Extract" button to "Open in new window" (it opens a window, not an export)
- Consistent card layout matching the rest of settings, sidebar entries for the new sections, and explanatory empty states throughout

Deliberately out of scope: the share-link builder/QR form, any server or `packages/types` changes, ping behavior, and bulk client actions.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` — unchanged at the pre-existing 120-warning baseline
- [x] `pnpm --filter ontime-ui build` succeeds (confirms SCSS compiles)
- [x] Manually hit `GET /data/session/` against a running server and confirmed the response matches what the new status card expects
- [x] `e2e/tests/features/210-client-remote.spec.ts` (redirect / identify / rename) passes unchanged — testids preserved
- [x] Full e2e suite: 53 passed, 1 skipped, 2 failed; both failures reproduce identically against the unmodified base commit (one flaky, re-ran green; `212-time-until › time until absolute` fails pre-existing, verified via a clean worktree)
- [ ] Visual check in a browser — not done in this environment, worth a look before merge, particularly the Sharing panel's Share link card (it reuses the same interface-list component, which now shows the full URL with port instead of a bare IP)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FdRte3v1Swc2MRt9fKJTXk)_