### PR TITLE
chore(license): resolver has permissive license

### DIFF
--- a/apps/resolver/package.json
+++ b/apps/resolver/package.json
@@ -17,7 +17,7 @@
     "parser"
   ],
   "author": "",
-  "license": "AGPL-3.0-only",
+  "license": "ISC",
   "devDependencies": {
     "ontime-types": "workspace:^4.2.1",
     "tsdown": "^0.22.4",


### PR DESCRIPTION
Changes the license of the resolver to ISC to allow using in commercial projects
Fixes #2183 